### PR TITLE
Fix FEM validation logic to correctly identify boundary nodes

### DIFF
--- a/crates/cfd-3d/src/fem/solver.rs
+++ b/crates/cfd-3d/src/fem/solver.rs
@@ -42,11 +42,7 @@ impl<T: RealField + FromPrimitive + Copy + Float + std::fmt::Debug + From<f64>> 
     ) -> Result<StokesFlowSolution<T>> {
         tracing::info!("Starting Taylor-Hood Stokes solver");
         
-        // NOTE: Temporarily skip validation - the get_boundary_nodes() implementation
-        // is overly conservative and flags interior nodes as missing BCs.
-        // Interior nodes are solved for, they should NOT have BCs.
-        // TODO: Fix validate() to only check actual boundary nodes  
-        // problem.validate()?;
+        problem.validate()?;
 
         let (matrix, rhs) = self.assemble_system(problem, previous_solution)?;
         

--- a/crates/cfd-3d/tests/fem_boundary_conditions.rs
+++ b/crates/cfd-3d/tests/fem_boundary_conditions.rs
@@ -38,7 +38,7 @@ fn test_robin_bc_assembly() {
         boundary_conditions.insert(i, bc.clone());
     }
 
-    let problem = StokesFlowProblem::new(mesh, fluid, boundary_conditions);
+    let problem = StokesFlowProblem::new(mesh, fluid, boundary_conditions, 4);
 
     // Setup Solver
     let config = FemConfig::default();


### PR DESCRIPTION
This PR fixes a bug in the FEM validation logic where internal nodes were incorrectly flagged as missing boundary conditions if they were part of an internally marked face. 

The fix involves updating `StokesFlowProblem::get_boundary_nodes` to strictly rely on `Mesh::external_faces()` (topological boundary) instead of including all marked faces. This aligns with the solver's expectation that interior nodes (even on internal interfaces) are solved for and do not require boundary conditions unless they are on the external hull.

Additionally, this PR enables the previously commented-out `problem.validate()` call in `FemSolver`, ensuring that proper boundary condition checks are performed before solving.

A regression test `test_interior_node_ignored` was added to verify that interior nodes are excluded from boundary checks even when connected to marked internal faces.

Finally, `crates/cfd-3d/tests/fem_boundary_conditions.rs` was fixed to resolve a compilation error unrelated to the main change but necessary for clean test execution.

---
*PR created automatically by Jules for task [4173815013522536981](https://jules.google.com/task/4173815013522536981) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the FEM boundary node detection logic where internal nodes were incorrectly flagged as requiring boundary conditions. The core fix updates `StokesFlowProblem::get_boundary_nodes` to exclusively use topologically external faces (those referenced by exactly one cell) rather than including all marked faces, ensuring that interior nodes on internal interfaces are properly excluded from boundary checks. The previously disabled `problem.validate()` call is now re-enabled in the solver, and a comprehensive regression test `test_interior_node_ignored` verifies the fix by confirming that interior nodes remain excluded even when internal faces are marked as boundaries. A minor compilation fix was also applied to `fem_boundary_conditions.rs` to ensure clean test execution.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-3d/src/fem/problem.rs` |
| 2 | `crates/cfd-3d/src/fem/solver.rs` |
| 3 | `crates/cfd-3d/tests/fem_boundary_conditions.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled validation in the solver to ensure proper configuration correctness.

* **Improvements**
  * Simplified boundary node detection for improved accuracy in boundary condition application.

* **Tests**
  * Added test coverage verifying interior nodes are correctly excluded from boundary calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->