### PR TITLE
build(cfdrs): Refresh Moirai provider graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - Error Consolidation
 
+### Changed
+
+- Updated CFDrs to merged Moirai `main` and regenerated the locked Atlas
+  provider graph. The resolved workspace uses Moirai 0.4 with Themis 0.10.
+- Replaced the serpentine-Venturi demo's untyped configuration tuple with a
+  named geometry record and repaired warning-denied `cfd-schematics`
+  test/example diagnostics.
+
 ### Breaking
 
 - Removed `spmv_parallel`, `IterativeSolverConfig::use_parallel_spmv`,

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,4 +1,15 @@
 # CFDrs Work Checklist
+- [x] `cfd-schematics` [patch]: Replace the unnamed serpentine-Venturi tuple
+  with a typed geometry record and repair all warning-denied test/example
+  diagnostics. Exact bit equality preserves the direct-value contract for
+  geometry bounds and bilateral phase direction. Evidence: all-target,
+  all-feature Clippy passes with warnings denied; focused nextest and doctests
+  pass.
+- [x] DEP-657-01 [patch]: Pin Moirai to merged `main`
+  `5ead788c70c728d971237d7afa0b915ea7cf87e3` and regenerate the locked Atlas
+  provider graph. Evidence: locked metadata and all-feature `cfd-schematics`
+  check pass with Moirai 0.4 and Themis 0.10. PR publication remains the
+  integration step.
 - [x] `cfd-1d`/`cfd-3d` [patch]: Delete the two stale scalar-file entries from
   `xtask/legacy_surface.allowlist`; exact source scans are clean and the legacy
   migration audit reports no cleanup candidates while retaining clean status.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apollo-fft"
-version = "0.17.0"
+version = "0.22.0"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -141,19 +141,19 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "apollo-leto-interop"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "leto",
 ]
 
 [[package]]
 name = "apollo-nufft"
-version = "0.4.0"
+version = "0.7.0"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -187,7 +187,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -284,9 +284,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -366,7 +366,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -386,7 +386,7 @@ checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -692,9 +692,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -718,7 +718,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -779,7 +779,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-autograd"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-leto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "coeus-core",
  "leto",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-nn"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-ops"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-optim"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-sparse"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-tensor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -1178,7 +1178,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1313,7 +1313,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "core-foundation",
  "core-graphics",
@@ -1350,7 +1350,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1432,7 +1432,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1466,9 +1466,10 @@ dependencies = [
 
 [[package]]
 name = "gaia"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "approx",
  "aquamarine",
  "cfd-schematics",
  "eunomia",
@@ -1617,7 +1618,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hephaestus-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytemuck",
  "leto",
@@ -1627,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "hephaestus-wgpu"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytemuck",
  "hephaestus-core",
@@ -1636,7 +1637,7 @@ dependencies = [
  "mnemosyne-core",
  "moirai",
  "moirai-gpu",
- "moirai-sync 0.3.1 (git+https://github.com/ryancinsight/Moirai.git)",
+ "moirai-sync 0.4.0 (git+https://github.com/ryancinsight/Moirai.git)",
  "num-complex",
  "themis",
  "wgpu",
@@ -1683,7 +1684,7 @@ version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1713,7 +1714,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1844,7 +1845,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leto"
-version = "0.36.0"
+version = "0.38.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1856,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "leto-ops"
-version = "0.36.0"
+version = "0.38.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1881,7 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1937,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -1976,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
@@ -1991,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-arena"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
@@ -2001,22 +2002,22 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "mnemosyne-core",
 ]
 
 [[package]]
 name = "mnemosyne-build-util"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "mnemosyne-core"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "mnemosyne-decay"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -2025,14 +2026,14 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-hardened"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "mnemosyne-core",
 ]
 
 [[package]]
 name = "mnemosyne-heap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -2045,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-local"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -2059,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-prof"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -2068,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "moirai"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "melinoe",
  "mnemosyne",
@@ -2078,14 +2079,14 @@ dependencies = [
  "moirai-iter",
  "moirai-parallel",
  "moirai-scheduler",
- "moirai-sync 0.3.1",
+ "moirai-sync 0.4.0",
  "moirai-transport",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
 ]
 
 [[package]]
 name = "moirai-async"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "futures",
  "libc",
@@ -2094,62 +2095,62 @@ dependencies = [
  "moirai-executor",
  "moirai-pal",
  "moirai-transport",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
  "socket2",
 ]
 
 [[package]]
 name = "moirai-async-macros"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "moirai-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "libc",
  "mnemosyne",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
 ]
 
 [[package]]
 name = "moirai-executor"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "melinoe",
  "mnemosyne",
  "moirai-core",
  "moirai-pal",
  "moirai-scheduler",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
 ]
 
 [[package]]
 name = "moirai-gpu"
-version = "0.3.1"
-source = "git+https://github.com/ryancinsight/Moirai.git#fce7c34691db55b7bd75db01a22393dc32b1f175"
+version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Moirai.git#4ad652028ead6e80944942b8a2c59e84f83035fe"
 dependencies = [
  "mnemosyne-core",
  "moirai-core",
- "moirai-utils 0.3.1 (git+https://github.com/ryancinsight/Moirai.git)",
+ "moirai-utils 0.4.0 (git+https://github.com/ryancinsight/Moirai.git)",
  "themis",
 ]
 
 [[package]]
 name = "moirai-iter"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "futures",
  "libc",
  "moirai-core",
  "moirai-executor",
  "moirai-scheduler",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
  "num_cpus",
  "themis",
  "thiserror 1.0.69",
@@ -2157,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-pal"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "js-sys",
  "libc",
@@ -2171,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-parallel"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "melinoe",
  "moirai-executor",
@@ -2179,52 +2180,52 @@ dependencies = [
 
 [[package]]
 name = "moirai-scheduler"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "mnemosyne",
  "moirai-core",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
  "num_cpus",
  "themis",
 ]
 
 [[package]]
 name = "moirai-sync"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "libc",
  "moirai-core",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
 ]
 
 [[package]]
 name = "moirai-sync"
-version = "0.3.1"
-source = "git+https://github.com/ryancinsight/Moirai.git#fce7c34691db55b7bd75db01a22393dc32b1f175"
+version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Moirai.git#4ad652028ead6e80944942b8a2c59e84f83035fe"
 dependencies = [
  "libc",
  "moirai-core",
- "moirai-utils 0.3.1 (git+https://github.com/ryancinsight/Moirai.git)",
+ "moirai-utils 0.4.0 (git+https://github.com/ryancinsight/Moirai.git)",
 ]
 
 [[package]]
 name = "moirai-transport"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "moirai-core",
  "moirai-scheduler",
- "moirai-utils 0.3.1",
+ "moirai-utils 0.4.0",
 ]
 
 [[package]]
 name = "moirai-utils"
-version = "0.3.1"
+version = "0.4.0"
 
 [[package]]
 name = "moirai-utils"
-version = "0.3.1"
-source = "git+https://github.com/ryancinsight/Moirai.git#fce7c34691db55b7bd75db01a22393dc32b1f175"
+version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Moirai.git#4ad652028ead6e80944942b8a2c59e84f83035fe"
 
 [[package]]
 name = "munge"
@@ -2243,7 +2244,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2254,7 +2255,7 @@ checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
  "bit-set 0.10.0",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -2377,7 +2378,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2406,7 +2407,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2417,7 +2418,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2428,7 +2429,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2440,7 +2441,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2483,9 +2484,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -2510,7 +2511,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2687,7 +2688,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -2735,7 +2736,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2785,7 +2786,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2798,7 +2799,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2978,7 +2979,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2994,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3006,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3085,12 +3086,6 @@ dependencies = [
 [[package]]
 name = "ritk-wgpu-compat"
 version = "0.1.0"
-dependencies = [
- "coeus-core",
- "coeus-ops",
- "coeus-tensor",
- "hephaestus-wgpu",
-]
 
 [[package]]
 name = "rkyv"
@@ -3148,7 +3143,7 @@ checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3190,7 +3185,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3275,7 +3270,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3328,9 +3323,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -3375,7 +3370,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3403,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3439,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "melinoe",
 ]
@@ -3470,7 +3465,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3481,7 +3476,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3578,7 +3573,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3670,9 +3665,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3772,7 +3767,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3802,7 +3797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -3828,7 +3823,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.10.0",
  "bit-vec 0.9.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -3879,7 +3874,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "bytemuck",
  "cfg-if",
@@ -3929,7 +3924,7 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "log",
  "naga-types",
@@ -4014,26 +4009,13 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
 ]
@@ -4045,7 +4027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -4057,7 +4039,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4068,7 +4050,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4079,7 +4061,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4090,14 +4072,8 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -4112,7 +4088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4126,20 +4102,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4154,20 +4121,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4185,7 +4143,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4210,7 +4168,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4349,7 +4307,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ ritk-vtk = { path = "../ritk/crates/ritk-vtk" }
 hermes-simd = { git = "https://github.com/ryancinsight/hermes.git" }
 # moirai: unified concurrency runtime replacing tokio + rayon. Moirai's parallel,
 # Mnemosyne, and Melinoe surfaces are enabled for the CFDrs workspace.
-moirai = { git = "https://github.com/ryancinsight/Moirai.git", rev = "029275807a4a406f7be0ee4be22ecae4a72fa27c", default-features = false, features = ["parallel", "mnemosyne", "melinoe"] }
+moirai = { git = "https://github.com/ryancinsight/Moirai.git", rev = "5ead788c70c728d971237d7afa0b915ea7cf87e3", default-features = false, features = ["parallel", "mnemosyne", "melinoe"] }
 # hephaestus-wgpu: Atlas GPU provider used for device acquisition and the
 # ongoing replacement of CFDrs-owned raw WGPU kernels.
 hephaestus-wgpu = { git = "https://github.com/ryancinsight/hephaestus.git" }

--- a/backlog.md
+++ b/backlog.md
@@ -29,6 +29,18 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # CFDrs Backlog
 
+## Active integration
+
+- **DEP-657-01 [patch] - Publish the merged Moirai provider revision (REVIEW;
+  owner=Codex; scope=`Cargo.toml`, `Cargo.lock`, `cfd-schematics` lint
+  remediation, PM artifacts).** Replace the stale explicit Moirai revision
+  with merged `main` commit `5ead788c70c728d971237d7afa0b915ea7cf87e3` so the
+  locked graph resolves Moirai 0.4 with Themis 0.10. `cfd-schematics` now
+  compiles its examples and tests under warning-denied Clippy. Acceptance
+  evidence: locked metadata, all-feature package check and Clippy, focused
+  nextest, doctests, and no whitespace errors. Publish and merge after the PR
+  check suite succeeds.
+
 ## Structural Improvements
 - [x] `cfd-1d`/`cfd-3d` [patch]: Remove obsolete legacy-audit exemptions for
   the Eunomia/Leto scalar seams after confirming both files contain no legacy

--- a/crates/cfd-schematics/examples/venturi/serpentine_venturi_demo.rs
+++ b/crates/cfd-schematics/examples/venturi/serpentine_venturi_demo.rs
@@ -24,67 +24,78 @@ use cfd_schematics::interface::presets::serpentine_venturi_rect;
 #[path = "../shared/mod.rs"]
 mod shared;
 
+#[derive(Clone, Copy)]
+struct VenturiGeometry {
+    label: &'static str,
+    segments: usize,
+    segment_length_m: f64,
+    channel_width_m: f64,
+    throat_width_m: f64,
+    channel_height_m: f64,
+    throat_length_m: f64,
+    bend_radius_m: f64,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Configuration matrix ────────────────────────────────────────
     // Millifluidic-scale channels within 96-well-plate footprint
     // (127.76 × 85.47 mm — ANSI/SLAS 1-2004).
-    let configs: Vec<(&str, usize, f64, f64, f64, f64, f64, f64)> = vec![
-        // (label, segments, seg_len_m, width_m, throat_m, height_m, throat_len_m, bend_r_m)
-        (
-            "baseline_4seg",
-            4,
-            0.015, // 15 mm segments
-            0.002, // 2 mm channel width
-            0.001, // 1 mm throat
-            0.001, // 1 mm height
-            0.003, // 3 mm throat length
-            0.001, // 1 mm bend radius
-        ),
-        (
-            "aggressive_6seg",
-            6,
-            0.012,  // 12 mm segments
-            0.003,  // 3 mm channel width
-            0.0012, // 1.2 mm throat (contraction ratio 2.5:1)
-            0.001,  // 1 mm height
-            0.004,  // 4 mm throat length
-            0.0015, // 1.5 mm bend radius
-        ),
-        (
-            "tight_bend_3seg",
-            3,
-            0.020,  // 20 mm segments
-            0.002,  // 2 mm channel width
-            0.0008, // 0.8 mm throat (contraction ratio 2.5:1)
-            0.001,  // 1 mm height
-            0.002,  // 2 mm throat length
-            0.0005, // 0.5 mm bend radius — high Dean number
-        ),
-        (
-            "mild_8seg",
-            8,
-            0.010,  // 10 mm segments
-            0.002,  // 2 mm channel width
-            0.0015, // 1.5 mm throat (contraction ratio 1.33:1)
-            0.001,  // 1 mm height
-            0.003,  // 3 mm throat length
-            0.002,  // 2 mm bend radius — lower Dean number
-        ),
+    let configurations = [
+        VenturiGeometry {
+            label: "baseline_4seg",
+            segments: 4,
+            segment_length_m: 0.015,
+            channel_width_m: 0.002,
+            throat_width_m: 0.001,
+            channel_height_m: 0.001,
+            throat_length_m: 0.003,
+            bend_radius_m: 0.001,
+        },
+        VenturiGeometry {
+            label: "aggressive_6seg",
+            segments: 6,
+            segment_length_m: 0.012,
+            channel_width_m: 0.003,
+            throat_width_m: 0.0012,
+            channel_height_m: 0.001,
+            throat_length_m: 0.004,
+            bend_radius_m: 0.0015,
+        },
+        VenturiGeometry {
+            label: "tight_bend_3seg",
+            segments: 3,
+            segment_length_m: 0.020,
+            channel_width_m: 0.002,
+            throat_width_m: 0.0008,
+            channel_height_m: 0.001,
+            throat_length_m: 0.002,
+            bend_radius_m: 0.0005,
+        },
+        VenturiGeometry {
+            label: "mild_8seg",
+            segments: 8,
+            segment_length_m: 0.010,
+            channel_width_m: 0.002,
+            throat_width_m: 0.0015,
+            channel_height_m: 0.001,
+            throat_length_m: 0.003,
+            bend_radius_m: 0.002,
+        },
     ];
 
     println!("Serpentine-Venturi Dean-Apex Demonstration");
     println!("==========================================\n");
 
-    for (label, segments, seg_len, width, throat, height, throat_len, bend_r) in &configs {
+    for configuration in configurations {
         let bp = serpentine_venturi_rect(
-            format!("sv_{label}"),
-            *segments,
-            *seg_len,
-            *width,
-            *throat,
-            *height,
-            *throat_len,
-            *bend_r,
+            format!("sv_{}", configuration.label),
+            configuration.segments,
+            configuration.segment_length_m,
+            configuration.channel_width_m,
+            configuration.throat_width_m,
+            configuration.channel_height_m,
+            configuration.throat_length_m,
+            configuration.bend_radius_m,
         );
 
         let n_venturis = bp.venturi_channels().len();
@@ -96,35 +107,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let total_channels = bp.channels.len();
 
         // Compute Dean number at each bend for this geometry
-        let d_h = 2.0 * width * height / (width + height);
+        let d_h = 2.0 * configuration.channel_width_m * configuration.channel_height_m
+            / (configuration.channel_width_m + configuration.channel_height_m);
         // Re at throat (blood: ρ=1060 kg/m³, μ=3.5e-3 Pa·s)
         let rho = 1060.0_f64;
         let mu = 3.5e-3_f64;
         // Approximate mean velocity for Re ~ 100 (typical millifluidic)
         let re_channel = 100.0_f64;
-        let de = re_channel * (d_h / (2.0 * bend_r)).sqrt();
-        let contraction_ratio = width / throat;
+        let de = re_channel * (d_h / (2.0 * configuration.bend_radius_m)).sqrt();
+        let contraction_ratio = configuration.channel_width_m / configuration.throat_width_m;
 
-        println!("─── {label} ───");
+        println!("─── {} ───", configuration.label);
         println!("  Segments:           {n_segments}");
         println!("  Venturi throats:    {n_venturis}");
         println!("  Total channels:     {total_channels}");
-        println!("  Channel width:      {:.1} mm", width * 1e3);
-        println!("  Throat width:       {:.2} mm", throat * 1e3);
+        println!(
+            "  Channel width:      {:.1} mm",
+            configuration.channel_width_m * 1e3
+        );
+        println!(
+            "  Throat width:       {:.2} mm",
+            configuration.throat_width_m * 1e3
+        );
         println!("  Contraction ratio:  {contraction_ratio:.2}:1");
-        println!("  Bend radius:        {:.1} mm", bend_r * 1e3);
+        println!(
+            "  Bend radius:        {:.1} mm",
+            configuration.bend_radius_m * 1e3
+        );
         println!("  D_h:                {:.3} mm", d_h * 1e3);
         println!("  Dean number (Re=100): {de:.1}");
         println!(
             "  Centripetal accel:  a_c = u²/R = (ν·Re/D_h)² / R = {:.2} m/s²",
             {
                 let u = re_channel * mu / (rho * d_h);
-                u * u / bend_r
+                u * u / configuration.bend_radius_m
             }
         );
 
         // Render schematic
-        shared::save_example_output_with_name(&bp, "serpentine_venturi_demo", label);
+        shared::save_example_output_with_name(&bp, "serpentine_venturi_demo", configuration.label);
     }
 
     // ── Summary comparison table ────────────────────────────────────
@@ -134,18 +155,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Config", "Segs", "Vents", "De", "CR", "R(mm)"
     );
     println!("{}", "─".repeat(52));
-    for (label, segments, _, width, throat, height, _, bend_r) in &configs {
-        let d_h = 2.0 * width * height / (width + height);
-        let de = 100.0 * (d_h / (2.0 * bend_r)).sqrt();
-        let cr = width / throat;
+    for configuration in configurations {
+        let d_h = 2.0 * configuration.channel_width_m * configuration.channel_height_m
+            / (configuration.channel_width_m + configuration.channel_height_m);
+        let de = 100.0 * (d_h / (2.0 * configuration.bend_radius_m)).sqrt();
+        let cr = configuration.channel_width_m / configuration.throat_width_m;
         println!(
             "{:<22} {:>4} {:>5} {:>6.1} {:>5.2} {:>5.1}",
-            label,
-            segments,
-            segments - 1,
+            configuration.label,
+            configuration.segments,
+            configuration.segments - 1,
             de,
             cr,
-            bend_r * 1e3,
+            configuration.bend_radius_m * 1e3,
         );
     }
 

--- a/crates/cfd-schematics/src/config/geometry/core.rs
+++ b/crates/cfd-schematics/src/config/geometry/core.rs
@@ -150,9 +150,18 @@ mod tests {
         )
         .expect("canonical bounds should validate");
 
-        assert_eq!(config.wall_clearance, constants::MIN_WALL_CLEARANCE);
-        assert_eq!(config.channel_width, constants::MIN_CHANNEL_WIDTH * 2.0);
-        assert_eq!(config.channel_height, constants::MAX_CHANNEL_HEIGHT);
+        assert_eq!(
+            config.wall_clearance.to_bits(),
+            constants::MIN_WALL_CLEARANCE.to_bits()
+        );
+        assert_eq!(
+            config.channel_width.to_bits(),
+            (constants::MIN_CHANNEL_WIDTH * 2.0).to_bits()
+        );
+        assert_eq!(
+            config.channel_height.to_bits(),
+            constants::MAX_CHANNEL_HEIGHT.to_bits()
+        );
     }
 
     #[test]
@@ -172,7 +181,7 @@ mod tests {
                 constraint,
             } => {
                 assert_eq!(field, "wall_clearance");
-                assert_eq!(value, constants::MIN_WALL_CLEARANCE);
+                assert_eq!(value.to_bits(), constants::MIN_WALL_CLEARANCE.to_bits());
                 assert!(constraint.contains("channel_width"));
             }
             other => panic!("unexpected error: {other:?}"),

--- a/crates/cfd-schematics/src/geometry/generator/selective/mod.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/mod.rs
@@ -309,8 +309,7 @@ mod tests {
 
         assert!(
             lane_keys.len() >= 3,
-            "Tri->Tri selective trees must preserve multiple treatment-window lanes instead of collapsing to a centerline surrogate, got {:?}",
-            lane_keys
+            "Tri->Tri selective trees must preserve multiple treatment-window lanes instead of collapsing to a centerline surrogate, got {lane_keys:?}"
         );
     }
 

--- a/crates/cfd-schematics/src/geometry/generator/tests.rs
+++ b/crates/cfd-schematics/src/geometry/generator/tests.rs
@@ -130,7 +130,7 @@ fn generated_serpentine_channels_persist_physical_length_and_shape() {
                     channel.id
                 );
             }
-            ref shape => panic!(
+            shape @ ChannelShape::Straight => panic!(
                 "channel {:?} should be marked serpentine for 1D modeling, got {:?}",
                 channel.id, shape
             ),

--- a/crates/cfd-schematics/src/state_management/bilateral_symmetry.rs
+++ b/crates/cfd-schematics/src/state_management/bilateral_symmetry.rs
@@ -376,14 +376,14 @@ mod tests {
         let upper_phase = calculator
             .calculate_phase_direction(&upper_context)
             .expect("structural invariant");
-        assert_eq!(upper_phase, 1.0);
+        assert_eq!(upper_phase.to_bits(), 1.0_f64.to_bits());
 
         // Test lower channel (should have negative phase)
         let lower_context = create_test_context((10.0, 10.0), (40.0, 15.0));
         let lower_phase = calculator
             .calculate_phase_direction(&lower_context)
             .expect("structural invariant");
-        assert_eq!(lower_phase, -1.0);
+        assert_eq!(lower_phase.to_bits(), (-1.0_f64).to_bits());
     }
 
     #[test]

--- a/crates/cfd-schematics/src/state_management/constraints.rs
+++ b/crates/cfd-schematics/src/state_management/constraints.rs
@@ -381,7 +381,7 @@ mod tests {
         let constraint = ParameterConstraints::range(0.0, 10.0);
         let description = constraint.description();
         assert!(description.contains("between"));
-        assert!(description.contains("0"));
+        assert!(description.contains('0'));
         assert!(description.contains("10"));
     }
 }

--- a/crates/cfd-schematics/src/state_management/errors.rs
+++ b/crates/cfd-schematics/src/state_management/errors.rs
@@ -43,7 +43,7 @@ mod tests {
     fn test_constraint_error_creation() {
         let error = ConstraintErrorKind::range_violation(&-1.0, &0.0, &10.0);
         assert!(error.to_string().contains("-1"));
-        assert!(error.to_string().contains("0"));
+        assert!(error.to_string().contains('0'));
         assert!(error.to_string().contains("10"));
     }
 }

--- a/crates/cfd-schematics/src/state_management/integration_test.rs
+++ b/crates/cfd-schematics/src/state_management/integration_test.rs
@@ -255,18 +255,11 @@ mod tests {
         for (name, value) in wave_params {
             assert!(
                 value.is_finite(),
-                "Parameter {} has invalid value: {}",
-                name,
-                value
+                "Parameter {name} has invalid value: {value}"
             );
             if name != "phase_offset" {
                 // phase_offset can be 0
-                assert!(
-                    value > 0.0,
-                    "Parameter {} should be positive: {}",
-                    name,
-                    value
-                );
+                assert!(value > 0.0, "Parameter {name} should be positive: {value}");
             }
         }
     }

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,19 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+- 2026-07-16: Updated the workspace Moirai source pin to merged `main`
+  `5ead788c70c728d971237d7afa0b915ea7cf87e3`. Locked metadata resolves Moirai
+  0.4 and Themis 0.10; `cfd-schematics` all-feature check, warning-denied
+  Clippy, focused nextest, doctests, and docs pass. The source- and
+  test-level evidence is compile-time integration plus value-semantic test
+  coverage.
+- 2026-07-16: Removed the `cfd-schematics` strict-Clippy baseline in the
+  touched test/example cone. Direct geometry/phase values use exact
+  bit-pattern assertions, and the Venturi example exposes named physical
+  fields instead of positional tuple entries. The workspace-wide formatter
+  remains blocked by unrelated pre-existing formatting in
+  `crates/cfd-schematics/src/error.rs`; touched files pass `rustfmt`.
+
 - 2026-07-10: Removed stale allowlist entries for `cfd-1d/src/scalar.rs` and
   `cfd-3d/src/scalar.rs`. Both seams are provider-native and contain no legacy
   dependency tokens; the active `cfd-core` compute-dispatch diff is untouched.


### PR DESCRIPTION
Pins the direct Moirai dependency to merged main 5ead788, refreshes the resolved Atlas provider graph, and repairs the strict cfd-schematics test/example lints exposed by the integration gate.\n\nVerification: locked metadata; cfd-schematics all-feature check and warning-denied Clippy; focused nextest; doctests; rustdoc; diff whitespace check.\n\nKnown baseline: workspace-wide fmt remains blocked by unrelated existing formatting in cfd-schematics/src/error.rs; the touched files are rustfmt-clean.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the CFDrs workspace to use **Moirai 0.4** with **Themis 0.10** by pinning the Moirai dependency to merged main commit `5ead788`, which triggers a complete refresh of the locked Atlas provider graph with numerous transitive dependency updates. Additionally, it addresses warning-denied Clippy diagnostics in `cfd-schematics` by replacing an untyped tuple configuration with a named `VenturiGeometry` struct in the serpentine-Venturi demo, and fixing test assertions to use exact bit-pattern equality for floating-point geometry values to preserve direct-value contracts for bounds and bilateral phase direction.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
| 3 | `CHANGELOG.md` |
| 4 | `CHECKLIST.md` |
| 5 | `backlog.md` |
| 6 | `gap_audit.md` |
| 7 | `crates/cfd-schematics/examples/venturi/serpentine_venturi_demo.rs` |
| 8 | `crates/cfd-schematics/src/config/geometry/core.rs` |
| 9 | `crates/cfd-schematics/src/state_management/bilateral_symmetry.rs` |
| 10 | `crates/cfd-schematics/src/state_management/constraints.rs` |
| 11 | `crates/cfd-schematics/src/state_management/errors.rs` |
| 12 | `crates/cfd-schematics/src/state_management/integration_test.rs` |
| 13 | `crates/cfd-schematics/src/geometry/generator/selective/mod.rs` |
| 14 | `crates/cfd-schematics/src/geometry/generator/tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->