### PR TITLE
Resolved TODO in compare_cavity_external.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ validation/references/
 # Example/optimiser output directories (all crates)
 outputs/
 report/
+.venv/
+venv/

--- a/validation/compare_cavity_external.py
+++ b/validation/compare_cavity_external.py
@@ -15,6 +15,7 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from pathlib import Path
+from scipy.interpolate import RectBivariateSpline
 
 # Add validation directory to path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -104,8 +105,28 @@ def compare_solutions(cfd_python_result, external_result, Re: float):
     # Ensure same grid size
     if cfd_python_result["u"].shape != ext_sol["u"].shape:
         print(f"WARN: Grid size mismatch: cfd_python {cfd_python_result['u'].shape} vs external {ext_sol['u'].shape}")
-        # TODO: Interpolate if needed
-        return None
+
+        # Interpolate external result onto cfd_python grid
+        x_ext = ext_solver.x
+        y_ext = ext_solver.y
+        x_cfd = cfd_python_result["x"]
+        y_cfd = cfd_python_result["y"]
+
+        u_spline = RectBivariateSpline(y_ext, x_ext, ext_sol["u"])
+        v_spline = RectBivariateSpline(y_ext, x_ext, ext_sol["v"])
+        p_spline = RectBivariateSpline(y_ext, x_ext, ext_sol["p"])
+
+        ext_sol["u"] = u_spline(y_cfd, x_cfd)
+        ext_sol["v"] = v_spline(y_cfd, x_cfd)
+        ext_sol["p"] = p_spline(y_cfd, x_cfd)
+
+        # Update centerlines
+        mid_x_idx = len(x_cfd) // 2
+        mid_y_idx = len(y_cfd) // 2
+        ext_sol["u_centerline"] = ext_sol["u"][:, mid_x_idx]
+        ext_sol["v_centerline"] = ext_sol["v"][mid_y_idx, :]
+
+        print("INFO: Interpolated external result onto cfd_python grid using RectBivariateSpline")
     
     # Compute L2 errors
     u_diff = cfd_python_result["u"] - ext_sol["u"]


### PR DESCRIPTION
This commit addresses the grid size mismatch warning in `validation/compare_cavity_external.py` by implementing interpolation logic using `scipy.interpolate.RectBivariateSpline` to properly compare the CFD-RS output and the external reference array, along with updating their centerlines appropriately.

---
*PR created automatically by Jules for task [8917404243692961663](https://jules.google.com/task/8917404243692961663) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR resolves a TODO in the cavity flow validation script by implementing interpolation logic to handle grid size mismatches between CFD-RS output and external reference data. Instead of returning `None` when grids don't match, the code now uses `RectBivariateSpline` from scipy to interpolate the external solution onto the CFD grid and updates the centerline values accordingly. Additionally, `.venv/` and `venv/` entries are added to `.gitignore` to exclude virtual environment directories.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.gitignore` |
| 2 | `validation/compare_cavity_external.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation workflow for external cavity comparisons. When reference and simulation grids have different sizes, the system now automatically interpolates the reference data to match the active grid, enabling comparison to proceed successfully.

* **Chores**
  * Added environment configuration patterns to development ignore list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->