### PR TITLE
feat(cfd)!: Seal typed GPU capabilities

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,26 @@ failure-output = "immediate"
 
 # Emit status updates for passing/slow tests to see progress in long suites.
 status-level = "all"
+
+# WGPU device creation is a process-global driver resource on this host. The
+# GPU contracts and compute capability detection create their own provider, so
+# Nextest serializes only those hardware-owning tests while unrelated CPU
+# contracts retain normal parallelism.
+[test-groups]
+gpu-device = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(cfd-core) & (test(/compute::gpu/) | test(/compute::tests/) | test(/gpu_tests/))'
+test-group = 'gpu-device'
+
+[[profile.default.overrides]]
+filter = 'package(cfd-math) & test(/gpu_metrics_tests/)'
+test-group = 'gpu-device'
+
+[[profile.default.overrides]]
+filter = 'package(cfd-2d) & test(/accelerated/)'
+test-group = 'gpu-device'
+
+[[profile.default.overrides]]
+filter = 'package(cfd-suite) & test(/gpu_tests/)'
+test-group = 'gpu-device'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-17 - Typed GPU Capability Boundary
+
+### Changed
+
+- `GpuContext` acquires its provider through Hephaestus'
+  `ComputeDeviceAcquisition` contract and reports capabilities through
+  `ComputeDeviceCapabilities`. The derived seven-storage-binding requirement
+  retains the provider's full downlevel compatibility baseline.
+- Nextest serializes only WGPU provider-acquiring tests through the
+  `gpu-device` group; CPU-only tests remain concurrent.
+
+### Breaking
+
+- `GpuContext::adapter_info` and `GpuContext::supports_features` are removed.
+  Consumers use `backend_name`, `supports_timestamp_queries`,
+  `max_work_group_size`, and `max_buffer_size`; new provider capabilities land
+  in Hephaestus rather than exposing WGPU types through CFDrs.
+
 ## [0.2.0] - 2026-07-17 - Error Consolidation
 
 ### Changed

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,6 +1,14 @@
 # CFDrs Work Checklist
 
-Target version: `0.2.0` (pre-1.0 breaking provider-boundary release).
+Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
+
+- [x] `cfd-core` [major]: Delete the remaining public WGPU adapter/feature
+  capability surface from `GpuContext`; acquire and query through Hephaestus
+  traits, preserve the seven-binding downlevel limit contract, and serialize
+  only process-global GPU tests through Nextest. Acceptance: empty raw API
+  consumer scan; value-semantic limit regression; complete cfd-core GPU,
+  cfd-math GPU, cfd-2d GPU, and root integration nextest; warning-denied
+  diagnostics; doctest/rustdoc; and pre-1.0 SemVer classification.
 
 - [x] `cfd-core` [major]: Make the Hephaestus buffer handle crate-private and
   delete `GpuBuffer::buffer`, which exposed a raw WGPU buffer despite having no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-1d"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-2d"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-3d"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "apollo-fft",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-io"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "approx",
  "bincode",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-math"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-optim"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-schematics"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cfd-core",
  "petgraph",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-suite"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "apollo-fft",
  "approx",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "cfd-validation"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1618,7 +1618,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hephaestus-core"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "bytemuck",
  "leto",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "hephaestus-wgpu"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "bytemuck",
  "hephaestus-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Ryan Clanton <ryan@clanton.dev>"]
 license = "MIT OR Apache-2.0"

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,24 @@
 
 ## Active integration
 
+- **CFD-GPU-CAPABILITY-1 [major] - Remove the remaining public WGPU
+  capability surface (DONE; owner=Codex; scope=`cfd-core` GPU context,
+  provider consumers, Nextest GPU resource group, release/PM artifacts).**
+  Acquire devices and query capabilities through Hephaestus's typed contracts,
+  preserve the downlevel descriptor while requiring seven storage bindings,
+  delete raw adapter/feature accessors, and serialize only hardware-owning
+  tests. Evidence: empty raw API scan; 245/245 cfd-core GPU, 362/362 cfd-math
+  GPU, 570/570 cfd-2d GPU (27 pre-existing skips), and 26/26 root nextest;
+  warning-denied touched-target Clippy; doctest/rustdoc; and expected
+  major-only SemVer classification for pre-1.0 `0.3.0`.
+
+- **CFD-EXAMPLE-CLIPPY-1 [patch] - Repair root validation-example diagnostics
+  (TODO; scope=`examples/{serpentine_mixing_comprehensive,bifurcation_3d_wall_shear_validation,comprehensive_cfd_validation_suite,venturi_blood_flow_validation,blood_flow_1d_validation,bifurcation_2d_blood_validation,bifurcation_3d_fem_validation}.rs`).**
+  Resolve the 29 warning-denied Clippy findings before restoring a clean
+  `cfd-suite --all-targets` gate. Acceptance: native examples compile and run
+  where CI-safe; no lint suppressions, placeholders, or changed numerical
+  assertions; root all-target Clippy passes with warnings denied.
+
 - **DEP-657-01 [patch] - Publish the merged Moirai provider revision (DONE;
   owner=Codex; scope=`Cargo.toml`, `Cargo.lock`, `cfd-schematics` lint
   remediation, PM artifacts).** Replace the stale explicit Moirai revision

--- a/crates/cfd-core/src/compute/gpu/buffer.rs
+++ b/crates/cfd-core/src/compute/gpu/buffer.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 /// GPU buffer wrapper
 pub struct GpuBuffer<T: RealField + Pod + Zeroable> {
-    /// Hephaestus-owned WGPU buffer.
+    /// Hephaestus-owned device buffer.
     pub(crate) buffer: HephaestusWgpuBuffer<T>,
     /// Buffer size in elements
     size: usize,
@@ -122,7 +122,7 @@ impl<T: RealField + Pod + Zeroable> std::fmt::Debug for GpuBuffer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GpuBuffer")
             .field("size", &self.size)
-            .field("buffer", &"<wgpu::Buffer>")
+            .field("buffer", &"<HephaestusDeviceBuffer>")
             .field("context", &"<GpuContext>") // Avoid recursive Debug
             .finish()
     }

--- a/crates/cfd-core/src/compute/gpu/mod.rs
+++ b/crates/cfd-core/src/compute/gpu/mod.rs
@@ -1,7 +1,10 @@
 //! GPU compute backend using Hephaestus' WGPU provider ABI.
 
 use crate::error::{Error, Result};
-use hephaestus_wgpu::{ComputeDevice, WgpuDevice, wgpu};
+use hephaestus_wgpu::{
+    ComputeDevice, ComputeDeviceAcquisition, ComputeDeviceCapabilities, DeviceFeature,
+    DeviceLimits, DevicePreference, WgpuDevice,
+};
 
 const REQUIRED_STORAGE_BUFFERS_PER_SHADER_STAGE: u32 = 7;
 
@@ -22,14 +25,8 @@ pub use turbulence_compute::GpuTurbulenceCompute;
 
 /// GPU context for managing device and queue
 pub struct GpuContext {
-    /// Hephaestus-owned WGPU provider and capability metadata.
+    /// Hephaestus-owned device provider.
     provider: WgpuDevice,
-    /// GPU adapter metadata captured during provider acquisition.
-    adapter_info: wgpu::AdapterInfo,
-    /// Enabled WGPU features for this provider device.
-    features: wgpu::Features,
-    /// Device limits
-    limits: wgpu::Limits,
 }
 
 impl GpuContext {
@@ -38,41 +35,21 @@ impl GpuContext {
     /// # Errors
     /// Returns error if GPU device initialization fails or no suitable adapter found
     pub fn create() -> Result<Self> {
-        let required_limits = wgpu::Limits {
-            // Three velocity inputs, pressure, and three corrected outputs are
-            // bound in one operation; requesting the derived limit makes the
-            // provider reject unsupported adapters during acquisition.
-            max_storage_buffers_per_shader_stage: REQUIRED_STORAGE_BUFFERS_PER_SHADER_STAGE,
-            ..wgpu::Limits::downlevel_defaults()
-        };
-        let provider = WgpuDevice::try_default_with_limits("CFD GPU Device", required_limits)
-            .map_err(|error| {
-                Error::InvalidConfiguration(format!(
-                    "Failed to acquire Hephaestus WGPU provider: {error}"
-                ))
-            })?;
-        let adapter_info = provider.adapter_info().cloned().ok_or_else(|| {
-            Error::InvalidConfiguration(
-                "Hephaestus WGPU provider did not report adapter metadata".to_string(),
-            )
+        let provider = WgpuDevice::try_acquire_device(
+            "CFD GPU Device",
+            DevicePreference::HighPerformance,
+            &[],
+            required_device_limits(),
+        )
+        .map_err(|error| {
+            Error::InvalidConfiguration(format!(
+                "Failed to acquire Hephaestus GPU provider: {error}"
+            ))
         })?;
 
-        // Log adapter info
-        tracing::info!(
-            "GPU adapter selected: {} ({:?}) - Backend: {:?}",
-            adapter_info.name,
-            adapter_info.device_type,
-            adapter_info.backend
-        );
+        tracing::info!(backend = provider.backend_name(), "GPU provider selected");
 
-        let features = provider.features();
-        let limits = provider.limits();
-        Ok(Self {
-            provider,
-            adapter_info,
-            features,
-            limits,
-        })
+        Ok(Self { provider })
     }
 
     /// Get the Hephaestus WGPU provider.
@@ -81,22 +58,19 @@ impl GpuContext {
         &self.provider
     }
 
-    /// Get adapter info
+    /// Return the selected provider's backend identifier.
     #[must_use]
-    pub fn adapter_info(&self) -> wgpu::AdapterInfo {
-        self.adapter_info.clone()
-    }
-
-    /// Check if GPU supports required features
-    #[must_use]
-    pub fn supports_features(&self, features: wgpu::Features) -> bool {
-        self.features.contains(features)
+    pub fn backend_name(&self) -> &'static str {
+        self.provider.backend_name()
     }
 
     /// Check whether timestamp query metrics are available.
     #[must_use]
     pub fn supports_timestamp_queries(&self) -> bool {
-        self.supports_features(wgpu::Features::TIMESTAMP_QUERY)
+        ComputeDeviceCapabilities::supports_device_feature(
+            &self.provider,
+            DeviceFeature::TimestampQuery,
+        )
     }
 
     /// Block until submitted GPU work visible to this context has completed.
@@ -110,12 +84,36 @@ impl GpuContext {
     /// Get maximum work group size
     #[must_use]
     pub fn max_work_group_size(&self) -> usize {
-        self.limits.max_compute_invocations_per_workgroup as usize
+        ComputeDeviceCapabilities::device_limits(&self.provider)
+            .max_compute_invocations_per_workgroup as usize
     }
 
     /// Get maximum buffer size
     #[must_use]
     pub fn max_buffer_size(&self) -> usize {
-        self.limits.max_buffer_size as usize
+        ComputeDeviceCapabilities::device_limits(&self.provider).max_buffer_size as usize
+    }
+}
+
+fn required_device_limits() -> DeviceLimits {
+    let mut limits = WgpuDevice::downlevel_device_limits();
+    // Three velocity inputs, pressure, and three corrected outputs are bound
+    // in one operation; provider acquisition rejects unsupported adapters.
+    limits.max_storage_buffers_per_shader_stage = Some(REQUIRED_STORAGE_BUFFERS_PER_SHADER_STAGE);
+    limits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_device_limits_preserve_downlevel_baseline() {
+        let limits = required_device_limits();
+        let mut expected = WgpuDevice::downlevel_device_limits();
+        expected.max_storage_buffers_per_shader_stage =
+            Some(REQUIRED_STORAGE_BUFFERS_PER_SHADER_STAGE);
+
+        assert_eq!(limits, expected);
     }
 }

--- a/crates/cfd-core/src/compute/tests.rs
+++ b/crates/cfd-core/src/compute/tests.rs
@@ -188,9 +188,7 @@ fn test_gpu_context_creation() {
     // Try to create GPU context
     match GpuContext::create() {
         Ok(context) => {
-            let info = context.adapter_info();
-            println!("GPU Adapter: {:?}", info.name);
-            println!("GPU Backend: {:?}", info.backend);
+            println!("GPU Backend: {}", context.backend_name());
             println!("Max work group size: {}", context.max_work_group_size());
             println!(
                 "Max buffer size: {} MB",

--- a/crates/cfd-core/tests/gpu_integration_test.rs
+++ b/crates/cfd-core/tests/gpu_integration_test.rs
@@ -21,9 +21,7 @@ mod gpu_tests {
             return;
         };
 
-        let info = context.adapter_info();
-        println!("GPU Device: {}", info.name);
-        println!("Driver: {}", info.driver);
+        assert_eq!(context.backend_name(), "wgpu");
 
         assert!(context.max_work_group_size() > 0);
         assert!(context.max_buffer_size() > 0);

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,25 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+- 2026-07-17 (resolved): `GpuContext` acquires and queries through
+  Hephaestus's `ComputeDeviceAcquisition` and `ComputeDeviceCapabilities`
+  seams after provider release 0.16.1 repaired typed downlevel acquisition.
+  The derived seven-storage-binding request preserves the full downlevel
+  descriptor; raw adapter and feature methods are deleted. Nextest serializes
+  only provider-acquiring tests through `gpu-device`, eliminating process-level
+  WGPU device races while CPU tests remain concurrent. Evidence tier:
+  compile-time API removal and empty source scan; value-semantic typed-limit
+  regression; cfd-core GPU 245/245, cfd-math GPU 362/362, cfd-2d GPU 570/570
+  (27 pre-existing skips), root integration 26/26; warning-denied touched
+  targets; doctest/rustdoc; and SemVer's expected major-only classification.
+  The root all-target example lint baseline is independently tracked by
+  CFD-EXAMPLE-CLIPPY-1.
+
+- 2026-07-17 (open): root `cfd-suite --all-targets` Clippy reports 29
+  pre-existing diagnostics across seven validation examples. The current
+  provider migration targets pass warning-denied Clippy; the exact example
+  scope and clean-gate acceptance are tracked by CFD-EXAMPLE-CLIPPY-1.
+
 - 2026-07-17: `cfd-core::compute::gpu::GpuContext::synchronize` now delegates
   completion to Hephaestus `ComputeDevice::synchronize`; `GpuContext` no longer
   exposes raw WGPU device, queue, or limit fields; and cfd-2d creates its
@@ -39,8 +58,8 @@
   coverage (244/244 cfd-core and 2/2 accelerated cfd-2d nextest),
   warning-denied cfd-core all-target Clippy, and exact source audits with no
   `device.poll`, old Poisson constructor, context device/queue access, or
-  public raw-buffer accessor. WGPU-specific adapter/feature introspection
-  remains a separate provider-boundary risk.
+  public raw-buffer accessor. The remaining adapter/feature introspection risk
+  is resolved by the 0.3.0 typed capability boundary above.
 
 - **Verification closure (2026-07-17)**: `cargo doc -p cfd-core --no-deps
   --features gpu --locked` completes warning-clean after the final raw-buffer

--- a/tests/gpu_integration.rs
+++ b/tests/gpu_integration.rs
@@ -1,6 +1,6 @@
 //! GPU integration tests
 //!
-//! Tests GPU compute functionality with wgpu.
+//! Tests GPU compute functionality through the Hephaestus provider.
 //! Detailed GPU kernel tests live in `crates/cfd-core/tests/gpu_integration_test.rs`.
 
 #[cfg(feature = "gpu")]
@@ -14,7 +14,9 @@ mod gpu_tests {
         // GPU context creation can fail in headless environments, which is OK
         if let Ok(context) = GpuContext::create() {
             println!("GPU context created successfully");
-            assert!(context.limits.max_texture_dimension_2d > 0);
+            assert_eq!(context.backend_name(), "wgpu");
+            assert!(context.max_work_group_size() > 0);
+            assert!(context.max_buffer_size() > 0);
         } else {
             println!("GPU not available (expected in CI/headless environments)");
         }


### PR DESCRIPTION
## Summary
- remove public WGPU adapter and feature capability access from GpuContext
- acquire and query through Hephaestus typed contracts while preserving the seven-binding downlevel request
- serialize only provider-owning Nextest cases to eliminate process-level device races

## Verification
- cfd-core GPU Nextest 245/245
- cfd-math GPU Nextest 362/362
- cfd-2d GPU Nextest 570/570, 27 pre-existing skips
- cfd-suite GPU Nextest 26/26
- warning-denied clippy for cfd-core, cfd-math, cfd-2d all targets and cfd-suite tests
- cfd-core doctest 3/3 and rustdoc
- SemVer minor detects the intentional removals; major classification passes

## Residual
Root all-target Clippy retains 29 pre-existing diagnostics across seven untouched validation examples, tracked as CFD-EXAMPLE-CLIPPY-1.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes direct WGPU adapter and feature exposure from `GpuContext`, replacing them with typed acquisition and capability queries through Hephaestus contracts (`ComputeDeviceAcquisition` and `ComputeDeviceCapabilities`). The seven-storage-binding requirement is preserved while maintaining full downlevel compatibility. Additionally, Nextest is configured to serialize only GPU provider-acquiring tests to eliminate process-level device races, while CPU-only tests continue running in parallel. Public methods `adapter_info()` and `supports_features()` are removed in favor of provider-agnostic accessors like `backend_name()`, `supports_timestamp_queries()`, `max_work_group_size()`, and `max_buffer_size()`.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `CHECKLIST.md` |
| 3 | `backlog.md` |
| 4 | `gap_audit.md` |
| 5 | `.config/nextest.toml` |
| 6 | `Cargo.toml` |
| 7 | `Cargo.lock` |
| 8 | `crates/cfd-core/src/compute/gpu/mod.rs` |
| 9 | `crates/cfd-core/src/compute/gpu/buffer.rs` |
| 10 | `crates/cfd-core/src/compute/tests.rs` |
| 11 | `crates/cfd-core/tests/gpu_integration_test.rs` |
| 12 | `tests/gpu_integration.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->