### PR TITLE
feat(cfd): Type fluid boundaries with Aequitas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Aequitas fluid dimensions**: `cfd-core` now evaluates kinematic
+  viscosity, Prandtl number, and Reynolds number through typed SI quantities;
+  `cfd-3d` computes cascade inlet velocity from typed volumetric flow and
+  area before crossing into the FEM scalar boundary.
+
 - **Atlas-native memory boundary**: `cfd-math::DirectSparseSolver` now passes
   its native `leto::Array1` view to `leto_ops::SparseLuSolver::solve_view` and
   returns the provider-owned `Array1` result directly. This removes the

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,10 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
+- [x] CFD-AEQUITAS-FLUID-ACOUSTIC-1 [patch]: route `cfd-core` fluid-number
+      equations and `cfd-3d` cascade inlet flow through Aequitas quantities;
+      typed provider tests and locked package checks pass.
+
 - [x] CFD-BOOK-PAGES-1 [patch]: add the repository-owned mdBook GitHub Pages
       workflow, declare the `/CFDrs/` project-site base path, and link the
       published book from the repository README. Local mdBook build and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
 name = "cfd-3d"
 version = "0.3.0"
 dependencies = [
+ "aequitas",
  "anyhow",
  "apollo-fft",
  "apollo-nufft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Math and numerical
-aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", default-features = false, features = ["std"] }
+aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", rev = "ce3ef7a6ea26a025b91df99034cadbbcf9b01330", default-features = false, features = ["std"] }
 proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
 hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
 tyche-core = { git = "https://github.com/ryancinsight/tyche", rev = "87923da922ec7bd17f12324c40d1da026be6b04e" }

--- a/crates/cfd-3d/Cargo.toml
+++ b/crates/cfd-3d/Cargo.toml
@@ -17,6 +17,7 @@ cfd-mesh = { workspace = true, features = ["cfdrs-integration"] }
 cfd-io.workspace = true
 apollo-fft.workspace = true
 apollo-nufft.workspace = true
+aequitas.workspace = true
 leto.workspace = true
 leto-ops.workspace = true
 eunomia.workspace = true

--- a/crates/cfd-3d/src/cascade/mod.rs
+++ b/crates/cfd-3d/src/cascade/mod.rs
@@ -47,6 +47,7 @@
 //! **Reference:** Hirn, A. (2013). "Finite element approximation of singular
 //! power-law systems." *Math. Comp.* 82:1247–1268.
 
+use aequitas::systems::si::quantities::{Area, VolumetricFlowRate, Velocity};
 use cfd_core::error::{Error, Result};
 use cfd_core::physics::boundary::BoundaryCondition;
 use cfd_core::physics::fluid::traits::Fluid as FluidTrait;
@@ -276,8 +277,10 @@ impl<F: FluidTrait<f64> + Clone> CascadeSolver3D<F> {
         }
 
         // 2. Compute inlet velocity from flow rate.
-        let inlet_area = spec.width * spec.height;
-        let u_inlet = spec.flow_rate_m3_s / inlet_area;
+        let inlet_area = Area::from_base(spec.width * spec.height);
+        let flow_rate = VolumetricFlowRate::from_base(spec.flow_rate_m3_s);
+        let inlet_velocity: Velocity = flow_rate / inlet_area;
+        let u_inlet = inlet_velocity.into_base();
 
         // 3. Assign boundary conditions.
         let mut boundary_conditions: HashMap<usize, BoundaryCondition<f64>> = HashMap::new();

--- a/crates/cfd-3d/tests/fem_tests.rs
+++ b/crates/cfd-3d/tests/fem_tests.rs
@@ -170,11 +170,13 @@ fn test_pressure_driven_channel_positive_x_velocity() {
                     .vertices
                     .get(VertexId::from_usize(node_idx))
                     .position;
-                if (p.x - 0.5).abs() < 0.3 && (p.y - 0.5).abs() < 0.3 && (p.z - 0.5).abs() < 0.3 {
-                    if sol.velocity[node_idx * 3] > 0.0 {
-                        found_positive = true;
-                        break;
-                    }
+                if (p.x - 0.5).abs() < 0.3
+                    && (p.y - 0.5).abs() < 0.3
+                    && (p.z - 0.5).abs() < 0.3
+                    && sol.velocity[node_idx * 3] > 0.0
+                {
+                    found_positive = true;
+                    break;
                 }
             }
             assert!(

--- a/crates/cfd-core/src/physics/fluid/traits.rs
+++ b/crates/cfd-core/src/physics/fluid/traits.rs
@@ -5,6 +5,10 @@
 
 use crate::error::Error;
 use crate::physics::fluid::thermophysical;
+use aequitas::systems::si::quantities::{
+    Dimensionless, DynamicViscosity, Length, MassDensity, SpecificHeatCapacity,
+    ThermalConductivity, Velocity,
+};
 use eunomia::NumericElement;
 use eunomia::RealField;
 
@@ -27,13 +31,20 @@ impl<T: RealField + NumericElement + Copy> FluidState<T> {
     /// Calculate kinematic viscosity [m²/s]
     #[inline]
     pub fn kinematic_viscosity(&self) -> T {
-        self.dynamic_viscosity / self.density
+        let dynamic_viscosity = DynamicViscosity::from_base(self.dynamic_viscosity);
+        let density = MassDensity::from_base(self.density);
+        let kinematic = dynamic_viscosity / density;
+        kinematic.into_base()
     }
 
     /// Calculate Prandtl number
     #[inline]
     pub fn prandtl_number(&self) -> T {
-        self.dynamic_viscosity * self.specific_heat / self.thermal_conductivity
+        let dynamic_viscosity = DynamicViscosity::from_base(self.dynamic_viscosity);
+        let specific_heat = SpecificHeatCapacity::from_base(self.specific_heat);
+        let thermal_conductivity = ThermalConductivity::from_base(self.thermal_conductivity);
+        let prandtl: Dimensionless<T> = dynamic_viscosity * specific_heat / thermal_conductivity;
+        prandtl.into_base()
     }
 
     /// Calculate thermal diffusivity [m²/s]
@@ -54,7 +65,12 @@ impl<T: RealField + NumericElement + Copy> FluidState<T> {
     /// Calculate Reynolds number
     #[inline]
     pub fn reynolds_number(&self, velocity: T, length: T) -> T {
-        self.density * velocity * length / self.dynamic_viscosity
+        let density = MassDensity::from_base(self.density);
+        let velocity = Velocity::from_base(velocity);
+        let length = Length::from_base(length);
+        let dynamic_viscosity = DynamicViscosity::from_base(self.dynamic_viscosity);
+        let reynolds: Dimensionless<T> = density * velocity * length / dynamic_viscosity;
+        reynolds.into_base()
     }
 
     /// Calculate Peclet number
@@ -176,3 +192,29 @@ pub trait CompressibleFluid<T: RealField + Copy>: Fluid<T> {
 }
 
 // Note: Individual types must implement the domains trait explicitly to avoid conflicts
+
+#[cfg(test)]
+mod tests {
+    use super::FluidState;
+
+    #[test]
+    fn typed_fluid_numbers_preserve_dimensionless_oracles() {
+        let state = FluidState {
+            density: 1_000.0_f64,
+            dynamic_viscosity: 0.004,
+            specific_heat: 4_000.0,
+            thermal_conductivity: 0.6,
+            speed_of_sound: 1_500.0,
+        };
+
+        assert_eq!(state.kinematic_viscosity().to_bits(), 4.0e-6_f64.to_bits());
+        assert_eq!(
+            state.prandtl_number().to_bits(),
+            (0.004_f64 * 4_000.0 / 0.6).to_bits()
+        );
+        assert_eq!(
+            state.reynolds_number(0.2, 0.01).to_bits(),
+            (1_000.0_f64 * 0.2 * 0.01 / 0.004).to_bits()
+        );
+    }
+}


### PR DESCRIPTION
## Summary\n- route cfd-core kinematic viscosity, Prandtl, and Reynolds equations through Aequitas SI quantities\n- compute cfd-3d cascade inlet velocity from typed volumetric flow and area\n- add value-semantic coverage and synchronize PM artifacts\n\nDepends on Aequitas PR #6.\n\n## Verification\n- cargo check --locked -p cfd-core --tests\n- cargo nextest run --locked -p cfd-core typed_fluid_numbers_preserve_dimensionless_oracles\n- cargo check --locked -p cfd-3d --tests\n- cargo clippy --locked -p cfd-core --all-targets -- -D warnings\n- cargo clippy --locked -p cfd-3d --lib -- -D warnings\n\nThe full cfd-3d all-target Clippy lane still reports 47 pre-existing warnings outside this slice.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces **type-safe dimensional analysis** for fluid boundary calculations by routing kinematic viscosity, Prandtl number, and Reynolds number computations through Aequitas SI quantity types. The `cfd-core` module now wraps raw values in typed quantities (`DynamicViscosity`, `MassDensity`, etc.) to ensure dimensional correctness, while `cfd-3d` computes cascade inlet velocity using typed `VolumetricFlowRate` and `Area` before converting to scalars for FEM operations. The changes preserve exact numerical behavior (verified via bitwise equality tests) while adding compile-time dimensional safety.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHECKLIST.md` |
| 2 | `CHANGELOG.md` |
| 3 | `Cargo.lock` |
| 4 | `crates/cfd-core/Cargo.toml` |
| 5 | `crates/cfd-core/src/physics/fluid/traits.rs` |
| 6 | `crates/cfd-3d/Cargo.toml` |
| 7 | `crates/cfd-3d/src/cascade/mod.rs` |
| 8 | `crates/cfd-3d/tests/fem_tests.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `crates/cfd-3d/tests/fem_tests.rs` | Contains unrelated formatting/style changes (nested conditional restructuring) that are not related to the Aequitas typing changes |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->