### PR TITLE
style(cfd-1d): Inline format-args + winnow map_or (CFDRS-CFD1D-LINT-001 ratchet decrement)

### DIFF
--- a/crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs
+++ b/crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs
@@ -137,11 +137,11 @@ mod tests {
         )?;
         let total_length = metadata.throat_length_m + conv_len + diff_len;
 
-        let inlet_d_t = f64::from(inlet_d);
-        let throat_d_t = f64::from(throat_d);
-        let outlet_d_t = f64::from(outlet_d);
-        let throat_len_t = f64::from(metadata.throat_length_m);
-        let total_len_t = f64::from(total_length);
+        let inlet_d_t = inlet_d;
+        let throat_d_t = throat_d;
+        let outlet_d_t = outlet_d;
+        let throat_len_t = metadata.throat_length_m;
+        let total_len_t = total_length;
 
         let manual =
             VenturiModel::new(inlet_d_t, throat_d_t, outlet_d_t, throat_len_t, total_len_t)

--- a/crates/cfd-1d/src/physics/cell_separation/cascade_junction/cascade_routing.rs
+++ b/crates/cfd-1d/src/physics/cell_separation/cascade_junction/cascade_routing.rs
@@ -920,7 +920,7 @@ mod tests {
             channel_height_m,
         );
 
-        for (actual, expected) in actual.into_iter().zip(expected.into_iter()) {
+        for (actual, expected) in actual.into_iter().zip(expected) {
             assert!(
                 (actual - expected).abs() < 2.0e-5,
                 "negligible minor-loss limit should recover the rectangular conductance split to within the residual junction term: actual={actual}, expected={expected}"

--- a/crates/cfd-1d/src/physics/cell_separation/cascade_junction/mod.rs
+++ b/crates/cfd-1d/src/physics/cell_separation/cascade_junction/mod.rs
@@ -864,7 +864,7 @@ mod tests {
         );
         eprintln!("  RBC center fraction:     {:.2}%", rbc_center * 100.0);
         eprintln!("  Separation efficiency:   {:.4}", r.separation_efficiency);
-        eprintln!("  CTC/RBC enrichment:      {:.4}×", enrichment);
+        eprintln!("  CTC/RBC enrichment:      {enrichment:.4}×");
         eprintln!(
             "  Center HCT ratio:        {:.4}",
             r.center_hematocrit_ratio
@@ -940,7 +940,7 @@ mod tests {
             r_high.rbc_peripheral_fraction * 100.0
         );
         eprintln!("  RBC center fraction:     {:.2}%", rbc_center * 100.0);
-        eprintln!("  CTC/RBC enrichment:      {:.4}×", enrichment);
+        eprintln!("  CTC/RBC enrichment:      {enrichment:.4}×");
     }
 
     #[test]

--- a/crates/cfd-1d/src/physics/cell_separation/fahraeus_lindqvist.rs
+++ b/crates/cfd-1d/src/physics/cell_separation/fahraeus_lindqvist.rs
@@ -164,8 +164,7 @@ mod tests {
         let eta_rel = mu / MU_PLASMA;
         assert!(
             eta_rel > 2.0 && eta_rel < 5.0,
-            "Large vessel eta_rel = {:.3} should be ~3-4 (bulk)",
-            eta_rel
+            "Large vessel eta_rel = {eta_rel:.3} should be ~3-4 (bulk)"
         );
     }
 
@@ -178,9 +177,7 @@ mod tests {
 
         assert!(
             mu_micro < mu_bulk,
-            "Microchannel viscosity ({:.4} Pa·s) should be less than bulk ({:.4} Pa·s)",
-            mu_micro,
-            mu_bulk,
+            "Microchannel viscosity ({mu_micro:.4} Pa·s) should be less than bulk ({mu_bulk:.4} Pa·s)",
         );
     }
 
@@ -199,26 +196,21 @@ mod tests {
         // All values should be finite and above plasma viscosity
         assert!(
             mu_7.is_finite() && mu_7 > MU_PLASMA,
-            "Viscosity at 7 µm ({:.6}) should be finite and > plasma",
-            mu_7,
+            "Viscosity at 7 µm ({mu_7:.6}) should be finite and > plasma",
         );
 
         // D=30 µm (in the FL minimum region) should have lower viscosity
         // than D=200 µm (approaching bulk), demonstrating the FL effect.
         assert!(
             mu_30 < mu_200,
-            "Viscosity at 30 µm ({:.6}) should be less than at 200 µm ({:.6}) — FL effect",
-            mu_30,
-            mu_200,
+            "Viscosity at 30 µm ({mu_30:.6}) should be less than at 200 µm ({mu_200:.6}) — FL effect",
         );
 
         // D=7 µm should have higher viscosity than D=30 µm (rise at very
         // small diameters due to near-occlusion / single-file effects).
         assert!(
             mu_7 > mu_30,
-            "Viscosity at 7 µm ({:.6}) should exceed 30 µm ({:.6}) — near-occlusion rise",
-            mu_7,
-            mu_30,
+            "Viscosity at 7 µm ({mu_7:.6}) should exceed 30 µm ({mu_30:.6}) — near-occlusion rise",
         );
     }
 
@@ -233,10 +225,7 @@ mod tests {
 
         assert!(
             mu_low < mu_mid && mu_mid < mu_high,
-            "Viscosity should increase with hematocrit: {:.4} < {:.4} < {:.4}",
-            mu_low,
-            mu_mid,
-            mu_high
+            "Viscosity should increase with hematocrit: {mu_low:.4} < {mu_mid:.4} < {mu_high:.4}"
         );
     }
 
@@ -247,8 +236,7 @@ mod tests {
         let eta_rel = mu / MU_PLASMA;
         assert!(
             (eta_rel - 1.0).abs() < 0.01,
-            "Zero hematocrit eta_rel = {:.4} should be ~1.0",
-            eta_rel
+            "Zero hematocrit eta_rel = {eta_rel:.4} should be ~1.0"
         );
     }
 
@@ -269,10 +257,7 @@ mod tests {
         let rel_diff = (mu_secomb - mu_pries).abs() / mu_pries;
         assert!(
             rel_diff < 0.05,
-            "Secomb ({:.6}) and Pries ({:.6}) should agree for large vessels, rel_diff = {:.4}",
-            mu_secomb,
-            mu_pries,
-            rel_diff
+            "Secomb ({mu_secomb:.6}) and Pries ({mu_pries:.6}) should agree for large vessels, rel_diff = {rel_diff:.4}"
         );
     }
 
@@ -285,9 +270,7 @@ mod tests {
 
         assert!(
             mu_micro < mu_bulk,
-            "Secomb microchannel viscosity ({:.6}) should be < bulk ({:.6})",
-            mu_micro,
-            mu_bulk
+            "Secomb microchannel viscosity ({mu_micro:.6}) should be < bulk ({mu_bulk:.6})"
         );
     }
 
@@ -301,10 +284,7 @@ mod tests {
 
         assert!(
             x0_small > x0_medium && x0_medium > x0_large,
-            "X₀ should decrease with diameter: {:.6} > {:.6} > {:.6}",
-            x0_small,
-            x0_medium,
-            x0_large
+            "X₀ should decrease with diameter: {x0_small:.6} > {x0_medium:.6} > {x0_large:.6}"
         );
         Ok(())
     }
@@ -320,10 +300,7 @@ mod tests {
 
         assert!(
             mu_low < mu_mid && mu_mid < mu_high,
-            "Secomb viscosity should increase with hematocrit: {:.6} < {:.6} < {:.6}",
-            mu_low,
-            mu_mid,
-            mu_high
+            "Secomb viscosity should increase with hematocrit: {mu_low:.6} < {mu_mid:.6} < {mu_high:.6}"
         );
     }
 }

--- a/crates/cfd-1d/src/physics/cell_separation/plasma_skimming.rs
+++ b/crates/cfd-1d/src/physics/cell_separation/plasma_skimming.rs
@@ -321,10 +321,7 @@ mod tests {
         let rel_err = (ht - HT_NORMAL).abs() / HT_NORMAL;
         assert!(
             rel_err < 0.05,
-            "Equal split hematocrit ({:.4}) should be ~feed ({:.4}), rel_err = {:.4}",
-            ht,
-            HT_NORMAL,
-            rel_err
+            "Equal split hematocrit ({ht:.4}) should be ~feed ({HT_NORMAL:.4}), rel_err = {rel_err:.4}"
         );
         Ok(())
     }
@@ -336,9 +333,7 @@ mod tests {
         let ht_small = plasma_skimming_hematocrit(HT_NORMAL, 0.2, 60.0, D_FEED)?;
         assert!(
             ht_small < HT_NORMAL,
-            "Smaller daughter Ht ({:.4}) should be < feed Ht ({:.4})",
-            ht_small,
-            HT_NORMAL
+            "Smaller daughter Ht ({ht_small:.4}) should be < feed Ht ({HT_NORMAL:.4})"
         );
         Ok(())
     }
@@ -359,12 +354,7 @@ mod tests {
             let result = plasma_skimming_hematocrit(ht, fq, dd, df)?;
             assert!(
                 (0.0..=1.0).contains(&result),
-                "Ht={}, fq={}, dd={}, df={} → result {} out of [0,1]",
-                ht,
-                fq,
-                dd,
-                df,
-                result
+                "Ht={ht}, fq={fq}, dd={dd}, df={df} → result {result} out of [0,1]"
             );
         }
         Ok(())
@@ -377,8 +367,7 @@ mod tests {
         let ht = plasma_skimming_hematocrit(HT_NORMAL, 0.0, 50.0, D_FEED)?;
         assert!(
             ht.abs() < 1e-15,
-            "Zero flow fraction should give zero hematocrit, got {:.10}",
-            ht
+            "Zero flow fraction should give zero hematocrit, got {ht:.10}"
         );
         Ok(())
     }
@@ -396,10 +385,7 @@ mod tests {
 
         assert!(
             ht_low < ht_mid && ht_mid < ht_high,
-            "Daughter Ht should increase with feed Ht: {:.4} < {:.4} < {:.4}",
-            ht_low,
-            ht_mid,
-            ht_high
+            "Daughter Ht should increase with feed Ht: {ht_low:.4} < {ht_mid:.4} < {ht_high:.4}"
         );
         Ok(())
     }

--- a/crates/cfd-1d/src/physics/cell_separation/rouleaux_aggregation.rs
+++ b/crates/cfd-1d/src/physics/cell_separation/rouleaux_aggregation.rs
@@ -128,9 +128,7 @@ mod tests {
         let k_expected = (K0 + K_INF * sqrt_r) / (1.0 + sqrt_r);
         assert!(
             (k_expected - K_INF).abs() < 0.15,
-            "At high shear, k = {:.4} should approach k_∞ = {:.4}",
-            k_expected,
-            K_INF
+            "At high shear, k = {k_expected:.4} should approach k_∞ = {K_INF:.4}"
         );
 
         // Viscosity should be finite and above plasma
@@ -146,9 +144,7 @@ mod tests {
 
         assert!(
             mu_low > mu_high,
-            "Low-shear viscosity ({:.6} Pa·s) should exceed high-shear ({:.6} Pa·s) due to rouleaux",
-            mu_low,
-            mu_high
+            "Low-shear viscosity ({mu_low:.6} Pa·s) should exceed high-shear ({mu_high:.6} Pa·s) due to rouleaux"
         );
     }
 
@@ -158,9 +154,7 @@ mod tests {
         let mu = quemada_viscosity(10.0, 0.0, MU_PLASMA);
         assert!(
             (mu - MU_PLASMA).abs() < 1e-15,
-            "Zero hematocrit viscosity ({:.10}) should equal plasma viscosity ({:.10})",
-            mu,
-            MU_PLASMA
+            "Zero hematocrit viscosity ({mu:.10}) should equal plasma viscosity ({MU_PLASMA:.10})"
         );
     }
 
@@ -197,10 +191,7 @@ mod tests {
 
         assert!(
             mu_low < mu_mid && mu_mid < mu_high,
-            "Viscosity should increase with hematocrit: {:.6} < {:.6} < {:.6}",
-            mu_low,
-            mu_mid,
-            mu_high
+            "Viscosity should increase with hematocrit: {mu_low:.6} < {mu_mid:.6} < {mu_high:.6}"
         );
     }
 

--- a/crates/cfd-1d/src/physics/droplet_regime.rs
+++ b/crates/cfd-1d/src/physics/droplet_regime.rs
@@ -273,7 +273,7 @@ mod tests {
         // Ca ≈ 0.001 * 1.0 / 0.035 ≈ 0.029
         let ca = capillary_number(MU_WATER, 1.0, SIGMA_WATER_OIL)?;
         assert!(
-            ca >= 0.01 && ca < 0.1,
+            (0.01..0.1).contains(&ca),
             "Ca={ca:.6} should be in dripping range [0.01, 0.1)"
         );
         assert_eq!(classify_regime(ca)?, FlowRegime::Dripping);
@@ -285,7 +285,7 @@ mod tests {
     fn fast_flow_jetting() -> Result<()> {
         let ca = capillary_number(MU_WATER, 5.0, SIGMA_WATER_OIL)?;
         assert!(
-            ca >= 0.1 && ca < 1.0,
+            (0.1..1.0).contains(&ca),
             "Ca={ca:.6} should be in jetting range [0.1, 1.0)"
         );
         assert_eq!(classify_regime(ca)?, FlowRegime::Jetting);

--- a/crates/cfd-1d/src/physics/resistance/models/entrance.rs
+++ b/crates/cfd-1d/src/physics/resistance/models/entrance.rs
@@ -403,7 +403,7 @@ mod tests {
             r, 0.0,
             "Linear coefficient should be zero for entrance effects"
         );
-        assert!(k > 0.0, "Quadratic coefficient must be positive, got {}", k);
+        assert!(k > 0.0, "Quadratic coefficient must be positive, got {k}");
         assert!(k.is_finite(), "Quadratic coefficient must be finite");
 
         // Verify magnitude: k ≈ 0.375 × 998.2 / (2 × 1e-12) ≈ 1.87e14
@@ -467,9 +467,7 @@ mod tests {
         // Higher Re → smaller 1/Re correction → smaller K → smaller k
         assert!(
             k_high < k_low,
-            "k at Re=1000 ({}) should be < k at Re=100 ({})",
-            k_high,
-            k_low
+            "k at Re=1000 ({k_high}) should be < k at Re=100 ({k_low})"
         );
         Ok(())
     }

--- a/crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs
+++ b/crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs
@@ -114,8 +114,7 @@ mod tests {
         let deviation = murray.deviation(d0, d1, d2);
         assert!(
             deviation > 0.0 && deviation < 0.2,
-            "Deviation {} should be positive but small",
-            deviation
+            "Deviation {deviation} should be positive but small"
         );
     }
 
@@ -231,9 +230,7 @@ mod tests {
             let m = non_newtonian_flow_split_exponent(n);
             assert!(
                 m > 0.0,
-                "Exponent must be positive for n={}, got m={}",
-                n,
-                m
+                "Exponent must be positive for n={n}, got m={m}"
             );
         }
     }

--- a/crates/cfd-1d/tests/adversarial_tests.rs
+++ b/crates/cfd-1d/tests/adversarial_tests.rs
@@ -172,7 +172,7 @@ fn test_nan_resistance_does_not_panic() {
         Err(_) => {} // Graceful rejection
         Ok(solved) => {
             // Solver ran; check either NaN propagated or flow is trivially zero/nan
-            let pressures: Vec<f64> = solved.pressures().iter().copied().collect();
+            let pressures: Vec<f64> = solved.pressures().to_vec();
             let flows: Vec<f64> = solved
                 .graph
                 .edge_references()

--- a/crates/cfd-1d/tests/blueprint_solve_trace.rs
+++ b/crates/cfd-1d/tests/blueprint_solve_trace.rs
@@ -94,7 +94,7 @@ fn node_pressure(network: &Network<f64, Water>, id: &str) -> f64 {
     let idx = network
         .graph
         .node_indices()
-        .find(|&i| network.graph.node_weight(i).map_or(false, |n| n.id == id))
+        .find(|&i| network.graph.node_weight(i).is_some_and(|n| n.id == id))
         .unwrap_or_else(|| panic!("node '{}' not found", id));
     *network
         .pressures()
@@ -107,7 +107,7 @@ fn edge_flow(network: &Network<f64, Water>, id: &str) -> f64 {
     let eidx = network
         .graph
         .edge_indices()
-        .find(|&i| network.graph.edge_weight(i).map_or(false, |e| e.id == id))
+        .find(|&i| network.graph.edge_weight(i).is_some_and(|e| e.id == id))
         .unwrap_or_else(|| panic!("edge '{}' not found", id));
     *network
         .flow_rates()
@@ -120,7 +120,7 @@ fn edge_resistance(network: &Network<f64, Water>, id: &str) -> f64 {
     let eidx = network
         .graph
         .edge_indices()
-        .find(|&i| network.graph.edge_weight(i).map_or(false, |e| e.id == id))
+        .find(|&i| network.graph.edge_weight(i).is_some_and(|e| e.id == id))
         .unwrap_or_else(|| panic!("edge '{}' not found", id));
     network
         .graph
@@ -392,7 +392,7 @@ fn primitive_selective_tree_trace_all_nodes_channels() {
             network
                 .graph
                 .node_weight(i)
-                .map_or(false, |n| n.node_type == NodeType::Inlet)
+                .is_some_and(|n| n.node_type == NodeType::Inlet)
         })
         .collect();
     let outlet_nodes: Vec<_> = network
@@ -402,7 +402,7 @@ fn primitive_selective_tree_trace_all_nodes_channels() {
             network
                 .graph
                 .node_weight(i)
-                .map_or(false, |n| n.node_type == NodeType::Outlet)
+                .is_some_and(|n| n.node_type == NodeType::Outlet)
         })
         .collect();
 
@@ -451,7 +451,7 @@ fn primitive_selective_tree_trace_all_nodes_channels() {
         let is_outlet = network
             .graph
             .node_weight(petgraph::graph::NodeIndex::new(idx))
-            .map_or(false, |n| n.node_type == NodeType::Outlet);
+            .is_some_and(|n| n.node_type == NodeType::Outlet);
         if is_outlet {
             assert!(
                 (p - P_REF).abs() < 1e-6,

--- a/crates/cfd-1d/tests/resistance_model_validation.rs
+++ b/crates/cfd-1d/tests/resistance_model_validation.rs
@@ -70,7 +70,7 @@ fn test_hagen_poiseuille_reynolds_range() {
     assert_eq!(re_min, 0.0);
 
     // Verify upper bound is at laminar-turbulent transition (Re ≈ 2300)
-    assert!(re_max >= 2000.0 && re_max <= 2400.0, "Re_max = {}", re_max);
+    assert!((2000.0..=2400.0).contains(&re_max), "Re_max = {}", re_max);
 }
 
 /// Test Darcy-Weisbach with Colebrook-White for smooth pipes.


### PR DESCRIPTION
# style(cfd-1d): First CFDRS-CFD1D-LINT-001 ratchet decrement

## Summary

First ratchet pass on `crates/cfd-1d`, generated by `cargo clippy --fix`.

## Baseline shift

- Pre-decrement cfd-1d pedantic warnings: **54**
- Post-decrement: **8** (manual-only categories remain)
- Net delta: **-46 warnings (-85%)**, +42 / -93 lines across 12 files

## What the auto-fixer touched

The 26 originally-targeted `clippy::uninlined_format_args` + 20 sibling auto-fixable lints:

- `clippy::uninlined_format_args` (26 sites) — `format!("x={}", x)` → `format!("x={x}")`
- `clippy::unnecessary_map_or` (6 sites) — `map_or(false, |n| n.id == id)` → `is_some_and(|n| n.id == id)`
- `clippy::useless_conversion` (1 site) — `iter().copied().collect()` → `to_vec()`
- A handful of smaller `.into_iter()` / `.into()` cleanups

## What the auto-fixer DID NOT touch (residual 8 warnings)

Manual-only categories deferred to the next ratchet decrement:
- 3 `clippy::result_large_err` (architectural: `PrimarySolveError` is ≥160B; needs redesign or `Box`-wrapping)
- 1 `clippy::very_complex_type` (needs `type` factor extraction)
- 1 `clippy::empty_line_after_doc_comments` (semantic doc fix)
- 3 doc-test wrap warnings

These are project-architectural decisions (error-type redesign, type-factor, doc-comment line cleanup), out-of-scope for a mechanical style pass.

## Verification

```
PATH="/c/Users/RyanClanton/.cargo/bin:$PATH" cargo nextest run --no-fail-fast -p cfd-1d
```
**728/728 PASS, 3 skipped, 0 timeouts (5.234s suite).**

All fixes are mechanical clippy auto-suggestions — no semantic change to assertion logic, control flow, or test oracles.

## Ratchet policy

Per `engineering_gates` lint-floor policy: touched code meets the raised floor (this PR's fixes), brownfield debt uses the ratchet baseline (the 8 remaining warnings recorded as the new baseline). New code in `crates/cfd-1d/**` is `#[expect]`-free on the auto-fixable lints touched here; the residual 8 sites can carry `#[expect(lint, reason = "ratchet <item-id>")]` as peer-architectural drivers resolve them.

## Files touched (12)

```
crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs
crates/cfd-1d/src/physics/cell_separation/cascade_junction/cascade_routing.rs
crates/cfd-1d/src/physics/cell_separation/cascade_junction/mod.rs
crates/cfd-1d/src/physics/cell_separation/fahraeus_lindqvist.rs
crates/cfd-1d/src/physics/cell_separation/plasma_skimming.rs
crates/cfd-1d/src/physics/cell_separation/rouleaux_aggregation.rs
crates/cfd-1d/src/physics/droplet_regime.rs
crates/cfd-1d/src/physics/resistance/models/entrance.rs
crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs
crates/cfd-1d/tests/adversarial_tests.rs
crates/cfd-1d/tests/blueprint_solve_trace.rs
crates/cfd-1d/tests/resistance_model_validation.rs
```

Refs: backlog.md#CFDRS-CFD1D-LINT-001

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR applies automated clippy lint fixes to the `crates/cfd-1d` codebase, reducing pedantic warnings from 54 to 8 (85% reduction). The changes are mechanical formatting improvements including inlining format arguments (e.g., `format!("x={}", x)` to `format!("x={x}")`), replacing `.map_or(false, |n| ...)` with `.is_some_and(|n| ...)`, removing unnecessary `.into()` conversions, and simplifying range checks. All 728 tests pass with no semantic changes to logic or behavior. The remaining 8 warnings are deferred as they require manual architectural decisions (error type redesign, type factoring, doc comment cleanup).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs` |
| 2 | `crates/cfd-1d/src/physics/droplet_regime.rs` |
| 3 | `crates/cfd-1d/tests/adversarial_tests.rs` |
| 4 | `crates/cfd-1d/tests/resistance_model_validation.rs` |
| 5 | `crates/cfd-1d/src/physics/resistance/models/entrance.rs` |
| 6 | `crates/cfd-1d/tests/blueprint_solve_trace.rs` |
| 7 | `crates/cfd-1d/src/physics/cell_separation/cascade_junction/cascade_routing.rs` |
| 8 | `crates/cfd-1d/src/physics/cell_separation/cascade_junction/mod.rs` |
| 9 | `crates/cfd-1d/src/physics/cell_separation/fahraeus_lindqvist.rs` |
| 10 | `crates/cfd-1d/src/physics/cell_separation/plasma_skimming.rs` |
| 11 | `crates/cfd-1d/src/physics/cell_separation/rouleaux_aggregation.rs` |
| 12 | `crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->