### PR TITLE
Fix API compatibility for poiseuille_bifurcation validation

### DIFF
--- a/crates/cfd-validation/src/analytical/poiseuille_2d.rs
+++ b/crates/cfd-validation/src/analytical/poiseuille_2d.rs
@@ -576,7 +576,6 @@ mod tests {
         let mu_inf = 0.0035_f64; // 3.5 cP
         
         let model = CassonBlood::new(
-            "Test Blood".to_string(),
             1060.0,
             tau_y,
             mu_inf,
@@ -604,7 +603,6 @@ mod tests {
     #[test]
     fn test_casson_wall_velocity_zero() {
         let model = CassonBlood::new(
-            "Human Blood".to_string(),
             1060.0,
             0.0056,
             0.00345,
@@ -624,7 +622,6 @@ mod tests {
     #[test]
     fn test_casson_flow_rate() {
         let model = CassonBlood::new(
-            "Human Blood".to_string(),
             1060.0,
             0.0056,
             0.00345,

--- a/crates/cfd-validation/src/benchmarks/mod.rs
+++ b/crates/cfd-validation/src/benchmarks/mod.rs
@@ -17,7 +17,7 @@ pub mod venturi;
 pub mod threed;
 pub mod serpentine;
 // TODO: Re-enable once API compatibility is fixed
-// pub mod poiseuille_bifurcation;
+pub mod poiseuille_bifurcation;
 
 pub use bifurcation::BifurcationFlow;
 pub use cavity::LidDrivenCavity;
@@ -28,7 +28,7 @@ pub use trifurcation::TrifurcationFlow;
 pub use venturi::VenturiFlow;
 pub use threed::*;
 pub use serpentine::SerpentineFlow;
-// pub use poiseuille_bifurcation::*;
+pub use poiseuille_bifurcation::*;
 
 /// Trait for CFD benchmark problems
 pub trait Benchmark<T: RealField + Copy> {


### PR DESCRIPTION
This PR addresses the TODO in `crates/cfd-validation/src/benchmarks/mod.rs` to re-enable the `poiseuille_bifurcation` validation module. The module was previously disabled due to API incompatibilities with `cfd-1d` and `cfd-core`.

Changes:
1.  **Refactored `poiseuille_bifurcation.rs`**:
    *   Updated imports to use `cfd_1d::channel::{Channel, ChannelGeometry}`.
    *   Implemented manual construction of `Channel` objects and hydraulic resistance calculation for the flow split ratio, as required by the current `BifurcationJunction` API.
    *   Updated `BifurcationJunction::solve` call to use calculated junction pressure.
    *   Updated validation logic for Wall Shear Stress (WSS). The previous logic expected WSS scaling with diameter, but for Murray's Law ($Q \propto D^3$) networks, the theoretical WSS is constant. The expectation was corrected to a ratio of 1.0.

2.  **Fixed `poiseuille_2d.rs`**:
    *   Updated `CassonBlood::new` calls in unit tests to match the current API (removed the `name` `String` argument). This was necessary to run the validation tests successfully.

The `test_bifurcation_2d_validation` now passes with 0% error for mass conservation, Murray's Law, and pressure equality, and passes the WSS check with constant WSS.

---
*PR created automatically by Jules for task [16786644506798439278](https://jules.google.com/task/16786644506798439278) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR re-enables the `poiseuille_bifurcation` validation module by fixing API compatibility issues with `cfd-1d` and `cfd-core`. The main changes include refactoring the bifurcation module to manually construct `Channel` objects and calculate hydraulic resistance for flow split ratios, updating the `BifurcationJunction::solve` call to use calculated junction pressure, and correcting the Wall Shear Stress (WSS) validation logic to expect constant WSS in Murray's Law networks (ratio of 1.0 instead of diameter-based scaling). Additionally, unit tests in `poiseuille_2d.rs` were updated to match the current `CassonBlood::new` API by removing the deprecated `name` parameter.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-validation/src/benchmarks/mod.rs` |
| 2 | `crates/cfd-validation/src/analytical/poiseuille_2d.rs` |
| 3 | `crates/cfd-validation/src/benchmarks/poiseuille_bifurcation.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations for blood model validation.

* **Chores**
  * Re-enabled bifurcation flow benchmarks.
  * Updated hydraulic calculations and pressure drop computations in the validation suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->