### PR TITLE
Preserve native sparse LU array ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Atlas-native memory boundary**: `cfd-math::DirectSparseSolver` now passes
+  its native `leto::Array1` view to `leto_ops::SparseLuSolver::solve_view` and
+  returns the provider-owned `Array1` result directly. This removes the
+  consumer-side RHS `Vec` staging and result copy without changing LU,
+  fallback, finiteness, or scalar contracts.
+
 - Recovered the mdBook example index with source-linked pages for twelve
   shipped examples, corrected their Cargo target names and behavior summaries,
   and consolidated the linear-algebra parity narrative on the analytical Leto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ cfd-io = { path = "crates/cfd-io" }
 cfd-mesh = { package = "gaia", git = "https://github.com/ryancinsight/gaia.git" }
 apollo-fft = { git = "https://github.com/ryancinsight/apollo.git" }
 apollo-nufft = { git = "https://github.com/ryancinsight/apollo.git" }
-leto = { git = "https://github.com/ryancinsight/leto.git", rev = "6545b6efe235daac04d78f2aa2522d3ccfaf284e", default-features = false, features = ["std"] }
-leto-ops = { git = "https://github.com/ryancinsight/leto.git", rev = "6545b6efe235daac04d78f2aa2522d3ccfaf284e", default-features = false, features = ["std"] }
+leto = { git = "https://github.com/ryancinsight/leto.git", rev = "b24fc860864abad84af3118aa2bb27c32bb81265", default-features = false, features = ["std"] }
+leto-ops = { git = "https://github.com/ryancinsight/leto.git", rev = "b24fc860864abad84af3118aa2bb27c32bb81265", default-features = false, features = ["std"] }
 # consus: pure-Rust scientific storage formats (HDF5 etc.). Consumed by cfd-io
 # behind the `hdf5` feature for real HDF5 output.
 consus-core = { git = "https://github.com/ryancinsight/consus.git", default-features = false }

--- a/crates/cfd-math/src/linear_solver/direct_solver.rs
+++ b/crates/cfd-math/src/linear_solver/direct_solver.rs
@@ -3,7 +3,8 @@
 //! Uses [`leto_ops::SparseLuSolver`] — the atlas-native sparse direct solver
 //! backed by dense partial-pivoting LU — for systems up to `max_size`. The
 //! dense LU path in `leto-ops` serves as both the primary sparse solver and
-//! the fallback, eliminating the external `rsparse` dependency.
+//! the fallback, eliminating the external `rsparse` dependency. The primary
+//! path preserves native Leto array ownership across the provider boundary.
 //!
 //! # Theorem — LU Factorisation Uniqueness
 //!
@@ -72,16 +73,10 @@ impl DirectSparseSolver {
             pivot_tolerance: self.pivot_tolerance,
         };
 
-        let rhs_slice: Vec<T> = rhs.iter().copied().collect();
-
-        match atlas_solver.solve(matrix, &rhs_slice) {
+        match atlas_solver.solve_view(matrix, &rhs.view()) {
             Ok(solution) => {
-                let mut x = Array1::from_elem([nrows], <T as NumericElement>::ZERO);
-                for (i, value) in solution.into_iter().enumerate() {
-                    x[i] = value;
-                }
-                Self::ensure_finite_solution(&x)?;
-                Ok(x)
+                Self::ensure_finite_solution(&solution)?;
+                Ok(solution)
             }
             Err(e) => {
                 let sparse_error = e.to_string();

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,5 +1,34 @@
 # CFD Suite Backlog
 
+## Sprint 1.96.167: cfd-math native sparse-LU result ownership
+**Status**: In Progress
+**Owner**: Codex `/root`
+**Change Class**: [minor] provider API + [patch] consumer allocation removal
+**Start Date**: July 22, 2026
+
+### Scope
+- Consume `leto_ops::SparseLuSolver::solve_view` from the direct solver.
+- Remove the consumer-owned RHS `Vec` staging and solution `Vec` to `Array1`
+  copy while preserving the existing fallback and finiteness contracts.
+- Synchronize the direct-solver tests, Rustdoc, changelog, and gap evidence.
+
+### Non-Goals
+- No change to dense-backed LU arithmetic, sparse storage, pivot policy,
+  fallback thresholds, or the legacy provider slice API.
+- No broad solver-family migration in this increment.
+
+### Acceptance and Verification
+- `DirectSparseSolver::solve` passes `rhs.view()` and returns the provider's
+  owned `Array1` result on the primary path.
+- Existing small-system, singular-input, dense-fallback, and generic scalar
+  value tests pass through the configured native test runner.
+- Format, warning-denied check/Clippy, focused Nextest, doctest, Rustdoc, and
+  public provider API SemVer checks pass on the exact delivered revisions.
+
+### Claimed Files
+`crates/cfd-math/src/linear_solver/direct_solver.rs`, its focused tests, and
+the corresponding `docs/{backlog,checklist,gap_audit}.md` plus `CHANGELOG.md`.
+
 ## Sprint 1.96.166: cfd-math IncompleteCholesky Leto CSR
 **Status**: Completed
 **Start Date**: July 5, 2026

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -29,6 +29,16 @@
 `crates/cfd-math/src/linear_solver/direct_solver.rs`, its focused tests, and
 the corresponding `docs/{backlog,checklist,gap_audit}.md` plus `CHANGELOG.md`.
 
+### Current Evidence
+- Provider `leto-ops` check, warning-denied all-target Clippy, sparse Nextest
+  (29/29), doctests (8/8), and Rustdoc pass against the local provider source.
+- Consumer `cfd-math` check, lib Clippy, direct-solver Nextest (4/4), doctest,
+  and Rustdoc pass. The package fmt check reports six pre-existing import-order
+  diffs outside the claimed file; the touched direct-solver file passes
+  standalone rustfmt.
+- Provider public-surface SemVer classification and exact merged dependency
+  integration remain open.
+
 ## Sprint 1.96.166: cfd-math IncompleteCholesky Leto CSR
 **Status**: Completed
 **Start Date**: July 5, 2026

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,7 +1,7 @@
 # CFD Suite Backlog
 
 ## Sprint 1.96.167: cfd-math native sparse-LU result ownership
-**Status**: In Progress
+**Status**: Completed
 **Owner**: Codex `/root`
 **Change Class**: [minor] provider API + [patch] consumer allocation removal
 **Start Date**: July 22, 2026
@@ -36,8 +36,9 @@ the corresponding `docs/{backlog,checklist,gap_audit}.md` plus `CHANGELOG.md`.
   and Rustdoc pass. The package fmt check reports six pre-existing import-order
   diffs outside the claimed file; the touched direct-solver file passes
   standalone rustfmt.
-- Provider public-surface SemVer classification and exact merged dependency
-  integration remain open.
+- Provider public-surface SemVer classification passes 196/196 checks with
+  57 skips, and the consumer pin is updated to merged Leto commit
+  `b24fc860864abad84af3118aa2bb27c32bb81265`.
 
 ## Sprint 1.96.166: cfd-math IncompleteCholesky Leto CSR
 **Status**: Completed

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -3,13 +3,13 @@
 the direct solver without redundant consumer-side allocations.
 
 **Success Criteria**:
-- [ ] `direct_solver.rs` passes `rhs.view()` to `SparseLuSolver::solve_view`.
-- [ ] The primary path returns the provider-owned `Array1` directly.
-- [ ] Existing positive, singular, fallback, and generic scalar value tests
+- [x] `direct_solver.rs` passes `rhs.view()` to `SparseLuSolver::solve_view`.
+- [x] The primary path returns the provider-owned `Array1` directly.
+- [x] Existing positive, singular, fallback, and generic scalar value tests
       pass without weakening assertions.
-- [ ] Direct-solver Rustdoc, changelog, and gap evidence describe the native
+- [x] Direct-solver Rustdoc, changelog, and gap evidence describe the native
       ownership boundary and its evidence limits.
-- [ ] Focused format, check, warning-denied Clippy, Nextest, doctest, and
+- [x] Focused format, check, warning-denied Clippy, Nextest, doctest, and
       Rustdoc gates pass.
 
 **Residual**: provider branch/API integration and exact-head downstream

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,3 +1,22 @@
+# Sprint 1.96.167 Checklist: cfd-math native sparse-LU result ownership
+**Goal**: Consume the provider-owned native array view/result boundary from
+the direct solver without redundant consumer-side allocations.
+
+**Success Criteria**:
+- [ ] `direct_solver.rs` passes `rhs.view()` to `SparseLuSolver::solve_view`.
+- [ ] The primary path returns the provider-owned `Array1` directly.
+- [ ] Existing positive, singular, fallback, and generic scalar value tests
+      pass without weakening assertions.
+- [ ] Direct-solver Rustdoc, changelog, and gap evidence describe the native
+      ownership boundary and its evidence limits.
+- [ ] Focused format, check, warning-denied Clippy, Nextest, doctest, and
+      Rustdoc gates pass.
+
+**Residual**: provider branch/API integration and exact-head downstream
+verification remain open until both repositories are delivered.
+
+---
+
 # Sprint 1.96.166 Checklist: cfd-math IncompleteCholesky Leto CSR
 **Goal**: Move IncompleteCholesky construction and factors to Leto CSR.
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -12,8 +12,9 @@ the direct solver without redundant consumer-side allocations.
 - [x] Focused format, check, warning-denied Clippy, Nextest, doctest, and
       Rustdoc gates pass.
 
-**Residual**: provider branch/API integration and exact-head downstream
-verification remain open until both repositories are delivered.
+**Closure**: Leto PR #70 is merged at
+`b24fc860864abad84af3118aa2bb27c32bb81265`; the `CFDrs` manifest pin and
+locked consumer gates now use that exact provider revision.
 
 ---
 

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -6,6 +6,27 @@
 **Date**: November 18, 2025 (Updated: February 23, 2026 - Sprint 1.95.0)
 **Status**: ✅ ALL CRITICAL ISSUES RESOLVED
 
+# Sprint 1.96.167 Resolution: cfd-math native sparse-LU result ownership
+
+### RESOLVED-196: Direct Solver Staged Native Arrays Through `Vec`
+- **Location**:
+  `crates/cfd-math/src/linear_solver/direct_solver.rs`.
+- **Issue**: the primary direct-solve path collected the native `Array1` RHS
+  into a temporary `Vec`, called the provider's slice API, then copied the
+  returned `Vec` into another `Array1`. This added two consumer-owned linear
+  buffers to every successful direct solve.
+- **Remediation**: `leto-ops` now owns the `ArrayView1`-based `solve_view`
+  contract. `DirectSparseSolver` passes `rhs.view()` and returns the provider
+  `Array1` directly; dense fallback and finite-result validation remain
+  unchanged.
+- **Evidence**: provider and consumer direct-solve tests preserve the exact
+  2×2 solution for `f32` and `f64`; provider all-target warning-denied Clippy,
+  provider check, consumer `cfd-math` check, consumer lib Clippy, and focused
+  direct-solver Nextest pass. Allocation reduction is established by the
+  source/data-flow audit; no runtime allocation profile is claimed.
+- **Residual**: the provider public API addition requires exact-head SemVer
+  classification and downstream lock/git revision integration before merge.
+
 # Sprint 1.96.166 Resolution: cfd-math IncompleteCholesky Still Required nalgebra CSR
 
 ### RESOLVED-PENDING-195: IncompleteCholesky Constructor Still Required nalgebra Sparse CSR

--- a/docs/gap_audit.md
+++ b/docs/gap_audit.md
@@ -24,8 +24,9 @@
   provider check, consumer `cfd-math` check, consumer lib Clippy, and focused
   direct-solver Nextest pass. Allocation reduction is established by the
   source/data-flow audit; no runtime allocation profile is claimed.
-- **Residual**: the provider public API addition requires exact-head SemVer
-  classification and downstream lock/git revision integration before merge.
+- **Closure**: provider SemVer classification passes 196/196 checks with 57
+  skips; Leto PR #70 merged at `b24fc860864abad84af3118aa2bb27c32bb81265`;
+  the `CFDrs` manifest pin and exact-head consumer gates use that revision.
 
 # Sprint 1.96.166 Resolution: cfd-math IncompleteCholesky Still Required nalgebra CSR
 


### PR DESCRIPTION
## Summary

- add the provider-owned Leto `ArrayView1` sparse-LU seam
- pass `cfd-math` native `Array1` views through the primary direct-solver path
- remove consumer-side RHS `Vec` staging and result copying
- pin the consumer to merged Leto commit `b24fc860864abad84af3118aa2bb27c32bb81265`

## Verification

- `cargo check --locked -p cfd-math --lib`
- warning-denied `cargo clippy --locked -p cfd-math --lib -- -D warnings`
- focused Nextest: 4/4 direct-solver tests passed
- doctests: 3 passed, 2 ignored
- Rustdoc passed
- touched-file rustfmt passed; package fmt reports six pre-existing import-order diffs outside the claimed file
- provider SemVer checks: 196 passed, 57 skipped

The allocation reduction is a source/data-flow result; no runtime allocation profile is claimed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes unnecessary memory allocations in the sparse direct solver by passing native `leto::Array1` views directly to the provider and returning provider-owned results, eliminating consumer-side RHS `Vec` staging and result copying. The change updates the `leto` and `leto-ops` dependency revisions to access the new `solve_view` API while preserving all existing LU, fallback, finiteness, and scalar contracts.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `crates/cfd-math/src/linear_solver/direct_solver.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/checklist.md` |
| 5 | `docs/backlog.md` |
| 6 | `docs/gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->