### PR TITLE
refactor(cfd-schematics)!: Preserve native paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Breaking / architecture**: schematic rendering now carries native `Path`
+  values through renderer traits, plotter backends, layout sidecars, exports,
+  tests, and examples. Public plotting facades accept `impl AsRef<Path>`, so
+  callers no longer allocate strings or assume output paths are valid UTF-8.
+
 - **Architecture**: `cfd-optim` now evaluates 405-nm delivery through Hyperion's
   validated coefficient, path, optical-depth, and Beer-Lambert transmission
   types. CFDrs retains the empirical blood coefficient, treatment-channel path

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,18 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
+- [x] CFD-SCHEMATIC-PATH-1 [major] [arch]: recover the unmerged native output-
+      path boundary from `codex/cfd-example-paths` onto current main.
+  - [x] Change the renderer seam from `&str` to `&Path`; keep public plotting
+        facades borrow-generic through `impl AsRef<Path>`.
+  - [x] Preserve native `OsStr` layout-sidecar stems and migrate every live
+        renderer caller without a compatibility overload or lossy conversion.
+  - [x] Compile every affected package/example and pass warning-denied Clippy
+        for `cfd-schematics`, cfd-1d/cfd-2d examples, `cfd-optim`, and the two
+        affected root examples.
+  - [x] Pass all 177 `cfd-schematics` tests through configured Nextest,
+        including native non-UTF-8 path format detection.
+
 - [x] CFD-HYPERION-OPTICAL-1 [patch] [arch]: replace the raw 405-nm
       Beer-Lambert report expression with direct Hyperion ownership.
   - [x] Align the Aequitas, Proteus, and Hyperion Git source identities.

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,17 @@
 
 ## Active integration
 
+- **CFD-SCHEMATIC-PATH-1 [major] [arch] - Preserve native renderer paths
+  (DONE; owner=Codex; scope=`cfd-schematics`, renderer consumers, ADR, and PM
+  artifacts).** Replace the string-only renderer seam with borrowed `Path`
+  values, expose borrow-generic `AsRef<Path>` plotting facades, and construct
+  layout sidecar names from `OsStr` without UTF-8 conversion. All live callers
+  migrate in the same change; no overload or compatibility adapter remains.
+  Acceptance: affected examples compile, warning-denied Clippy passes,
+  warning-denied Clippy passes, all 177 rendering tests pass through configured
+  Nextest, and conversion scans find no renderer-bound `to_str` or
+  `to_string_lossy` call.
+
 - **CFD-HYPERION-OPTICAL-1 [patch] [arch] - Consolidate 405-nm transport on
   Hyperion (DONE; owner=`/root`; scope=`Cargo.toml`, `Cargo.lock`,
   `cfd-optim` report metric/tests, PM artifacts).** Retain the empirical blood

--- a/crates/cfd-1d/examples/cavitation_venturi_analysis.rs
+++ b/crates/cfd-1d/examples/cavitation_venturi_analysis.rs
@@ -60,12 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── 2. Plain schematic ───────────────────────────────────────────────────
     println!("2. Rendering plain schematic...");
-    plot_geometry(
-        &system,
-        out.join("cavitation/channel_schematic.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-    )?;
+    plot_geometry(&system, out.join("cavitation/channel_schematic.png"))?;
 
     // ── 3. Convert geometry → 1D specs ───────────────────────────────────────
     let node_specs = system.nodes.clone();
@@ -258,9 +253,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        out.join("cavitation/cavitation_number.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &out.join("cavitation/cavitation_number.png"),
         &config_cav,
         &cav_overlay,
     )?;
@@ -280,9 +273,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        out.join("cavitation/pressure_distribution.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &out.join("cavitation/pressure_distribution.png"),
         &config_p,
         &pressure_overlay,
     )?;
@@ -302,9 +293,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        out.join("cavitation/velocity_distribution.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &out.join("cavitation/velocity_distribution.png"),
         &config_v,
         &vel_overlay,
     )?;

--- a/crates/cfd-1d/examples/geometry_integration_demo.rs
+++ b/crates/cfd-1d/examples/geometry_integration_demo.rs
@@ -172,10 +172,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        output_dir
-            .join("flow_analysis.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &output_dir.join("flow_analysis.png"),
         &render_config,
         &overlay,
     )?;

--- a/crates/cfd-1d/examples/hemolysis_serpentine_analysis.rs
+++ b/crates/cfd-1d/examples/hemolysis_serpentine_analysis.rs
@@ -63,12 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── 2. Render plain schematic ────────────────────────────────────────────
     println!("2. Rendering plain channel schematic...");
-    plot_geometry(
-        &system,
-        out.join("hemolysis/channel_schematic.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-    )?;
+    plot_geometry(&system, out.join("hemolysis/channel_schematic.png"))?;
 
     // ── 3. Convert to 1D simulation specs ────────────────────────────────────
     // The system.nodes and system.channels are already the specs needed.
@@ -249,9 +244,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        out.join("hemolysis/hemolysis_index.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &out.join("hemolysis/hemolysis_index.png"),
         &config_hi,
         &hemolysis_overlay,
     )?;
@@ -272,9 +265,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        out.join("hemolysis/wall_shear_stress.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &out.join("hemolysis/wall_shear_stress.png"),
         &config_wss,
         &shear_overlay,
     )?;
@@ -297,9 +288,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     renderer.render_analysis(
         &system,
-        out.join("hemolysis/cavitation_risk.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
+        &out.join("hemolysis/cavitation_risk.png"),
         &config_cav,
         &cavitation_overlay,
     )?;

--- a/crates/cfd-1d/examples/medical_millifluidic_screening.rs
+++ b/crates/cfd-1d/examples/medical_millifluidic_screening.rs
@@ -76,12 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── 2. Plain schematic ───────────────────────────────────────────────────
     println!("2. Rendering plain schematic...");
-    plot_geometry(
-        &system,
-        out.join("medical_screening/schematic.png")
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-    )?;
+    plot_geometry(&system, out.join("medical_screening/schematic.png"))?;
 
     // ── 3. Convert & build network ───────────────────────────────────────────
     println!("3. Building 1D network with Carreau-Yasuda blood...");
@@ -357,13 +352,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             show_grid: false,
             ..Default::default()
         };
-        let output_path = path.to_str().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "visualization output path is not valid UTF-8",
-            )
-        })?;
-        renderer.render_analysis(&system, output_path, &rc, overlay)?;
+        renderer.render_analysis(&system, &path, &rc, overlay)?;
         println!("   ✓ {filename}");
     }
 

--- a/crates/cfd-1d/examples/venturi_parallel_analysis.rs
+++ b/crates/cfd-1d/examples/venturi_parallel_analysis.rs
@@ -107,12 +107,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Render schematic
         let schematic_path = out.join(format!("venturi_parallel/{label}_schematic.png"));
-        plot_geometry(
-            &system,
-            schematic_path
-                .to_str()
-                .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        )?;
+        plot_geometry(&system, &schematic_path)?;
         println!("  Rendered schematic → {label}_schematic.png");
 
         // ── 2. Convert to Network Specs ──────────────────────────────────────
@@ -326,13 +321,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ..Default::default()
             };
             let path = out.join(format!("venturi_parallel/{label}_{filename}.png"));
-            renderer.render_analysis(
-                &system,
-                path.to_str()
-                    .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-                &rc,
-                &overlay,
-            )?;
+            renderer.render_analysis(&system, &path, &rc, &overlay)?;
         }
         println!("  Rendered 4 overlay maps.");
 

--- a/crates/cfd-2d/examples/bifurcation_schematic.rs
+++ b/crates/cfd-2d/examples/bifurcation_schematic.rs
@@ -113,13 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let schematic_path = out.join("bifurcation_schematic.png");
-    renderer.render_system(
-        &system,
-        schematic_path
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        &schematic_cfg,
-    )?;
+    renderer.render_system(&system, &schematic_path, &schematic_cfg)?;
     println!("  ✅ Schematic → {}", schematic_path.display());
     println!(
         "  Murray's law: r_parent={:.3} mm, r_daughter={:.3} mm",
@@ -216,14 +210,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let overlay_path = out.join("bifurcation_flow_overlay.png");
-    renderer.render_analysis(
-        &system,
-        overlay_path
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        &overlay_cfg,
-        &overlay,
-    )?;
+    renderer.render_analysis(&system, &overlay_path, &overlay_cfg, &overlay)?;
     println!("  ✅ Flow rate overlay → {}", overlay_path.display());
 
     println!("\n✅ Bifurcation example complete.");

--- a/crates/cfd-2d/examples/serpentine_mixing_schematic.rs
+++ b/crates/cfd-2d/examples/serpentine_mixing_schematic.rs
@@ -101,13 +101,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let schematic_path = out.join("serpentine_schematic.png");
-    renderer.render_system(
-        &system,
-        schematic_path
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        &schematic_cfg,
-    )?;
+    renderer.render_system(&system, &schematic_path, &schematic_cfg)?;
     println!("  ✅ Schematic → {}", schematic_path.display());
 
     // ── Phase 2: Simulation (cfd-2d) ─────────────────────────────────────────
@@ -216,14 +210,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let overlay_path = out.join("serpentine_mixing_overlay.png");
-    renderer.render_analysis(
-        &system,
-        overlay_path
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        &overlay_cfg,
-        &overlay,
-    )?;
+    renderer.render_analysis(&system, &overlay_path, &overlay_cfg, &overlay)?;
     println!("  ✅ Pressure overlay → {}", overlay_path.display());
 
     println!("\n✅ Serpentine mixing example complete.");

--- a/crates/cfd-2d/examples/venturi_schematic.rs
+++ b/crates/cfd-2d/examples/venturi_schematic.rs
@@ -93,13 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let schematic_path = out.join("venturi_schematic.png");
-    renderer.render_system(
-        &system,
-        schematic_path
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        &schematic_cfg,
-    )?;
+    renderer.render_system(&system, &schematic_path, &schematic_cfg)?;
     println!("  ✅ Schematic → {}", schematic_path.display());
 
     // ── Phase 2: Simulation (cfd-2d) ─────────────────────────────────────────
@@ -188,14 +182,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let overlay_path = out.join("venturi_pressure_overlay.png");
-    renderer.render_analysis(
-        &system,
-        overlay_path
-            .to_str()
-            .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-        &overlay_cfg,
-        &overlay,
-    )?;
+    renderer.render_analysis(&system, &overlay_path, &overlay_cfg, &overlay)?;
     println!("  ✅ Pressure overlay → {}", overlay_path.display());
 
     println!("\n✅ Venturi example complete.");

--- a/crates/cfd-optim/src/delivery/export.rs
+++ b/crates/cfd-optim/src/delivery/export.rs
@@ -89,9 +89,8 @@ pub fn save_blueprint_schematic_svg(
         .into());
     }
     validate_blueprint_for_1d_solve(blueprint)?;
-    let output_path = path.to_string_lossy();
     let mut config = RenderConfig::well_plate_96_report_annotated();
     config.title.clone_from(&blueprint.name);
-    plot_blueprint_auto_annotated(blueprint, &output_path, &config)?;
+    plot_blueprint_auto_annotated(blueprint, path, &config)?;
     Ok(())
 }

--- a/crates/cfd-schematics/examples/advanced/shell_cuboid_demo.rs
+++ b/crates/cfd-schematics/examples/advanced/shell_cuboid_demo.rs
@@ -93,7 +93,6 @@ fn main() {
 
     fs::create_dir_all(&output_dir).expect("could not create outputs dir");
     let output_path = output_dir.join("shell_cuboid_demo.svg");
-    let output_path_str = output_path.to_str().unwrap().to_string();
 
     let config = RenderConfig {
         title: "TPMS-Filled Shell Cuboid — 96-well (Gyroid λ=5mm)".to_string(),
@@ -104,7 +103,7 @@ fn main() {
 
     let renderer = PlottersRenderer;
     renderer
-        .render_shell_cuboid(&shell, &output_path_str, &config)
+        .render_shell_cuboid(&shell, &output_path, &config)
         .expect("rendering failed");
 
     // ── 4. Interchange JSON ──────────────────────────────────────────────────

--- a/crates/cfd-schematics/examples/shared/output.rs
+++ b/crates/cfd-schematics/examples/shared/output.rs
@@ -43,7 +43,7 @@ pub fn save_example_output(blueprint: &NetworkBlueprint, example_name: &str) {
 
     // 2. Save SVG Visualization
     let svg_path = output_dir.join(format!("{}.svg", example_name));
-    plot_geometry(blueprint, svg_path.to_str().unwrap())
+    plot_geometry(blueprint, &svg_path)
         .map_err(|e| e.to_string())
         .unwrap_or_else(|e| panic!("Failed to plot geometry {:?}: {}", svg_path, e));
     println!("  - SVG : {:?}", svg_path.file_name().unwrap());
@@ -76,7 +76,7 @@ pub fn save_example_output_with_name(
 
     // 2. Save SVG Visualization
     let svg_path = output_dir.join(format!("{}.svg", file_name));
-    plot_geometry(blueprint, svg_path.to_str().unwrap())
+    plot_geometry(blueprint, &svg_path)
         .map_err(|e| e.to_string())
         .unwrap_or_else(|e| panic!("Failed to plot geometry {:?}: {}", svg_path, e));
 

--- a/crates/cfd-schematics/src/visualizations/plotters_backend/render_core.rs
+++ b/crates/cfd-schematics/src/visualizations/plotters_backend/render_core.rs
@@ -24,7 +24,7 @@ impl SchematicRenderer for PlottersRenderer {
     fn render_system(
         &self,
         system: &NetworkBlueprint,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
     ) -> VisualizationResult<()> {
         self.render_analysis(
@@ -38,7 +38,7 @@ impl SchematicRenderer for PlottersRenderer {
     fn render_analysis(
         &self,
         system: &NetworkBlueprint,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
         overlay: &AnalysisOverlay<'_>,
     ) -> VisualizationResult<()> {
@@ -66,16 +66,15 @@ impl SchematicRenderer for PlottersRenderer {
 impl PlottersRenderer {
     pub(super) fn detect_output_format(
         &self,
-        output_path: &str,
+        output_path: &Path,
     ) -> VisualizationResult<OutputFormat> {
-        let path = Path::new(output_path);
-        let extension = path
+        let extension = output_path
             .extension()
             .and_then(|ext| ext.to_str())
             .map(str::to_lowercase)
             .ok_or_else(|| {
                 VisualizationError::invalid_output_path(
-                    output_path,
+                    &output_path.display().to_string(),
                     "File must have a valid extension",
                 )
             })?;
@@ -86,7 +85,7 @@ impl PlottersRenderer {
             "svg" => Ok(OutputFormat::SVG),
             "pdf" => Ok(OutputFormat::PDF),
             _ => Err(VisualizationError::invalid_output_path(
-                output_path,
+                &output_path.display().to_string(),
                 &format!("Unsupported file extension: .{extension}"),
             )),
         }
@@ -95,7 +94,7 @@ impl PlottersRenderer {
     fn render_bitmap(
         &self,
         #[allow(unused_variables)] system: &NetworkBlueprint,
-        #[allow(unused_variables)] output_path: &str,
+        #[allow(unused_variables)] output_path: &Path,
         #[allow(unused_variables)] config: &RenderConfig,
         #[allow(unused_variables)] overlay: &AnalysisOverlay<'_>,
     ) -> VisualizationResult<()> {
@@ -119,7 +118,7 @@ impl PlottersRenderer {
     fn render_svg(
         &self,
         system: &NetworkBlueprint,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
         overlay: &AnalysisOverlay<'_>,
     ) -> VisualizationResult<()> {
@@ -134,7 +133,7 @@ impl PlottersRenderer {
         system: &NetworkBlueprint,
         config: &RenderConfig,
         root: DrawingArea<DB, Shift>,
-        output_path: &str,
+        output_path: &Path,
         overlay: &AnalysisOverlay<'_>,
     ) -> VisualizationResult<()> {
         let renderable =
@@ -293,7 +292,40 @@ impl PlottersRenderer {
         root.present()
             .map_err(|e| VisualizationError::rendering_error(&e.to_string()))?;
 
-        ::tracing::info!("Schematic plot saved to {output_path}");
+        ::tracing::info!(path = %output_path.display(), "Schematic plot saved");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OutputFormat, PlottersRenderer};
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    #[cfg(unix)]
+    fn native_non_utf8_svg_path() -> PathBuf {
+        use std::os::unix::ffi::OsStringExt;
+
+        PathBuf::from(OsString::from_vec(b"schematic_\xff.svg".to_vec()))
+    }
+
+    #[cfg(windows)]
+    fn native_non_utf8_svg_path() -> PathBuf {
+        use std::os::windows::ffi::OsStringExt;
+
+        let mut path = vec![0x0073, 0xD800];
+        path.extend(".svg".encode_utf16());
+        PathBuf::from(OsString::from_wide(&path))
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn detects_format_without_requiring_a_utf8_stem() {
+        let format = PlottersRenderer
+            .detect_output_format(&native_non_utf8_svg_path())
+            .expect("a native non-UTF-8 stem with an SVG extension is supported");
+
+        assert_eq!(format, OutputFormat::SVG);
     }
 }

--- a/crates/cfd-schematics/src/visualizations/plotters_backend/render_shell.rs
+++ b/crates/cfd-schematics/src/visualizations/plotters_backend/render_shell.rs
@@ -5,6 +5,7 @@ use crate::visualizations::traits::{OutputFormat, RenderConfig, SchematicRendere
 use plotters::coord::Shift;
 use plotters::prelude::*;
 use plotters::style::Color as PlottersColor;
+use std::path::Path;
 
 use super::convert_color;
 use super::render_core::PlottersRenderer;
@@ -14,7 +15,7 @@ impl PlottersRenderer {
     pub fn render_shell_cuboid(
         &self,
         cuboid: &ShellCuboid,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
     ) -> VisualizationResult<()> {
         self.validate_output_path(output_path)?;
@@ -33,7 +34,7 @@ impl PlottersRenderer {
     fn render_shell_bitmap(
         &self,
         #[allow(unused_variables)] cuboid: &ShellCuboid,
-        #[allow(unused_variables)] output_path: &str,
+        #[allow(unused_variables)] output_path: &Path,
         #[allow(unused_variables)] config: &RenderConfig,
     ) -> VisualizationResult<()> {
         #[cfg(target_arch = "wasm32")]
@@ -56,7 +57,7 @@ impl PlottersRenderer {
     fn render_shell_svg(
         &self,
         cuboid: &ShellCuboid,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
     ) -> VisualizationResult<()> {
         let root = SVGBackend::new(output_path, (config.width, config.height)).into_drawing_area();
@@ -70,7 +71,7 @@ impl PlottersRenderer {
         cuboid: &ShellCuboid,
         config: &RenderConfig,
         root: DrawingArea<DB, Shift>,
-        output_path: &str,
+        output_path: &Path,
     ) -> VisualizationResult<()> {
         let (w, h) = cuboid.outer_dims;
         let x_buffer = w * config.margin_fraction;
@@ -175,14 +176,17 @@ impl PlottersRenderer {
         root.present()
             .map_err(|e| VisualizationError::rendering_error(&e.to_string()))?;
 
-        ::tracing::info!("Shell cuboid schematic saved to {output_path}");
+        ::tracing::info!(path = %output_path.display(), "Shell cuboid schematic saved");
         Ok(())
     }
 }
 
 /// Convenience function: render a shell-cuboid with default config.
-pub fn plot_shell_cuboid(cuboid: &ShellCuboid, output_path: &str) -> VisualizationResult<()> {
+pub fn plot_shell_cuboid(
+    cuboid: &ShellCuboid,
+    output_path: impl AsRef<Path>,
+) -> VisualizationResult<()> {
     let renderer = PlottersRenderer;
     let config = RenderConfig::default();
-    renderer.render_shell_cuboid(cuboid, output_path, &config)
+    renderer.render_shell_cuboid(cuboid, output_path.as_ref(), &config)
 }

--- a/crates/cfd-schematics/src/visualizations/schematic/channel_system.rs
+++ b/crates/cfd-schematics/src/visualizations/schematic/channel_system.rs
@@ -2,6 +2,7 @@ use crate::domain::model::{ChannelShape, ChannelSpec, NetworkBlueprint, NodeKind
 use crate::geometry::metadata::ChannelPathMetadata;
 use crate::geometry::{ChannelTypeCategory, Point2D};
 use std::collections::HashMap;
+use std::path::Path;
 
 use super::layout::{blueprint_node_positions, save_auto_layout_json, BlueprintNodeLayout};
 use super::path_generation::{
@@ -18,7 +19,7 @@ pub(crate) struct RenderChannelSystem {
 pub(crate) fn channel_system_from_blueprint(
     blueprint: &NetworkBlueprint,
     box_dims_hint: Option<(f64, f64)>,
-    output_path: Option<&str>,
+    output_path: Option<&Path>,
 ) -> RenderChannelSystem {
     let box_dims = box_dims_hint.unwrap_or(blueprint.box_dims);
     let node_layout = blueprint_node_positions(blueprint, box_dims);

--- a/crates/cfd-schematics/src/visualizations/schematic/layout.rs
+++ b/crates/cfd-schematics/src/visualizations/schematic/layout.rs
@@ -126,16 +126,17 @@ struct NodePositionRecord {
 pub(super) fn save_auto_layout_json(
     layout: &BlueprintNodeLayout<'_>,
     box_dims: (f64, f64),
-    output_path: &str,
+    output_path: &std::path::Path,
 ) {
-    let stem = std::path::Path::new(output_path)
+    let stem = output_path
         .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("layout");
-    let dir = std::path::Path::new(output_path)
+        .unwrap_or_else(|| std::ffi::OsStr::new("layout"));
+    let dir = output_path
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."));
-    let json_path = dir.join(format!("{stem}_layout.json"));
+    let mut json_file_name = stem.to_os_string();
+    json_file_name.push("_layout.json");
+    let json_path = dir.join(json_file_name);
 
     let record = AutoLayoutRecord {
         source: "auto_layout",

--- a/crates/cfd-schematics/src/visualizations/schematic/mod.rs
+++ b/crates/cfd-schematics/src/visualizations/schematic/mod.rs
@@ -5,6 +5,7 @@ use crate::geometry::Point2D;
 use crate::visualizations::annotations::SchematicAnnotations;
 use crate::visualizations::plotters_backend::PlottersRenderer;
 use crate::visualizations::traits::{RenderConfig, SchematicRenderer};
+use std::path::Path;
 
 mod auto_annotations;
 mod channel_system;
@@ -17,34 +18,37 @@ pub(crate) use channel_system::channel_system_from_blueprint;
 use channel_system::resolved_channel_paths;
 use layout::blueprint_node_positions;
 
-pub fn plot_geometry(blueprint: &NetworkBlueprint, output_path: &str) -> VisualizationResult<()> {
+pub fn plot_geometry(
+    blueprint: &NetworkBlueprint,
+    output_path: impl AsRef<Path>,
+) -> VisualizationResult<()> {
     plot_blueprint_auto_annotated(blueprint, output_path, &RenderConfig::default())
 }
 
 pub fn plot_geometry_with_config(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     config: &RenderConfig,
 ) -> VisualizationResult<()> {
     let renderer = PlottersRenderer;
-    renderer.render_system(blueprint, output_path, config)
+    renderer.render_system(blueprint, output_path.as_ref(), config)
 }
 
 pub fn plot_geometry_with_annotations(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     config: &RenderConfig,
     annotations: &SchematicAnnotations,
 ) -> VisualizationResult<()> {
     let renderer = PlottersRenderer;
     let mut annotated_config = config.clone();
     annotated_config.annotations = Some(annotations.clone());
-    renderer.render_system(blueprint, output_path, &annotated_config)
+    renderer.render_system(blueprint, output_path.as_ref(), &annotated_config)
 }
 
 pub fn plot_blueprint(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     config: &RenderConfig,
 ) -> VisualizationResult<()> {
     plot_geometry_with_config(blueprint, output_path, config)
@@ -52,7 +56,7 @@ pub fn plot_blueprint(
 
 pub fn plot_blueprint_with_annotations(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     config: &RenderConfig,
     annotations: &SchematicAnnotations,
 ) -> VisualizationResult<()> {
@@ -61,7 +65,7 @@ pub fn plot_blueprint_with_annotations(
 
 pub fn plot_blueprint_auto_annotated(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     config: &RenderConfig,
 ) -> VisualizationResult<()> {
     let annotations = build_auto_annotations(blueprint);
@@ -101,7 +105,7 @@ pub(crate) fn materialize_blueprint_layout(blueprint: &mut NetworkBlueprint) {
 
 pub fn plot_geometry_auto_annotated(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     config: &RenderConfig,
 ) -> VisualizationResult<()> {
     plot_blueprint_auto_annotated(blueprint, output_path, config)
@@ -109,11 +113,11 @@ pub fn plot_geometry_auto_annotated(
 
 pub fn plot_geometry_with_renderer<R: SchematicRenderer>(
     blueprint: &NetworkBlueprint,
-    output_path: &str,
+    output_path: impl AsRef<Path>,
     renderer: &R,
     config: &RenderConfig,
 ) -> VisualizationResult<()> {
-    renderer.render_system(blueprint, output_path, config)
+    renderer.render_system(blueprint, output_path.as_ref(), config)
 }
 
 /// Collect all centerline vertices from a rendered system, including routed

--- a/crates/cfd-schematics/src/visualizations/traits/interfaces.rs
+++ b/crates/cfd-schematics/src/visualizations/traits/interfaces.rs
@@ -2,6 +2,7 @@ use crate::domain::model::NetworkBlueprint;
 use crate::error::VisualizationResult;
 use crate::geometry::Point2D;
 use crate::visualizations::analysis_field::AnalysisOverlay;
+use std::path::Path;
 
 use super::styles::{Color, LineStyle, OutputFormat, RenderConfig, TextStyle};
 
@@ -11,7 +12,7 @@ pub trait SchematicRenderer {
     fn render_system(
         &self,
         system: &NetworkBlueprint,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
     ) -> VisualizationResult<()>;
 
@@ -19,7 +20,7 @@ pub trait SchematicRenderer {
     fn render_analysis(
         &self,
         system: &NetworkBlueprint,
-        output_path: &str,
+        output_path: &Path,
         config: &RenderConfig,
         overlay: &AnalysisOverlay<'_>,
     ) -> VisualizationResult<()>;
@@ -28,12 +29,15 @@ pub trait SchematicRenderer {
     fn supported_formats(&self) -> Vec<OutputFormat>;
 
     /// Validate that the output path has a supported format.
-    fn validate_output_path(&self, path: &str) -> VisualizationResult<()> {
+    fn validate_output_path(&self, path: &Path) -> VisualizationResult<()> {
         let formats = self.supported_formats();
-        let path_lower = path.to_lowercase();
 
         for format in &formats {
-            if path_lower.ends_with(&format.extension()) {
+            if path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case(format.extension()))
+            {
                 return Ok(());
             }
         }
@@ -43,8 +47,9 @@ pub trait SchematicRenderer {
             .map(|format| format!(".{}", format.extension()))
             .collect();
 
+        let path_display = path.display().to_string();
         Err(crate::error::VisualizationError::invalid_output_path(
-            path,
+            &path_display,
             &format!(
                 "Unsupported format. Supported formats: {}",
                 supported_extensions.join(", ")

--- a/crates/cfd-schematics/tests/schematic_annotations.rs
+++ b/crates/cfd-schematics/tests/schematic_annotations.rs
@@ -120,9 +120,8 @@ fn annotated_svg_contains_markers_labels_and_role_colors() {
 
     let config = RenderConfig::well_plate_96_report_annotated();
     let path = unique_svg_path("cfd_schematic_annotations");
-    let path_str = path.to_string_lossy();
 
-    plot_geometry_with_annotations(&system, path_str.as_ref(), &config, &annotations)
+    plot_geometry_with_annotations(&system, &path, &config, &annotations)
         .expect("annotated schematic render must succeed");
 
     let svg = std::fs::read_to_string(&path).expect("must read rendered svg");
@@ -141,9 +140,8 @@ fn plot_geometry_with_config_still_renders_without_annotations() {
     let system = synthetic_system();
     let config = RenderConfig::well_plate_96();
     let path = unique_svg_path("cfd_schematic_plain");
-    let path_str = path.to_string_lossy();
 
-    plot_geometry_with_config(&system, path_str.as_ref(), &config)
+    plot_geometry_with_config(&system, &path, &config)
         .expect("non-annotated render must still succeed");
 
     let svg = std::fs::read_to_string(&path).expect("must read rendered svg");
@@ -154,9 +152,8 @@ fn plot_geometry_with_config_still_renders_without_annotations() {
 fn auto_annotations_include_computed_volume_label() {
     let system = synthetic_system();
     let path = unique_svg_path("cfd_schematic_auto_volume");
-    let path_str = path.to_string_lossy();
 
-    plot_geometry(&system, path_str.as_ref()).expect("auto-annotated render must succeed");
+    plot_geometry(&system, &path).expect("auto-annotated render must succeed");
 
     let svg = std::fs::read_to_string(&path).expect("must read rendered svg");
     assert!(svg.contains("Volume:"));
@@ -167,9 +164,8 @@ fn auto_annotations_include_computed_volume_label() {
 fn auto_annotations_with_render_hints_render_volume_once() {
     let system = synthetic_hinted_system();
     let path = unique_svg_path("cfd_schematic_auto_hinted_volume");
-    let path_str = path.to_string_lossy();
 
-    plot_geometry(&system, path_str.as_ref()).expect("hinted schematic render must succeed");
+    plot_geometry(&system, &path).expect("hinted schematic render must succeed");
 
     let svg = std::fs::read_to_string(&path).expect("must read rendered svg");
     assert_eq!(svg.matches("Volume:").count(), 1);
@@ -188,9 +184,8 @@ fn legend_notes_render_as_compact_segments() {
 
     let config = RenderConfig::well_plate_96_report_annotated();
     let path = unique_svg_path("cfd_schematic_legend_note");
-    let path_str = path.to_string_lossy();
 
-    plot_geometry_with_annotations(&system, path_str.as_ref(), &config, &annotations)
+    plot_geometry_with_annotations(&system, &path, &config, &annotations)
         .expect("legend note render must succeed");
 
     let svg = std::fs::read_to_string(&path).expect("must read rendered svg");

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -15,6 +15,7 @@
 | **Provider-owned CSR execution** | 2026-07-10 | Leto is the CSR SpMV SSOT; CFDrs parallel flags had no behavioral effect | One `spmv`/`try_spmv` family; zero ignored execution flags | Breaking removal of inert compatibility APIs |
 | **Iris-owned color laws** | 2026-07-21 | `cfd-schematics` duplicated color formulas and rescanned field maps per rendered element | One direct `NamedColorMap` contract; linear range preprocessing; zero transient range allocations | Breaking overlay builders and field visibility |
 | **Hyperion-owned optical transport** | 2026-07-21 | `cfd-optim` evaluated a raw Beer-Lambert expression without the stack's validated optical types | One typed coefficient/path/optical-depth/transmission chain; zero duplicate production laws | CFDrs retains its empirical coefficient and hematocrit policy |
+| **Native schematic output paths** | 2026-07-22 | String-only renderer seams forced UTF-8 conversion at every filesystem boundary | Renderer traits borrow `Path`; public facades accept `AsRef<Path>`; sidecar naming stays in `OsStr` | Breaking change for external renderer-trait implementations |
 
 ## Architecture Overview
 
@@ -73,6 +74,28 @@ UnifiedCompute → Backend selection (CPU/GPU/Hybrid)
 | **Performance Validation** | ⚠️ PENDING | HIGH | SIMD benchmarks needed to quantify 2-4x speedup |
 
 ## Recent Decisions
+
+### 2026-07-22: Preserve native schematic output paths [major] [arch]
+
+**Context**: the renderer trait and plotting facade accepted output paths as
+`&str`. Native `PathBuf` callers therefore allocated lossy strings or asserted
+UTF-8 validity before filesystem I/O. The stale `codex/cfd-example-paths`
+branch had solved this boundary, but its long-lived base could not be replayed
+over current main without overwriting later example and PM work.
+
+**Decision**: renderer implementations borrow `&Path`; public plotting
+facades accept `impl AsRef<Path>` and borrow once at the operation boundary.
+Layout sidecar names derive from `OsStr`/`OsString`. Every in-tree renderer
+caller passes its existing path directly, with no compatibility overload.
+
+**Rejected alternative**: retaining `&str` and centralizing conversion still
+rejects or alters valid native paths. Adding parallel string and path methods
+would create two public operation families and preserve the obsolete contract.
+
+**Consequences**: literals and strings remain accepted by the borrow-generic
+facades without allocation, while renderer-trait implementors migrate to
+`&Path`. The trait signature change is intentionally breaking; all in-tree
+implementors and consumers migrate in this delivery.
 
 ### 2026-07-21: Hyperion owns 405-nm optical transport [patch] [arch]
 

--- a/examples/cross_fidelity_branching.rs
+++ b/examples/cross_fidelity_branching.rs
@@ -241,24 +241,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         let overlay_path = out_dir.join(format!("{}_flow_overlay.svg", filename_prefix));
-        renderer.render_analysis(
-            &bp,
-            overlay_path
-                .to_str()
-                .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-            &overlay_cfg,
-            &overlay,
-        )?;
+        renderer.render_analysis(&bp, &overlay_path, &overlay_cfg, &overlay)?;
 
         let overlay_path_png = out_dir.join(format!("{}_flow_overlay.png", filename_prefix));
-        renderer.render_analysis(
-            &bp,
-            overlay_path_png
-                .to_str()
-                .expect("invariant: the manifest path and output suffix are valid UTF-8"),
-            &overlay_cfg,
-            &overlay,
-        )?;
+        renderer.render_analysis(&bp, &overlay_path_png, &overlay_cfg, &overlay)?;
 
         println!("  ✅ Rendered overlay → {}", overlay_path.display());
     }

--- a/examples/csgrs_api_test.rs
+++ b/examples/csgrs_api_test.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let svg_path = output_dir.join("ui_venturi_rect.svg");
     let mut render = RenderConfig::well_plate_96_report_annotated();
     render.title = "Canonical venturi schematic export".to_string();
-    plot_blueprint_auto_annotated(&blueprint, &svg_path.to_string_lossy(), &render)?;
+    plot_blueprint_auto_annotated(&blueprint, &svg_path, &render)?;
 
     println!("Blueprint: {}", blueprint.name);
     println!("Geometry-authored: {}", blueprint.is_geometry_authored());

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,17 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+- 2026-07-22 (resolved in CFD-SCHEMATIC-PATH-1): the stale
+  `codex/cfd-example-paths` branch contained a valid native-path boundary that
+  never reached main. Current main still required ten lossy or fallible UTF-8
+  conversions around renderer calls. The recovery ports only that contract
+  onto the current tree: renderer traits borrow `Path`, plotting facades accept
+  `AsRef<Path>`, sidecar naming stays in `OsStr`, and every live caller passes
+  its native path directly. Evidence tier: exact branch/content comparison,
+  affected package/example compilation, warning-denied Clippy, and a clean
+  renderer conversion scan. Configured Nextest passes all 177
+  `cfd-schematics` tests, including native non-UTF-8 path format detection.
+
 - 2026-07-21 (resolved in CFD-IRIS-COLOR-1): `cfd-schematics` duplicated
   Iris's normalized color-law role with a consumer-owned enum and three local
   formulas. Each edge or node lookup also rebuilt a value vector and rescanned


### PR DESCRIPTION
## Summary
- migrate the renderer contract from UTF-8 strings to borrowed native paths
- keep plotting facades borrow-generic with AsRef<Path>
- preserve native sidecar stems and migrate every live example/export caller
- add a non-UTF-8 stem format-detection regression and reconcile ADR/PM artifacts

## Verification
- cargo check and warning-denied Clippy for cfd-schematics, cfd-1d/cfd-2d examples, cfd-optim, and affected root examples
- cargo nextest run -p cfd-schematics --all-features --no-fail-fast (177 passed)
- rustfmt --check on every changed Rust file
- renderer conversion residue scan: clean

BREAKING CHANGE: SchematicRenderer output parameters now use &Path.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates the schematic rendering contract from UTF-8 strings to native borrowed paths (`&Path`), eliminating lossy conversions at filesystem boundaries. The `SchematicRenderer` trait and plotting backends now accept `&Path` parameters while public plotting facades remain borrow-generic through `impl AsRef<Path>`. Layout sidecar naming preserves native `OsStr` stems, and all in-tree renderer callers (across cfd-1d, cfd-2d, cfd-optim examples, and root examples) migrate to pass paths directly without string conversion. A new test ensures non-UTF-8 path stems work correctly with format detection.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-schematics/src/visualizations/traits/interfaces.rs` |
| 2 | `crates/cfd-schematics/src/visualizations/plotters_backend/render_core.rs` |
| 3 | `crates/cfd-schematics/src/visualizations/plotters_backend/render_shell.rs` |
| 4 | `crates/cfd-schematics/src/visualizations/schematic/mod.rs` |
| 5 | `crates/cfd-schematics/src/visualizations/schematic/channel_system.rs` |
| 6 | `crates/cfd-schematics/src/visualizations/schematic/layout.rs` |
| 7 | `crates/cfd-optim/src/delivery/export.rs` |
| 8 | `crates/cfd-schematics/examples/advanced/shell_cuboid_demo.rs` |
| 9 | `crates/cfd-schematics/examples/shared/output.rs` |
| 10 | `crates/cfd-schematics/tests/schematic_annotations.rs` |
| 11 | `crates/cfd-1d/examples/cavitation_venturi_analysis.rs` |
| 12 | `crates/cfd-1d/examples/geometry_integration_demo.rs` |
| 13 | `crates/cfd-1d/examples/hemolysis_serpentine_analysis.rs` |
| 14 | `crates/cfd-1d/examples/medical_millifluidic_screening.rs` |
| 15 | `crates/cfd-1d/examples/venturi_parallel_analysis.rs` |
| 16 | `crates/cfd-2d/examples/bifurcation_schematic.rs` |
| 17 | `crates/cfd-2d/examples/serpentine_mixing_schematic.rs` |
| 18 | `crates/cfd-2d/examples/venturi_schematic.rs` |
| 19 | `examples/cross_fidelity_branching.rs` |
| 20 | `examples/csgrs_api_test.rs` |
| 21 | `docs/adr.md` |
| 22 | `CHANGELOG.md` |
| 23 | `CHECKLIST.md` |
| 24 | `backlog.md` |
| 25 | `gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Schematic rendering now preserves native filesystem paths instead of requiring UTF-8 strings.
  * Plotting APIs accept path-like values directly, reducing unnecessary conversions and supporting non-UTF-8 paths.
  * Renderer integrations may require updates to use the new path-based interface.

* **Bug Fixes**
  * Output format detection and layout sidecar naming now work reliably with native filesystem paths.

* **Documentation**
  * Updated changelog, architecture decisions, checklists, and backlog records for the path-handling change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->