### PR TITLE
refactor(cfd-optim): Use Hyperion transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Architecture**: `cfd-optim` now evaluates 405-nm delivery through Hyperion's
+  validated coefficient, path, optical-depth, and Beer-Lambert transmission
+  types. CFDrs retains the empirical blood coefficient, treatment-channel path
+  selection, and nonnegative hematocrit policy; the duplicate raw production
+  exponential is removed.
+
 - **Breaking / architecture**: schematic analysis overlays now consume Iris
   `NamedColorMap` values directly, accept borrowed or owned scalar maps through
   `Cow`, validate finite fields at construction, and precompute scalar ranges.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,16 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
+- [ ] CFD-HYPERION-OPTICAL-1 [patch] [arch]: replace the raw 405-nm
+      Beer-Lambert report expression with direct Hyperion ownership.
+  - [ ] Align the Aequitas, Proteus, and Hyperion Git source identities.
+  - [ ] Retain empirical coefficient and hematocrit policy locally, but move
+        coefficient/path validation and transmission evaluation to Hyperion.
+  - [ ] Delete the raw production exponential and add analytical consumer
+        regressions for zero path, hematocrit policy, and finite attenuation.
+  - [ ] Pass locked cfd-optim check, Nextest, warning-denied Clippy, doctest,
+        Rustdoc, dependency identity, and production-residue gates.
+
 - [x] CFD-IRIS-COLOR-1 [major] [arch]: make Iris the normalized color-law
   owner for schematic analysis overlays.
   - [x] Add Iris as a direct dependency and remove the local map enum and

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,15 +2,18 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
-- [ ] CFD-HYPERION-OPTICAL-1 [patch] [arch]: replace the raw 405-nm
+- [x] CFD-HYPERION-OPTICAL-1 [patch] [arch]: replace the raw 405-nm
       Beer-Lambert report expression with direct Hyperion ownership.
-  - [ ] Align the Aequitas, Proteus, and Hyperion Git source identities.
-  - [ ] Retain empirical coefficient and hematocrit policy locally, but move
+  - [x] Align the Aequitas, Proteus, and Hyperion Git source identities.
+  - [x] Retain empirical coefficient and hematocrit policy locally, but move
         coefficient/path validation and transmission evaluation to Hyperion.
-  - [ ] Delete the raw production exponential and add analytical consumer
+  - [x] Delete the raw production exponential and add analytical consumer
         regressions for zero path, hematocrit policy, and finite attenuation.
-  - [ ] Pass locked cfd-optim check, Nextest, warning-denied Clippy, doctest,
-        Rustdoc, dependency identity, and production-residue gates.
+  - [x] Pass the cfd-optim compile, configured Nextest (132/132),
+        warning-denied all-target Clippy, doctest (2 passed, 3 existing
+        ignored), warning-denied Rustdoc, dependency identity, and production-
+        residue gates. The linked verification lane mounted the canonical,
+        gitignored contract fixtures so the full suite ran without exclusions.
 
 - [x] CFD-IRIS-COLOR-1 [major] [arch]: make Iris the normalized color-law
   owner for schematic analysis overlays.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
 name = "cfd-optim"
 version = "0.3.0"
 dependencies = [
+ "aequitas",
  "anyhow",
  "bincode",
  "cfd-1d",
@@ -579,6 +580,7 @@ dependencies = [
  "cfd-validation",
  "chrono",
  "gaia",
+ "hyperion",
  "moirai",
  "petgraph",
  "plotters",
@@ -1237,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "eunomia"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1468,7 +1470,6 @@ name = "gaia"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "approx",
  "cfd-schematics",
  "eunomia",
  "geometry-predicates",
@@ -1644,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1656,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1667,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-intrinsics"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1675,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1684,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-types"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1695,6 +1696,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hyperion"
+version = "0.1.0"
+dependencies = [
+ "aequitas",
+ "eunomia",
+ "proteus",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1824,7 +1834,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leto"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1836,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "leto-ops"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -2655,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "proteus"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/proteus?rev=335e5297b28c334987bd18bd85a09393a90dfe5f#335e5297b28c334987bd18bd85a09393a90dfe5f"
+source = "git+https://github.com/ryancinsight/proteus#bb51ac414f74fb47d8001310206c5aea2e3a160c"
 dependencies = [
  "aequitas",
  "eunomia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Math and numerical
-aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", rev = "be3a1ac91286a17aecf18f0065d2aa6b385eb67b", default-features = false, features = ["std"] }
-proteus = { git = "https://github.com/ryancinsight/proteus", rev = "335e5297b28c334987bd18bd85a09393a90dfe5f" }
+aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", default-features = false, features = ["std"] }
+proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
+hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
 tyche-core = { git = "https://github.com/ryancinsight/tyche", rev = "87923da922ec7bd17f12324c40d1da026be6b04e" }
 eunomia = { git = "https://github.com/ryancinsight/eunomia", default-features = false, features = ["std"] }
 iris = { git = "https://github.com/ryancinsight/iris", rev = "ef43861ae480ed199768580e0842968d98487e0f" }
@@ -137,6 +138,9 @@ gaia = { path = "../gaia" }
 
 [patch."https://github.com/ryancinsight/hephaestus.git"]
 hephaestus-wgpu = { path = "../hephaestus/crates/hephaestus-wgpu" }
+
+[patch."https://github.com/ryancinsight/hyperion"]
+hyperion = { path = "../hyperion" }
 
 [patch."https://github.com/ryancinsight/hermes.git"]
 hermes-simd = { path = "../hermes/crates/hermes-simd" }

--- a/backlog.md
+++ b/backlog.md
@@ -32,7 +32,7 @@
 ## Active integration
 
 - **CFD-HYPERION-OPTICAL-1 [patch] [arch] - Consolidate 405-nm transport on
-  Hyperion (IN PROGRESS; owner=`/root`; scope=`Cargo.toml`, `Cargo.lock`,
+  Hyperion (DONE; owner=`/root`; scope=`Cargo.toml`, `Cargo.lock`,
   `cfd-optim` report metric/tests, PM artifacts).** Retain the empirical blood
   coefficient, treatment-channel path selection, and hematocrit scaling in
   CFDrs; move coefficient/path validation, optical-depth construction, and
@@ -40,7 +40,14 @@
   expression without a wrapper or fallback. Acceptance: analytical zero-path,
   hematocrit-policy, and finite-path consumer regressions; exact residue and
   dependency-identity scans; locked cfd-optim check, Nextest, Clippy, doctest,
-  and Rustdoc gates.
+  and Rustdoc gates. Evidence: the four optical regressions pass, including the
+  exact zero-path and nonpositive-hematocrit identities, a finite analytical
+  oracle within Hyperion's `gamma(32)` bound, and typed negative-path
+  rejection. Configured Nextest passes 132/132; warning-denied all-target
+  Clippy, two runnable
+  doctests, and warning-denied Rustdoc pass. The lock contains one Aequitas,
+  Hyperion, and Proteus entry, and the production residue scan finds no raw
+  optical exponential.
 
 - **CFD-IRIS-COLOR-1 [major] [arch] - Consolidate schematic color laws on
   Iris (DONE; owner=Codex; scope=`cfd-schematics` analysis overlays/rendering,

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,17 @@
 
 ## Active integration
 
+- **CFD-HYPERION-OPTICAL-1 [patch] [arch] - Consolidate 405-nm transport on
+  Hyperion (IN PROGRESS; owner=`/root`; scope=`Cargo.toml`, `Cargo.lock`,
+  `cfd-optim` report metric/tests, PM artifacts).** Retain the empirical blood
+  coefficient, treatment-channel path selection, and hematocrit scaling in
+  CFDrs; move coefficient/path validation, optical-depth construction, and
+  Beer-Lambert transmission to Hyperion. Delete the raw production `exp(-mu L)`
+  expression without a wrapper or fallback. Acceptance: analytical zero-path,
+  hematocrit-policy, and finite-path consumer regressions; exact residue and
+  dependency-identity scans; locked cfd-optim check, Nextest, Clippy, doctest,
+  and Rustdoc gates.
+
 - **CFD-IRIS-COLOR-1 [major] [arch] - Consolidate schematic color laws on
   Iris (DONE; owner=Codex; scope=`cfd-schematics` analysis overlays/rendering,
   cfd-1d/cfd-2d/root examples, dependency lock, ADR and PM artifacts).**

--- a/crates/cfd-optim/Cargo.toml
+++ b/crates/cfd-optim/Cargo.toml
@@ -30,6 +30,8 @@ cfd-mesh.workspace = true
 cfd-math.workspace = true
 cfd-schematics.workspace = true
 cfd-validation.workspace = true
+aequitas.workspace = true
+hyperion.workspace = true
 tyche-core.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/cfd-optim/src/metrics/sdt_metrics.rs
+++ b/crates/cfd-optim/src/metrics/sdt_metrics.rs
@@ -642,8 +642,8 @@ pub struct SdtMetrics {
 
     /// Relative 405 nm light-delivery index ∈ [0, 1].
     ///
-    /// Beer-Lambert-style proxy:
-    /// `exp(-μ_eff,405 · optical_path_length_405_m · hematocrit_scale)`.
+    /// Hyperion Beer-Lambert transmission for the CFDrs-owned empirical
+    /// 405-nm blood attenuation coefficient and hematocrit scaling policy.
     ///
     /// Higher values indicate stronger blue-light delivery to circulating cells.
     #[serde(default)]

--- a/crates/cfd-optim/src/reporting/report_metrics.rs
+++ b/crates/cfd-optim/src/reporting/report_metrics.rs
@@ -1,3 +1,4 @@
+use aequitas::systems::si::quantities::{Length, ReciprocalLength};
 use cfd_1d::{
     acoustic_contrast_factor, acoustic_energy_density, cavitation_amplified_hi,
     cavitation_hemolysis_amplification, giersiepen_hi, sonosensitizer_activation_efficiency,
@@ -5,6 +6,10 @@ use cfd_1d::{
     SENSITIZER_K_ACT_HEMATOPORPHYRIN,
 };
 use cfd_schematics::topology::TreatmentActuationMode;
+use hyperion::{
+    coefficient::{InteractionCoefficient, LinearAttenuation},
+    quantity::PathLength,
+};
 
 use super::report_math::{
     coefficient_of_variation, cumulative_pass_damage, direct_linear_risk, inverse_linear_risk,
@@ -35,6 +40,18 @@ use crate::metrics::{
 fn cavitation_strength_from_sigma(cavitation_number: f64) -> f64 {
     let strength = (1.0 - cavitation_number).max(0.0);
     strength / (1.0 + strength)
+}
+
+fn blue_light_delivery_index(
+    optical_path_length_m: f64,
+    feed_hematocrit: f64,
+) -> Result<f64, hyperion::TransportError<f64>> {
+    let attenuation = InteractionCoefficient::<f64, LinearAttenuation>::new(
+        ReciprocalLength::from_base(BLOOD_ATTENUATION_405NM_INV_M * feed_hematocrit.max(0.0)),
+    )?;
+    let path = PathLength::new(Length::from_base(optical_path_length_m))?;
+    let transmission = attenuation.optical_depth(path)?.transmission();
+    Ok(transmission.into_quantity().into_base())
 }
 
 /// Compute the full set of report-grade SDT metrics for a single blueprint candidate.
@@ -347,11 +364,14 @@ pub fn compute_blueprint_report_metrics(
         .map(|sample| sample.cross_section.dims().1)
         .reduce(f64::max)
         .unwrap_or(0.0);
-    let blue_light_delivery_index_405nm = (-BLOOD_ATTENUATION_405NM_INV_M
-        * optical_path_length_405_m
-        * candidate.operating_point.feed_hematocrit.max(0.0))
-    .exp()
-    .clamp(0.0, 1.0);
+    let blue_light_delivery_index_405nm = blue_light_delivery_index(
+        optical_path_length_405_m,
+        candidate.operating_point.feed_hematocrit,
+    )
+    .map_err(|source| OptimError::PhysicsError {
+        id: candidate.id.clone(),
+        reason: format!("405-nm optical transport: {source}"),
+    })?;
 
     metrics.cavitation_number = cavitation_number;
     metrics.cavitation_potential = cavitation_potential;
@@ -714,6 +734,51 @@ mod tests {
         solve_blueprint_candidate,
     };
     use cfd_schematics::topology::VenturiPlacementMode;
+
+    #[test]
+    fn blue_light_delivery_is_unity_for_zero_path() {
+        let transmission = blue_light_delivery_index(0.0, 0.42).expect("valid optical input");
+
+        assert_eq!(transmission, 1.0);
+    }
+
+    #[test]
+    fn blue_light_delivery_preserves_nonnegative_hematocrit_policy() {
+        let transmission = blue_light_delivery_index(0.002, -0.2).expect("valid optical input");
+
+        assert_eq!(transmission, 1.0);
+    }
+
+    #[test]
+    fn blue_light_delivery_matches_beer_lambert_oracle() {
+        let optical_path_length_m = 0.002;
+        let feed_hematocrit = 0.42;
+        let transmission = blue_light_delivery_index(optical_path_length_m, feed_hematocrit)
+            .expect("valid optical input");
+        let expected =
+            (-BLOOD_ATTENUATION_405NM_INV_M * optical_path_length_m * feed_hematocrit).exp();
+        let scaled_epsilon = 32.0 * f64::EPSILON;
+        let tolerance = scaled_epsilon / (1.0 - scaled_epsilon) * expected.abs().max(1.0);
+
+        assert!(
+            (transmission - expected).abs() <= tolerance,
+            "Hyperion transmission {transmission} differs from the f64 Beer-Lambert oracle {expected} by more than {tolerance}"
+        );
+    }
+
+    #[test]
+    fn blue_light_delivery_rejects_negative_path() {
+        let error = blue_light_delivery_index(-0.001, 0.42)
+            .expect_err("negative optical path must fail validation");
+
+        assert!(matches!(
+            error,
+            hyperion::TransportError::InvalidValue {
+                field: hyperion::ValueKind::PathLength,
+                ..
+            }
+        ));
+    }
 
     #[test]
     fn test_sdt_acoustic_metrics_computable() {

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -14,6 +14,7 @@
 | **GMRES Linear Solver** | 2024-Sprint1.36 | Industry standard for SIMPLE/PISO | Configurable backend, GMRES default | ✅ Robust convergence ⚠️ Memory O(mn) |
 | **Provider-owned CSR execution** | 2026-07-10 | Leto is the CSR SpMV SSOT; CFDrs parallel flags had no behavioral effect | One `spmv`/`try_spmv` family; zero ignored execution flags | Breaking removal of inert compatibility APIs |
 | **Iris-owned color laws** | 2026-07-21 | `cfd-schematics` duplicated color formulas and rescanned field maps per rendered element | One direct `NamedColorMap` contract; linear range preprocessing; zero transient range allocations | Breaking overlay builders and field visibility |
+| **Hyperion-owned optical transport** | 2026-07-21 | `cfd-optim` evaluated a raw Beer-Lambert expression without the stack's validated optical types | One typed coefficient/path/optical-depth/transmission chain; zero duplicate production laws | CFDrs retains its empirical coefficient and hematocrit policy |
 
 ## Architecture Overview
 
@@ -72,6 +73,37 @@ UnifiedCompute → Backend selection (CPU/GPU/Hybrid)
 | **Performance Validation** | ⚠️ PENDING | HIGH | SIMD benchmarks needed to quantify 2-4x speedup |
 
 ## Recent Decisions
+
+### 2026-07-21: Hyperion owns 405-nm optical transport [patch] [arch]
+
+**Context**: `cfd-optim` selected an optical path from the solved treatment
+channels, then evaluated a raw `exp(-mu L)` expression. This duplicated the
+validated coefficient, path, optical-depth, and Beer-Lambert law already owned
+by Hyperion.
+
+**Decision**: CFDrs retains its empirical 405-nm blood attenuation coefficient,
+nonnegative hematocrit policy, and treatment-channel path selection. It converts
+those consumer inputs into Aequitas quantities and delegates validation,
+optical-depth construction, and transmission evaluation directly to Hyperion.
+Hyperion failures retain the candidate ID and enter the existing typed CFDrs
+physics-error boundary.
+
+**Rejected alternative**: a CFDrs wrapper type or local attenuation function was
+rejected because either would preserve a second optical-law owner. Moving the
+empirical blood coefficient or hematocrit policy upstream was rejected because
+they are SDT report assumptions, not general photon-transport laws.
+
+**Consequences**: production has one Beer-Lambert implementation and one
+dimensional validity boundary. Adding another optical consumer reuses the same
+Hyperion hierarchy instead of adding a sibling formula. No public CFDrs
+signature changes; invalid derived paths now fail rather than producing a
+clamped value.
+
+**Verification**: consumer regressions cover the exact zero-path identity,
+the local negative-hematocrit policy, a finite analytical Beer-Lambert oracle
+within the provider's documented `gamma(32)` exponential bound, and negative
+path rejection. Locked package checks, configured Nextest, Clippy, doctest,
+Rustdoc, dependency-identity, and raw-law residue scans close the change.
 
 ### 2026-07-21: Iris owns schematic color laws [major] [arch]
 


### PR DESCRIPTION
## Summary
- retain the empirical 405-nm blood coefficient and hematocrit policy in CFDrs
- delegate dimensional validation, optical-depth construction, and Beer-Lambert transmission to Hyperion
- align the Aequitas, Proteus, and Hyperion source graph and delete the raw production exponential

## Verification
- cargo nextest run --locked -p cfd-optim --build-jobs 4 (132 passed)
- cargo clippy --locked -p cfd-optim --all-targets -- -D warnings
- cargo test --locked -p cfd-optim --doc (2 passed, 3 existing ignored)
- RUSTDOCFLAGS=-D warnings cargo doc --locked -p cfd-optim --no-deps
- rustfmt --edition 2021 --check on touched Rust sources
- dependency-identity and production-residue scans

The linked verification lane mounted CFDrs's canonical gitignored contract fixtures so the complete package suite ran without exclusions.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the `cfd-optim` package to delegate 405-nm optical transport calculations to the Hyperion library. CFDrs continues to maintain its empirical blood attenuation coefficient and hematocrit policy but now uses Hyperion's validated types for coefficient validation, path-length handling, optical-depth construction, and Beer-Lambert transmission evaluation. The raw production `exp(-mu L)` expression is removed, consolidating optical transport logic into a single canonical implementation and eliminating code duplication.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr.md` |
| 2 | `Cargo.toml` |
| 3 | `Cargo.lock` |
| 4 | `crates/cfd-optim/Cargo.toml` |
| 5 | `crates/cfd-optim/src/reporting/report_metrics.rs` |
| 6 | `crates/cfd-optim/src/metrics/sdt_metrics.rs` |
| 7 | `CHANGELOG.md` |
| 8 | `CHECKLIST.md` |
| 9 | `backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->