### PR TITLE
refactor(cfd-core)!: Delegate density response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ All notable changes to this project will be documented in this file.
   mutable-RNG sampler and direct `rand` dependency are removed. The provider
   closure advances Aequitas and Proteus together so CFDrs, Proteus, and
   Hephaestus share one dimensional-type identity.
+- **Breaking / architecture**: `PolynomialViscosity::calculate_density` now
+  returns a typed `Result` and delegates its linear thermal-expansion response
+  to Proteus. The response remains generic over the native scalar, while
+  invalid reference states, coefficients, temperatures, and evaluated
+  densities are rejected at the shared material-law boundary.
 - **Breaking / architecture**: `FluidState::thermal_diffusivity` now returns a
   typed `Result`, and both fluid-property entry points delegate dimensional
   validation and `alpha = k / (rho c_p)` to Proteus. CFDrs retains rheology and

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -3823,3 +3823,14 @@ Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 - [x] Integrate Tyche Latin-hypercube sampling into `cfd-optim`, including
   deterministic seed differentiation, invalid-count rejection, value-semantic
   consumer tests, provider-residue scans, and package gates.
+
+## Proteus temperature-response increment
+
+- [x] Advance Aequitas and Proteus to their merged temperature-response
+  revisions.
+- [x] Replace the local polynomial-fluid density equation with the generic
+  Proteus `TemperatureLaw`, using a linear density strategy and zero-sized
+  constant heat-capacity and conductivity strategies.
+- [x] Propagate material-domain failures through `cfd_core::Error::InvalidInput`.
+- [x] Document the ownership decision and verify the independent closed-form
+  density oracle plus negative-response rejection.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The suite is organized into 10 specialized crates:
 - **Adaptive Refinement**: Local mesh refinement based on solution features
 
 ### Thermal Physics & Conjugate Heat Transfer
+- **Proteus Constitutive Boundary**: Shared, dimensionally validated linear
+  temperature response for fluid density
 - **Boussinesq Approximation**: Temperature-dependent density for natural convection
 - **Buoyancy Coupling**: Momentum-energy equation integration with thermal expansion
 - **Conjugate Interfaces**: Solid-fluid thermal coupling with interface continuity

--- a/backlog.md
+++ b/backlog.md
@@ -2983,6 +2983,10 @@
   delegate Latin-hypercube sampling to Tyche, map fixed const-generic samples
   directly into candidates, and remove the duplicate sampler and `rand`
   dependency.
+- [x] `cfd-core` [major/arch]: Delegate the polynomial fluid model's linear
+  temperature-density response to Proteus, propagate its typed validation
+  failure, and verify the generic response against an independent closed-form
+  oracle and a negative-density rejection case.
 
 ## Rigor & Correctness
 - [x] Review all numerical bounds and geometry assumptions in `cfd-schematics`.

--- a/crates/cfd-core/src/compute/dispatch.rs
+++ b/crates/cfd-core/src/compute/dispatch.rs
@@ -124,9 +124,14 @@ impl ComputeDispatcher {
         }
         #[cfg(not(feature = "gpu"))]
         {
-            Err(crate::error::Error::UnsupportedOperation(
-                "GPU backend was requested but the gpu feature is disabled".to_string(),
-            ))
+            Err(crate::error::Error::UnsupportedOperation(format!(
+                "GPU backend was requested for kernel '{}' with input length {}, output \
+                     length {}, and problem size {}, but the gpu feature is disabled",
+                kernel.name(),
+                input.len(),
+                output.len(),
+                params.size
+            )))
         }
     }
 

--- a/crates/cfd-core/src/compute/gpu/kernels/laplacian/kernel.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/laplacian/kernel.rs
@@ -61,10 +61,10 @@ impl Laplacian2DKernel {
         ny: usize,
         dx: Length<f32>,
         dy: Length<f32>,
-    bc: BoundaryCondition,
-    result: &mut [f32],
-) -> Result<()> {
-    let params = validate_contract(field.len(), result.len(), nx, ny, dx, dy, bc)?;
+        bc: BoundaryCondition,
+        result: &mut [f32],
+    ) -> Result<()> {
+        let params = validate_contract(field.len(), result.len(), nx, ny, dx, dy, bc)?;
         let provider = self.context.provider();
         let input = provider.upload(field)?;
         let output = provider.alloc_zeroed(field.len())?;
@@ -86,9 +86,9 @@ impl Laplacian2DKernel {
         ny: usize,
         dx: Length<f32>,
         dy: Length<f32>,
-    bc: BoundaryCondition,
-) -> Result<()> {
-    let params = validate_contract(input.size(), output.size(), nx, ny, dx, dy, bc)?;
+        bc: BoundaryCondition,
+    ) -> Result<()> {
+        let params = validate_contract(input.size(), output.size(), nx, ny, dx, dy, bc)?;
         self.kernel.dispatch(
             self.context.provider(),
             &input.buffer,

--- a/crates/cfd-core/src/physics/fluid/newtonian.rs
+++ b/crates/cfd-core/src/physics/fluid/newtonian.rs
@@ -69,7 +69,9 @@ impl<T: RealField + Copy> ConstantPropertyFluid<T> {
         )?;
 
         if self.viscosity <= <T as NumericElement>::ZERO {
-            return Err(Error::InvalidInput("Viscosity must be positive".to_string()));
+            return Err(Error::InvalidInput(
+                "Viscosity must be positive".to_string(),
+            ));
         }
         if self.speed_of_sound <= <T as NumericElement>::ZERO {
             return Err(Error::InvalidInput(
@@ -279,11 +281,11 @@ mod tests {
     fn base_fluid() -> ConstantPropertyFluid<f64> {
         ConstantPropertyFluid::new(
             "test".to_string(),
-            998.2,    // density [kg/m³]
+            998.2,     // density [kg/m³]
             0.001_002, // viscosity [Pa·s]
-            4186.0,   // specific heat [J/(kg·K)]
-            0.599,    // thermal conductivity [W/(m·K)]
-            1482.0,   // speed of sound [m/s]
+            4186.0,    // specific heat [J/(kg·K)]
+            0.599,     // thermal conductivity [W/(m·K)]
+            1482.0,    // speed of sound [m/s]
         )
     }
 
@@ -326,7 +328,9 @@ mod tests {
     fn validate_rejects_negative_specific_heat_with_proteus_message() {
         let mut fluid = base_fluid();
         fluid.specific_heat = -1.0;
-        let err = fluid.validate().expect_err("negative specific heat is invalid");
+        let err = fluid
+            .validate()
+            .expect_err("negative specific heat is invalid");
         match err {
             Error::InvalidInput(msg) => assert!(
                 msg.contains("SpecificHeatCapacity"),
@@ -359,7 +363,7 @@ mod tests {
         let err = fluid.validate().expect_err("zero viscosity is invalid");
         match err {
             Error::InvalidInput(msg) => {
-                assert!(msg.to_lowercase().contains("viscosity"), "got: {msg}")
+                assert!(msg.to_lowercase().contains("viscosity"), "got: {msg}");
             }
             other => panic!("unexpected error variant: {other:?}"),
         }
@@ -373,10 +377,7 @@ mod tests {
             .validate()
             .expect_err("zero speed of sound is invalid");
         match err {
-            Error::InvalidInput(msg) => assert!(
-                msg.to_lowercase().contains("speed"),
-                "got: {msg}"
-            ),
+            Error::InvalidInput(msg) => assert!(msg.to_lowercase().contains("speed"), "got: {msg}"),
             other => panic!("unexpected error variant: {other:?}"),
         }
     }

--- a/crates/cfd-core/src/physics/fluid/temperature.rs
+++ b/crates/cfd-core/src/physics/fluid/temperature.rs
@@ -1,5 +1,6 @@
 //! Temperature-dependent fluid models
 
+use super::thermophysical::linear_density_at;
 use super::traits::{Fluid as FluidTrait, FluidState};
 use crate::error::Error;
 use eunomia::RealField;
@@ -45,10 +46,22 @@ impl<T: RealField + NumericElement + Copy> PolynomialViscosity<T> {
         viscosity
     }
 
-    /// Calculate density with thermal expansion
-    pub fn calculate_density(&self, temperature: T) -> T {
-        let dt = temperature - self.t_ref;
-        self.density_ref * (<T as NumericElement>::ONE - self.thermal_expansion * dt)
+    /// Calculate density with the shared Proteus linear temperature response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidInput`] when the reference thermophysical state,
+    /// response coefficient, evaluation temperature, or resulting density lies
+    /// outside the Proteus material-property contract.
+    pub fn calculate_density(&self, temperature: T) -> Result<T, Error> {
+        linear_density_at(
+            self.density_ref,
+            self.thermal_expansion,
+            self.t_ref,
+            self.specific_heat,
+            self.thermal_conductivity,
+            temperature,
+        )
     }
 }
 
@@ -60,7 +73,7 @@ impl<T: RealField + NumericElement + Copy> FluidTrait<T> for PolynomialViscosity
             ));
         }
 
-        let density = self.calculate_density(temperature);
+        let density = self.calculate_density(temperature)?;
         let viscosity = self.calculate_viscosity(temperature);
 
         Ok(FluidState {
@@ -370,9 +383,39 @@ mod tests {
         let expected_viscosity = 1.0 - 0.01 * 310.0 + 0.0001 * 310.0 * 310.0;
         assert!((viscosity - expected_viscosity).abs() <= 16.0 * f64::EPSILON);
 
-        let density = fluid.calculate_density(310.0);
+        let density = fluid
+            .calculate_density(310.0)
+            .expect("finite positive thermophysical state");
         let expected_density = 1000.0 * (1.0 - 2.0e-4 * 10.0);
-        assert!((density - expected_density).abs() <= 16.0 * f64::EPSILON * expected_density);
+        // Proteus evaluates the response with an FMA. Four native roundings
+        // bound that path, this independent expression, and density scaling.
+        let rounding = 4.0 * f64::EPSILON * expected_density.abs();
+        assert!((density - expected_density).abs() <= rounding);
+    }
+
+    #[test]
+    fn polynomial_density_rejects_a_negative_proteus_state() {
+        let fluid = PolynomialViscosity::<f64> {
+            name: "Invalid response".to_string(),
+            density_ref: 1000.0,
+            thermal_expansion: 0.2,
+            viscosity_coeffs: vec![1.0],
+            t_ref: 300.0,
+            specific_heat: 4180.0,
+            thermal_conductivity: 0.6,
+            speed_of_sound: 1480.0,
+        };
+
+        let error = fluid
+            .calculate_density(310.0)
+            .expect_err("the linear response produces negative density");
+        match error {
+            Error::InvalidInput(message) => {
+                assert!(message.contains("MassDensity"));
+                assert!(message.contains("FiniteNonNegative"));
+            }
+            other => panic!("unexpected error variant: {other}"),
+        }
     }
 
     #[test]

--- a/crates/cfd-core/src/physics/fluid/thermophysical.rs
+++ b/crates/cfd-core/src/physics/fluid/thermophysical.rs
@@ -1,6 +1,12 @@
-use aequitas::systems::si::quantities::{MassDensity, SpecificHeatCapacity, ThermalConductivity};
+use aequitas::systems::si::quantities::{
+    MassDensity, ReciprocalTemperature, SpecificHeatCapacity, ThermalConductivity,
+    ThermodynamicTemperature,
+};
 use eunomia::RealField;
-use proteus::ThermophysicalProperties;
+use proteus::{
+    ConstantResponse, ConstitutiveLaw, LinearResponse, ResponseSet, TemperatureLaw,
+    ThermophysicalProperties,
+};
 
 use crate::error::Error;
 
@@ -42,6 +48,46 @@ pub(super) fn validate_thermophysical_subset<T: RealField>(
     .map_err(|error| Error::InvalidInput(error.to_string()))
 }
 
+/// Evaluate a linearly temperature-dependent density through Proteus.
+///
+/// The CFD thermal-expansion convention
+/// `rho(T) = rho_ref * (1 - beta * (T - T_ref))` maps to a Proteus
+/// [`LinearResponse`] coefficient of `-beta`. Heat capacity and conductivity
+/// remain invariant ZST responses.
+pub(super) fn linear_density_at<T: RealField>(
+    density_ref: T,
+    thermal_expansion: T,
+    reference_temperature: T,
+    specific_heat: T,
+    thermal_conductivity: T,
+    temperature: T,
+) -> Result<T, Error> {
+    let reference_properties = ThermophysicalProperties::try_from_quantities(
+        MassDensity::from_base(density_ref),
+        SpecificHeatCapacity::from_base(specific_heat),
+        ThermalConductivity::from_base(thermal_conductivity),
+    )
+    .map_err(invalid_input)?;
+    let density_response =
+        LinearResponse::new(ReciprocalTemperature::from_base(-thermal_expansion))
+            .map_err(invalid_input)?;
+    let law = TemperatureLaw::new(
+        reference_properties,
+        ThermodynamicTemperature::from_base(reference_temperature),
+        ResponseSet::new(density_response, ConstantResponse, ConstantResponse),
+    )
+    .map_err(invalid_input)?;
+    let evaluation_temperature = ThermodynamicTemperature::from_base(temperature);
+
+    law.properties(&evaluation_temperature)
+        .map(|properties| *properties.density().quantity().as_base())
+        .map_err(invalid_input)
+}
+
+fn invalid_input(error: impl ToString) -> Error {
+    Error::InvalidInput(error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -58,6 +104,33 @@ mod tests {
     fn reports_the_proteus_property_that_violated_its_contract() {
         let error = thermal_diffusivity(-1.0_f64, 4_000.0, 0.6)
             .expect_err("negative density is outside the material domain");
+        match error {
+            Error::InvalidInput(message) => {
+                assert!(message.contains("MassDensity"));
+                assert!(message.contains("FiniteNonNegative"));
+            }
+            other => panic!("unexpected error variant: {other}"),
+        }
+    }
+
+    #[test]
+    fn linear_density_matches_the_closed_form_oracle() {
+        let actual = linear_density_at(1_000.0_f64, 2.0e-4, 300.0, 4_180.0, 0.6, 310.0)
+            .expect("finite positive thermophysical state");
+        let expected = 1_000.0_f64 * (1.0 - 2.0e-4 * (310.0 - 300.0));
+        // The Proteus response uses one FMA while the independent oracle uses
+        // separate product and subtraction. Four native roundings bound both
+        // evaluation paths and the final density scaling.
+        let rounding = 4.0 * f64::EPSILON * expected.abs();
+
+        assert!((actual - expected).abs() <= rounding);
+    }
+
+    #[test]
+    fn linear_density_rejects_a_nonphysical_response() {
+        let error = linear_density_at(1_000.0_f64, 0.2, 300.0, 4_180.0, 0.6, 310.0)
+            .expect_err("the response produces a negative mass density");
+
         match error {
             Error::InvalidInput(message) => {
                 assert!(message.contains("MassDensity"));

--- a/docs/atlas-migration/proteus-temperature-response.md
+++ b/docs/atlas-migration/proteus-temperature-response.md
@@ -1,0 +1,41 @@
+# Proteus temperature-response ownership
+
+## Context
+
+`cfd-core::physics::fluid::PolynomialViscosity` historically evaluated the
+linear thermal-expansion density law locally:
+
+`rho(T) = rho_ref * (1 - beta * (T - T_ref))`.
+
+Kwavers uses the same response family for tissue properties. Proteus now owns
+the dimensional, validated, statically dispatched temperature-response law.
+Retaining the CFDrs arithmetic would create a second constitutive-law owner.
+
+## Decision
+
+`cfd-core` delegates the density response to Proteus through its existing
+thermophysical anti-corruption module. The CFD expansion coefficient `beta`
+maps to the Proteus linear-response coefficient `-beta`; specific heat and
+conductivity use `ConstantResponse` zero-sized strategies.
+
+`PolynomialViscosity::calculate_density` becomes fallible because Proteus
+rejects invalid reference temperatures, non-finite coefficients, invalid
+thermophysical reference properties, and negative evaluated densities.
+Callers propagate the existing `cfd_core::Error::InvalidInput` boundary.
+
+The law remains monomorphized over `T`. Its GAT state borrows the evaluation
+temperature, and its response set contains no allocation or dynamic dispatch.
+
+## Rejected alternative
+
+Keeping the scalar formula in CFDrs avoids a fallible public method but leaves
+constitutive arithmetic duplicated and permits negative or non-finite density
+states. A downstream wrapper around the scalar formula has the same ownership
+defect.
+
+## Verification
+
+The focused tests compare the delegated result with an independent closed-form
+linear oracle under a four-rounding native-precision bound and assert that a
+coefficient producing negative density is rejected with Proteus property and
+constraint diagnostics.


### PR DESCRIPTION
## Summary
- delegate the polynomial fluid density response to the generic Proteus temperature law
- encode the CFD expansion coefficient as a linear response with zero-sized constant heat-capacity and conductivity strategies
- propagate invalid material states through the existing typed error boundary
- clear the two cfd-core formatting/clippy residuals that blocked the package gate

## Verification
- cargo fmt -p cfd-core -- --check
- cargo check --locked -p cfd-core --no-default-features
- cargo clippy --locked -p cfd-core --no-default-features --all-targets -- -D warnings
- cargo nextest run --locked -p cfd-core --no-default-features --no-fail-fast: 214 passed
- cargo test --locked -p cfd-core --no-default-features --doc: 3 passed
- RUSTDOCFLAGS=-D warnings cargo doc --locked -p cfd-core --no-default-features --no-deps
- cargo semver-checks: 223 checks passed; source contract remains classified breaking because the tool does not flag this generic method return-type change

## Supply-chain limit
CFDrs has no deny.toml. Default cargo-deny reports pre-existing workspace-wide source/license policy plus unmaintained bincode and ttf-parser advisories; this change adds no dependency or lock delta over main.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the fluid density calculation in `cfd-core` to delegate the linear thermal-expansion response to the shared Proteus temperature law, replacing local arithmetic with a validated, dimensional constitutive boundary. The `PolynomialViscosity::calculate_density` method now returns a typed `Result` that propagates material-domain failures (negative density, invalid coefficients, or reference states) through the existing `Error::InvalidInput` boundary. The change also includes formatting and clippy fixes that clear remaining package gate issues.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/atlas-migration/proteus-temperature-response.md` |
| 2 | `crates/cfd-core/src/physics/fluid/thermophysical.rs` |
| 3 | `crates/cfd-core/src/physics/fluid/temperature.rs` |
| 4 | `crates/cfd-core/src/physics/fluid/newtonian.rs` |
| 5 | `crates/cfd-core/src/compute/gpu/kernels/laplacian/kernel.rs` |
| 6 | `crates/cfd-core/src/compute/dispatch.rs` |
| 7 | `CHANGELOG.md` |
| 8 | `README.md` |
| 9 | `backlog.md` |
| 10 | `CHECKLIST.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Polynomial fluid density calculations now return a validation result instead of a raw value.
  - Invalid temperatures, coefficients, reference states, or nonphysical densities are rejected with clear input errors.

- **Improvements**
  - Temperature-dependent fluid density now uses a shared, dimensionally validated response.
  - GPU execution errors now include kernel and buffer details when GPU support is unavailable.

- **Documentation**
  - Updated thermal physics documentation, migration guidance, changelog, and project planning materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->