### PR TITLE
Publish CFDrs book through GitHub Pages

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -38,6 +38,7 @@ jobs:
             --output mdbook.tar.gz
           tar -xzf mdbook.tar.gz
           echo "$PWD" >> "$GITHUB_PATH"
+          export PATH="$PWD:$PATH"
           mdbook --version
 
       - name: Build book

--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -1,0 +1,69 @@
+name: Deploy mdBook
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - ".github/workflows/book-pages.yml"
+  pull_request:
+    paths:
+      - "docs/book/**"
+      - ".github/workflows/book-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: book-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install mdBook
+        env:
+          MDBOOK_VERSION: "0.5.4"
+        run: |
+          curl --fail --location --silent --show-error \
+            "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            --output mdbook.tar.gz
+          tar -xzf mdbook.tar.gz
+          echo "$PWD" >> "$GITHUB_PATH"
+          mdbook --version
+
+      - name: Build book
+        run: |
+          mdbook build docs/book
+          test -f target/book/cfdrs/index.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: target/book/cfdrs
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,9 +2,10 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
-- [ ] CFD-BOOK-PAGES-1 [patch]: add the repository-owned mdBook GitHub Pages
+- [x] CFD-BOOK-PAGES-1 [patch]: add the repository-owned mdBook GitHub Pages
       workflow, declare the `/CFDrs/` project-site base path, and link the
-      published book from the repository README.
+      published book from the repository README. Local mdBook build and
+      workflow syntax checks pass.
 
 - [x] CFD-BOOK-CLOSEOUT-1 [patch]: recover the stale book increment without
       retaining fabricated API or performance claims.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,10 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
+- [ ] CFD-BOOK-PAGES-1 [patch]: add the repository-owned mdBook GitHub Pages
+      workflow, declare the `/CFDrs/` project-site base path, and link the
+      published book from the repository README.
+
 - [x] CFD-BOOK-CLOSEOUT-1 [patch]: recover the stale book increment without
       retaining fabricated API or performance claims.
   - [x] Preserve twelve source-backed example pages and correct every source

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A modular Computational Fluid Dynamics (CFD) simulation framework in Rust with MPI parallelization, emphasizing clean architecture, performance optimization, and production readiness.
 
+## Documentation
+
+- [Published CFDrs book](https://ryancinsight.github.io/CFDrs/) — hosted mdBook site.
+- [Book source](docs/book/) — Markdown chapters and local build configuration.
+
 ## Architecture
 
 The suite is organized into 10 specialized crates:

--- a/backlog.md
+++ b/backlog.md
@@ -32,13 +32,14 @@
 ## Active integration
 
 - **CFD-BOOK-PAGES-1 [patch] - Publish the source-backed mdBook through
-  GitHub Pages (IN-PROGRESS; owner=Codex; scope=`.github/workflows/book-pages.yml`,
+  GitHub Pages (DONE; owner=Codex; scope=`.github/workflows/book-pages.yml`,
   `docs/book/book.toml`, `README.md`, and PM artifacts).** Build the existing
   mdBook source with the pinned mdBook release and deploy the generated static
   site through the repository-owned GitHub Pages environment. Acceptance:
   the workflow builds `docs/book`, uploads the configured output directory,
   deploys only from `main`, and the project-site base path is declared in
-  `book.toml`.
+  `book.toml`. Local evidence: `mdbook v0.5.4` built the book and produced
+  `target/book/cfdrs/index.html`; workflow syntax parsed successfully.
 
 - **CFD-BOOK-CLOSEOUT-1 [patch] - Recover source-backed book content
   (DONE; owner=Codex; scope=book navigation/example pages, linear-algebra

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,15 @@
 
 ## Active integration
 
+- **CFD-BOOK-PAGES-1 [patch] - Publish the source-backed mdBook through
+  GitHub Pages (IN-PROGRESS; owner=Codex; scope=`.github/workflows/book-pages.yml`,
+  `docs/book/book.toml`, `README.md`, and PM artifacts).** Build the existing
+  mdBook source with the pinned mdBook release and deploy the generated static
+  site through the repository-owned GitHub Pages environment. Acceptance:
+  the workflow builds `docs/book`, uploads the configured output directory,
+  deploys only from `main`, and the project-site base path is declared in
+  `book.toml`.
+
 - **CFD-BOOK-CLOSEOUT-1 [patch] - Recover source-backed book content
   (DONE; owner=Codex; scope=book navigation/example pages, linear-algebra
   parity report, lockfile, and PM artifacts).** Retain the twelve real

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -18,6 +18,7 @@ create-missing = false
 
 [output.html]
 mathjax-support = true
+site-url = "/CFDrs/"
 default-theme = "light"
 preferred-dark-theme = "navy"
 git-repository-url = "https://github.com/ryancinsight/CFDrs"


### PR DESCRIPTION
## Summary

- add a repository-owned GitHub Pages workflow for the mdBook
- pin the hosted build to mdBook 0.5.4 and verify the generated index
- declare the /CFDrs/ project-site base path and link the published book
- record the completed PM item

## Validation

- mdbook build docs/book
- generated target/book/cfdrs/index.html exists
- workflow YAML parses successfully
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR sets up automated deployment of the CFDrs documentation book (mdBook) to GitHub Pages. It adds a GitHub Actions workflow that builds the book using mdBook 0.5.4, configures the `/CFDrs/` project-site base path in the book configuration, adds a link to the published book in the README, and updates project management artifacts (CHECKLIST.md and backlog.md) to record the completion of this task.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/book/book.toml` |
| 2 | `.github/workflows/book-pages.yml` |
| 3 | `README.md` |
| 4 | `CHECKLIST.md` |
| 5 | `backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->