### PR TITLE
feat(cfd)!: Seal GPU provider boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - Error Consolidation
+## [Unreleased]
+
+## [0.2.0] - 2026-07-17 - Error Consolidation
 
 ### Changed
 
+- `cfd-core::compute::gpu::GpuContext::synchronize` now uses Hephaestus'
+  backend-neutral `ComputeDevice` completion contract rather than polling the
+  underlying WGPU device directly.
 - Updated CFDrs to merged Moirai `main` and regenerated the locked Atlas
   provider graph. The resolved workspace uses Moirai 0.4 with Themis 0.10.
 - Advanced the direct Leto and Leto-ops source pins to merged `main`.
@@ -43,6 +48,11 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
+- `GpuContext` no longer exposes raw WGPU device, queue, or limit fields, and
+  `GpuPoissonSolver::new(device, queue, ...)` is removed. Construct the solver
+  with `GpuPoissonSolver::from_context(&context, ...)` so Hephaestus retains
+  provider ownership. `GpuBuffer` no longer exposes its raw buffer handle or
+  a `buffer` accessor.
 - Removed `spmv_parallel`, `IterativeSolverConfig::use_parallel_spmv`,
   `IterativeSolverConfig::with_parallel_spmv`, and
   `MomentumSolver::with_parallel_spmv`. Callers use `spmv`, `try_spmv`, and

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,4 +1,21 @@
 # CFDrs Work Checklist
+
+Target version: `0.2.0` (pre-1.0 breaking provider-boundary release).
+
+- [x] `cfd-core` [major]: Make the Hephaestus buffer handle crate-private and
+  delete `GpuBuffer::buffer`, which exposed a raw WGPU buffer despite having no
+  external consumer. Evidence: GPU-enabled cfd-core nextest 244/244 and source
+  audit shows the handle is used only by the typed Laplacian dispatch.
+- [x] `cfd-core`/`cfd-2d` [major]: Remove public raw WGPU device, queue, and
+  limit fields from `GpuContext`; replace `GpuPoissonSolver::new(device,
+  queue, ...)` with `from_context(&GpuContext, ...)`. Evidence: GPU-enabled
+  accelerated-solver nextest 2/2, cfd-core nextest 244/244, and exact consumer
+  scans contain no old constructor or context device/queue access.
+- [x] `cfd-core` [patch]: Route `GpuContext::synchronize` through the
+  Hephaestus `ComputeDevice` contract instead of calling the raw WGPU polling
+  API. Evidence: touched-file `rustfmt --check`, GPU-enabled core nextest
+  (244/244), and warning-denied GPU all-target Clippy pass; the GPU compute
+  tree contains no direct `device.poll` call.
 - [x] `cfd-schematics` [patch]: Replace the unnamed serpentine-Venturi tuple
   with a typed geometry record and repair all warning-denied test/example
   diagnostics. Exact bit equality preserves the direct-value contract for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-1d"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-2d"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-3d"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "apollo-fft",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-io"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "approx",
  "bincode",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-math"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-optim"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-schematics"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cfd-core",
  "petgraph",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-suite"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apollo-fft",
  "approx",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-validation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Ryan Clanton <ryan@clanton.dev>"]
 license = "MIT OR Apache-2.0"

--- a/backlog.md
+++ b/backlog.md
@@ -48,6 +48,21 @@
   branch rebased through current CFDrs `main`.
 
 ## Structural Improvements
+- [x] `cfd-core` [major]: Remove public raw WGPU access from `GpuBuffer`.
+  Restrict its Hephaestus buffer handle to cfd-core and delete the unused raw
+  accessor. Acceptance: GPU core regressions pass and typed-kernel dispatch is
+  the only remaining handle consumer.
+- [x] `cfd-core`/`cfd-2d` [major]: Make the acquired Hephaestus context the
+  sole GPU Poisson construction boundary. Delete public raw WGPU device, queue,
+  and limit fields plus `GpuPoissonSolver::new(device, queue, ...)`; use
+  `GpuPoissonSolver::from_context` at every live caller. Acceptance: GPU
+  accelerated-solver and cfd-core regressions pass, with empty old-constructor
+  and context device/queue consumer scans.
+- [x] `cfd-core` [patch]: Delegate GPU completion through Hephaestus
+  `ComputeDevice::synchronize` and remove the direct WGPU polling call from
+  `GpuContext`. Evidence: GPU core nextest 244/244, warning-denied all-target
+  Clippy, formatter check, and an exact GPU-tree source audit with no
+  `device.poll` residue.
 - [x] `cfd-1d`/`cfd-3d` [patch]: Remove obsolete legacy-audit exemptions for
   the Eunomia/Leto scalar seams after confirming both files contain no legacy
   dependency tokens. Preserve the active `cfd-core` compute-dispatch work.

--- a/crates/cfd-2d/src/solvers/accelerated.rs
+++ b/crates/cfd-2d/src/solvers/accelerated.rs
@@ -40,9 +40,8 @@ impl AcceleratedPoissonSolver {
         #[cfg(feature = "gpu")]
         {
             if let Ok(gpu_context) = cfd_core::compute::gpu::GpuContext::create() {
-                if let Ok(gpu_solver) = cfd_core::compute::gpu::GpuPoissonSolver::new(
-                    gpu_context.device.clone(),
-                    gpu_context.queue.clone(),
+                if let Ok(gpu_solver) = cfd_core::compute::gpu::GpuPoissonSolver::from_context(
+                    &gpu_context,
                     _nx,
                     _ny,
                     _dx,

--- a/crates/cfd-core/src/compute/gpu/buffer.rs
+++ b/crates/cfd-core/src/compute/gpu/buffer.rs
@@ -5,14 +5,14 @@ use crate::compute::traits::ComputeBuffer;
 use crate::error::{Error, Result};
 use bytemuck::{Pod, Zeroable};
 use eunomia::RealField;
-use hephaestus_wgpu::{wgpu, ComputeDevice, WgpuBuffer as HephaestusWgpuBuffer};
+use hephaestus_wgpu::{ComputeDevice, WgpuBuffer as HephaestusWgpuBuffer};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// GPU buffer wrapper
 pub struct GpuBuffer<T: RealField + Pod + Zeroable> {
     /// Hephaestus-owned WGPU buffer.
-    pub buffer: HephaestusWgpuBuffer<T>,
+    pub(crate) buffer: HephaestusWgpuBuffer<T>,
     /// Buffer size in elements
     size: usize,
     /// GPU context
@@ -69,11 +69,6 @@ impl<T: RealField + Pod + Zeroable + Copy> GpuBuffer<T> {
             context,
             _phantom: PhantomData,
         })
-    }
-
-    /// Get underlying wgpu buffer
-    pub fn buffer(&self) -> &wgpu::Buffer {
-        self.buffer.raw()
     }
 }
 

--- a/crates/cfd-core/src/compute/gpu/mod.rs
+++ b/crates/cfd-core/src/compute/gpu/mod.rs
@@ -1,8 +1,7 @@
 //! GPU compute backend using Hephaestus' WGPU provider ABI.
 
 use crate::error::{Error, Result};
-use hephaestus_wgpu::{wgpu, WgpuDevice};
-use std::sync::Arc;
+use hephaestus_wgpu::{ComputeDevice, WgpuDevice, wgpu};
 
 const REQUIRED_STORAGE_BUFFERS_PER_SHADER_STAGE: u32 = 7;
 
@@ -29,12 +28,8 @@ pub struct GpuContext {
     adapter_info: wgpu::AdapterInfo,
     /// Enabled WGPU features for this provider device.
     features: wgpu::Features,
-    /// GPU device
-    pub device: Arc<wgpu::Device>,
-    /// Command queue
-    pub queue: Arc<wgpu::Queue>,
     /// Device limits
-    pub limits: wgpu::Limits,
+    limits: wgpu::Limits,
 }
 
 impl GpuContext {
@@ -72,22 +67,17 @@ impl GpuContext {
 
         let features = provider.features();
         let limits = provider.limits();
-        let device = provider.device().clone();
-        let queue = provider.queue().clone();
-
         Ok(Self {
             provider,
             adapter_info,
             features,
-            device,
-            queue,
             limits,
         })
     }
 
     /// Get the Hephaestus WGPU provider.
     #[must_use]
-    pub fn provider(&self) -> &WgpuDevice {
+    pub(crate) fn provider(&self) -> &WgpuDevice {
         &self.provider
     }
 
@@ -112,12 +102,9 @@ impl GpuContext {
     /// Block until submitted GPU work visible to this context has completed.
     ///
     /// # Errors
-    /// Returns an error if WGPU reports that polling failed.
+    /// Returns an error if the Hephaestus provider cannot observe completion.
     pub fn synchronize(&self) -> Result<()> {
-        self.device.poll(wgpu::PollType::wait_indefinitely()).map_err(|error| {
-            Error::InvalidConfiguration(format!("GPU device poll failed: {error:?}"))
-        })?;
-        Ok(())
+        self.provider.synchronize().map_err(Error::from)
     }
 
     /// Get maximum work group size

--- a/crates/cfd-core/src/compute/gpu/poisson_solver.rs
+++ b/crates/cfd-core/src/compute/gpu/poisson_solver.rs
@@ -1,14 +1,13 @@
 //! GPU-accelerated Poisson equation solver.
 //!
-//! The solver owns Hephaestus WGPU provider kernels and buffers; raw WGPU
-//! handles appear only at the public constructor boundary for existing callers.
+//! The solver owns Hephaestus WGPU provider kernels and buffers.
 
+use super::GpuContext;
 use crate::error::{Error, Result};
 use hephaestus_wgpu::{
-    wgpu, ComputeDevice, DispatchGrid, MultiStorageKernel, WgpuBuffer, WgpuDevice,
+    ComputeDevice, DispatchGrid, MultiStorageKernel, WgpuBuffer, WgpuDevice,
     WgslMultiStorageKernel, WgslStorageBinding, WgslStorageBindingLayout,
 };
-use std::sync::Arc;
 
 /// GPU Poisson solver parameters.
 #[repr(C)]
@@ -39,21 +38,20 @@ pub struct GpuPoissonSolver {
 }
 
 impl GpuPoissonSolver {
-    /// Create a new GPU Poisson solver.
+    /// Create a new GPU Poisson solver from an acquired Hephaestus context.
     ///
     /// # Errors
     ///
     /// Returns an error if the Hephaestus WGSL kernels cannot be compiled for
-    /// the supplied WGPU device.
-    pub fn new(
-        device: Arc<wgpu::Device>,
-        queue: Arc<wgpu::Queue>,
+    /// the context's provider device.
+    pub fn from_context(
+        context: &GpuContext,
         nx: usize,
         ny: usize,
         dx: f32,
         dy: f32,
     ) -> Result<Self> {
-        let provider = WgpuDevice::new(device, queue);
+        let provider = context.provider().clone();
         let storage_layouts = [
             WgslStorageBindingLayout::read_only(1),
             WgslStorageBindingLayout::read_only(2),

--- a/crates/cfd-core/src/compute/tests.rs
+++ b/crates/cfd-core/src/compute/tests.rs
@@ -196,6 +196,9 @@ fn test_gpu_context_creation() {
                 "Max buffer size: {} MB",
                 context.max_buffer_size() / (1024 * 1024)
             );
+            context
+                .synchronize()
+                .expect("Hephaestus provider must observe an idle context");
         }
         Err(e) => {
             println!("GPU not available: {e}");

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -72,6 +72,34 @@ UnifiedCompute → Backend selection (CPU/GPU/Hybrid)
 
 ## Recent Decisions
 
+### 2026-07-17: Hephaestus owns acquired Poisson devices [major]
+
+**Context**: `GpuContext` acquired a Hephaestus WGPU provider but then exposed
+its raw device, queue, and limits. cfd-2d rebuilt a `WgpuDevice` only to
+construct `GpuPoissonSolver`, creating a second ownership boundary for the same
+provider resource.
+
+**Decision**: Delete the public raw context fields,
+`GpuPoissonSolver::new(device, queue, ...)`, and `GpuBuffer` raw-buffer
+access. `GpuPoissonSolver::from_context` clones the context's already-acquired
+provider internally; raw buffer handles stay within cfd-core typed kernels.
+cfd-2d therefore depends on the CFD context contract rather than a WGPU handle
+pair.
+
+**Rejected alternative**: Retaining a forwarding raw-handle constructor would
+preserve the duplicate boundary and allow consumers to reconstruct providers.
+A context-local wrapper around the old constructor was rejected for the same
+reason.
+
+**Consequences**: The public migration is breaking: callers construct a
+`GpuContext` and pass it to `from_context`; raw buffers cannot cross the
+cfd-core boundary. WGPU-specific adapter/feature reporting remains a separate
+audit item.
+
+**Evidence**: GPU-enabled cfd-core nextest passes 244/244 and cfd-2d
+accelerated-solver nextest passes 2/2. Exact source audits find no old
+constructor or context device/queue accesses.
+
 ### 2026-07-10: delete generic GPU pipeline ownership [arch]
 
 **Context**: After every live CFD GPU operation moved to a typed Hephaestus

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,30 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+- 2026-07-17: `cfd-core::compute::gpu::GpuContext::synchronize` now delegates
+  completion to Hephaestus `ComputeDevice::synchronize`; `GpuContext` no longer
+  exposes raw WGPU device, queue, or limit fields; and cfd-2d creates its
+  Poisson solver through `GpuPoissonSolver::from_context`. Evidence tier:
+  compile-time provider integration plus GPU-enabled value-semantic regression
+  coverage (244/244 cfd-core and 2/2 accelerated cfd-2d nextest),
+  warning-denied cfd-core all-target Clippy, and exact source audits with no
+  `device.poll`, old Poisson constructor, context device/queue access, or
+  public raw-buffer accessor. WGPU-specific adapter/feature introspection
+  remains a separate provider-boundary risk.
+
+- **Verification closure (2026-07-17)**: `cargo doc -p cfd-core --no-deps
+  --features gpu --locked` completes warning-clean after the final raw-buffer
+  visibility change. The final source state is verified by cfd-core GPU
+  nextest 244/244, cfd-2d accelerated nextest 2/2, warning-denied cfd-core/
+  cfd-2d Clippy, and the package documentation gate.
+
+- **SemVer classification (2026-07-17)**: Git-baseline semver checks identify
+  the intentional removals as three breaking API classes under a minor-change
+  assumption. The explicit major-change classification passes. CFDrs remains
+  pre-1.0, so the workspace advances from `0.1.0` to `0.2.0` and records the
+  migration in the `0.2.0` changelog section without retaining a compatibility
+  surface.
+
 - 2026-07-17: Preserved the stale peer's valid Leto source revision
   `6aedde0c7835238867d6f3cd17b030f7e69cb6f2`, which is merged on Leto `main`,
   and advanced its Moirai companion pin to merged `main`


### PR DESCRIPTION
Removes public raw-WGPU ownership from the CFD GPU boundary.\n\n- GpuContext retains the acquired Hephaestus provider and synchronizes through ComputeDevice.\n- GpuPoissonSolver::from_context replaces raw device/queue construction.\n- GpuBuffer no longer exposes its raw handle.\n- Workspace moves to pre-1.0 

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR seals the GPU provider boundary by removing public raw WGPU ownership from `cfd-core`. `GpuContext` now retains the acquired Hephaestus provider internally and synchronizes through `ComputeDevice` rather than direct WGPU polling. `GpuPoissonSolver` construction shifts from accepting raw device and queue handles to `from_context`, ensuring Hephaestus maintains provider ownership. `GpuBuffer` no longer exposes its raw buffer handle. The workspace advances from version `0.1.0` to `0.2.0` as a pre-1.0 breaking release, with comprehensive documentation of the migration in the changelog and architecture decision records.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHECKLIST.md` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/adr.md` |
| 4 | `Cargo.toml` |
| 5 | `Cargo.lock` |
| 6 | `crates/cfd-core/src/compute/gpu/mod.rs` |
| 7 | `crates/cfd-core/src/compute/gpu/poisson_solver.rs` |
| 8 | `crates/cfd-core/src/compute/gpu/buffer.rs` |
| 9 | `crates/cfd-2d/src/solvers/accelerated.rs` |
| 10 | `crates/cfd-core/src/compute/tests.rs` |
| 11 | `gap_audit.md` |
| 12 | `backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->