### PR TITLE
⚡ Optimize LowStorageRK4 with buffer reuse

### DIFF
--- a/crates/cfd-math/Cargo.toml
+++ b/crates/cfd-math/Cargo.toml
@@ -67,3 +67,7 @@ harness = false
 [[bench]]
 name = "swar_ops_bench"
 harness = false
+
+[[bench]]
+name = "rk_bench"
+harness = false

--- a/crates/cfd-math/benches/rk_bench.rs
+++ b/crates/cfd-math/benches/rk_bench.rs
@@ -1,0 +1,28 @@
+use cfd_math::time_stepping::runge_kutta::LowStorageRK4;
+use cfd_math::time_stepping::traits::TimeStepper;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use nalgebra::DVector;
+
+fn bench_rk_step(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rk_step");
+    // Test with different vector sizes
+    for &n in &[1000, 10000, 100000] {
+        let rk4 = LowStorageRK4::<f64>::new();
+        let u0 = DVector::from_element(n, 1.0);
+        let dt = 0.01;
+        let t = 0.0;
+
+        // Simple function: f(u) = -u
+        let f = |_t: f64, u: &DVector<f64>| Ok(-u.clone());
+
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &_| {
+            b.iter(|| {
+                black_box(rk4.step(f, t, &u0, dt).unwrap())
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_rk_step);
+criterion_main!(benches);


### PR DESCRIPTION
Optimize LowStorageRK4 with buffer reuse

`LowStorageRK4::step` previously allocated two temporary vectors (`u_tmp` and `u_new`) on every call. This PR modifies the struct to hold these buffers in `RefCell`s, reusing them across steps.
This reduces the number of allocations per step from 2 (plus internal clones) to 1 (the unavoidable return value clone).
Also optimizes the inner update loop to use slice operations, avoiding `RefMut` dereference overhead.

Measured impact:
- Small vectors (1k-10k): Comparable performance (within noise / slight regression due to overhead).
- Large vectors (100k): ~3% improvement in execution time, plus benefits of reduced memory allocator pressure.

Includes a new benchmark `rk_bench.rs`.

---
*PR created automatically by Jules for task [12690171826446054370](https://jules.google.com/task/12690171826446054370) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the `LowStorageRK4` time-stepping implementation by introducing buffer reuse to reduce memory allocations. Previously, two temporary vectors (`u_tmp` and `u_new`) were allocated on every call to `step`. The optimization stores these buffers in `RefCell`s within the struct, reusing and resizing them as needed across multiple steps. The inner update loop is also improved to use slice operations directly, avoiding `RefMut` dereference overhead. A new benchmark is added to measure performance gains, which show ~3% improvement for large vectors (100k elements) and reduced allocator pressure overall.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-math/Cargo.toml` |
| 2 | `crates/cfd-math/benches/rk_bench.rs` |
| 3 | `crates/cfd-math/src/time_stepping/runge_kutta.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->