### PR TITLE
⚡ Optimize GPU Operator Buffer Reuse

### DIFF
--- a/crates/cfd-math/Cargo.toml
+++ b/crates/cfd-math/Cargo.toml
@@ -67,3 +67,7 @@ harness = false
 [[bench]]
 name = "swar_ops_bench"
 harness = false
+
+[[bench]]
+name = "gpu_operator_bench"
+harness = false

--- a/crates/cfd-math/benches/gpu_operator_bench.rs
+++ b/crates/cfd-math/benches/gpu_operator_bench.rs
@@ -1,0 +1,57 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[cfg(feature = "gpu")]
+fn bench_gpu_operator(c: &mut Criterion) {
+    use std::sync::Arc;
+    use cfd_core::compute::gpu::GpuContext;
+    use cfd_math::linear_solver::operators::gpu::{GpuLaplacianOperator2D, BoundaryType};
+    use cfd_math::linear_solver::LinearOperator;
+    use nalgebra::DVector;
+
+    // Initialize GPU context once
+    // Note: This might fail if run in parallel or repeatedly if context doesn't clean up well
+    let context = match GpuContext::create() {
+        Ok(ctx) => Arc::new(ctx),
+        Err(e) => {
+            eprintln!("Skipping benchmark: Failed to create GpuContext: {:?}", e);
+            return;
+        }
+    };
+
+    let mut group = c.benchmark_group("gpu_operator");
+
+    let nx = 128;
+    let ny = 128;
+    let dx = 1.0;
+    let dy = 1.0;
+    let bc = BoundaryType::Dirichlet;
+
+    let operator = GpuLaplacianOperator2D::new(
+        context.clone(),
+        nx,
+        ny,
+        dx,
+        dy,
+        bc
+    );
+
+    let size = nx * ny;
+    let x = DVector::from_element(size, 1.0f32);
+    let mut y = DVector::zeros(size);
+
+    group.bench_function("apply_gpu_op", |b| {
+        b.iter(|| {
+            operator.apply(&x, &mut y).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(not(feature = "gpu"))]
+fn bench_gpu_operator(_c: &mut Criterion) {
+    // No-op
+}
+
+criterion_group!(benches, bench_gpu_operator);
+criterion_main!(benches);


### PR DESCRIPTION
This PR optimizes the `GpuLaplacianOperator2D` by implementing buffer reuse. Previously, `apply_gpu_async` allocated new GPU buffers for input and output on every invocation, which is inefficient for iterative solvers. 

The optimization involves:
1.  Introducing `OperatorBuffers` to hold `input` and `output` buffers.
2.  Storing these buffers in `GpuLaplacianOperator2D` using `Mutex<Option<OperatorBuffers>>` for thread-safe lazy initialization.
3.  Modifying `apply_gpu_async` to initialize buffers on first use and reuse them subsequently using `write()` for input updates.

A benchmark `gpu_operator_bench` was added. On software rasterizers (llvmpipe), a regression was observed due to `wgpu` command submission overhead vs cheap `malloc`, but on real hardware, this change is expected to significantly reduce VRAM allocation overhead and fragmentation.

---
*PR created automatically by Jules for task [5283945119670527532](https://jules.google.com/task/5283945119670527532) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the `GpuLaplacianOperator2D` by implementing buffer reuse to reduce GPU memory allocation overhead. Previously, the operator allocated new GPU buffers on every invocation, which was inefficient for iterative solvers. The changes introduce an `OperatorBuffers` struct to cache input and output buffers, implement thread-safe lazy initialization using `Mutex<Option<OperatorBuffers>>`, and modify `apply_gpu_async` to reuse buffers across invocations by updating input data via `write()` instead of allocating fresh buffers. A new benchmark `gpu_operator_bench` is added to measure the performance impact of these optimizations.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-math/Cargo.toml` |
| 2 | `crates/cfd-math/benches/gpu_operator_bench.rs` |
| 3 | `crates/cfd-math/src/linear_solver/operators/gpu.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->