### PR TITLE
Fix FEM solver validation logic and enable it

### DIFF
--- a/crates/cfd-3d/src/fem/solver.rs
+++ b/crates/cfd-3d/src/fem/solver.rs
@@ -42,11 +42,8 @@ impl<T: RealField + FromPrimitive + Copy + Float + std::fmt::Debug + From<f64>> 
     ) -> Result<StokesFlowSolution<T>> {
         tracing::info!("Starting Taylor-Hood Stokes solver");
         
-        // NOTE: Temporarily skip validation - the get_boundary_nodes() implementation
-        // is overly conservative and flags interior nodes as missing BCs.
-        // Interior nodes are solved for, they should NOT have BCs.
-        // TODO: Fix validate() to only check actual boundary nodes  
-        // problem.validate()?;
+        // Validate problem configuration before solving
+        problem.validate()?;
 
         let (matrix, rhs) = self.assemble_system(problem, previous_solution)?;
         

--- a/crates/cfd-3d/tests/fem_boundary_conditions.rs
+++ b/crates/cfd-3d/tests/fem_boundary_conditions.rs
@@ -38,7 +38,7 @@ fn test_robin_bc_assembly() {
         boundary_conditions.insert(i, bc.clone());
     }
 
-    let problem = StokesFlowProblem::new(mesh, fluid, boundary_conditions);
+    let problem = StokesFlowProblem::new(mesh, fluid, boundary_conditions, 4);
 
     // Setup Solver
     let config = FemConfig::default();


### PR DESCRIPTION
This PR addresses a TODO in `crates/cfd-3d/src/fem/solver.rs` regarding overly conservative validation in the FEM solver.

Previously, `get_boundary_nodes` included all marked faces, even if they were internal to the domain (e.g. interfaces or monitor surfaces). This caused `validate()` to fail if no boundary condition was assigned to these internal nodes, which is the correct behavior for interfaces (they should be solved for).

The fix modifies `get_boundary_nodes` to only consider faces that are topologically external (referenced by exactly one cell) as requiring boundary conditions.

Also re-enabled the validation call in `FemSolver::solve` which was previously commented out.

Added a reproduction test case `test_validate_ignores_internal_marked_nodes` in `crates/cfd-3d/src/fem/problem.rs` to verify the fix.

Also fixed a compilation error in `crates/cfd-3d/tests/fem_boundary_conditions.rs` due to a mismatch in `StokesFlowProblem::new` arguments (unrelated to logic change, but necessary for tests to pass).

---
*PR created automatically by Jules for task [11937469120726628484](https://jules.google.com/task/11937469120726628484) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a validation bug in the FEM solver where internal marked faces (like interfaces or monitor surfaces) were incorrectly treated as boundary nodes requiring boundary conditions. The fix modifies `get_boundary_nodes` to only consider topologically external faces (referenced by exactly one cell) as true boundaries. The validation logic is now re-enabled in `FemSolver::solve`, and a new test verifies that internal marked nodes are correctly ignored during validation.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-3d/src/fem/problem.rs` |
| 2 | `crates/cfd-3d/src/fem/solver.rs` |
| 3 | `crates/cfd-3d/tests/fem_boundary_conditions.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `crates/cfd-3d/tests/fem_boundary_conditions.rs` | This appears to be a simple compilation fix to add a missing parameter to StokesFlowProblem::new, which is unrelated to the core validation logic fix described in the PR |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Re-enabled problem validation to ensure configurations are checked before system assembly.

* **Improvements**
  * Refined boundary condition validation logic to only require boundary conditions on external surfaces, allowing internal marked boundaries to be ignored during validation.

* **API Changes**
  * Updated `StokesFlowProblem` constructor signature to accept an additional parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->