### PR TITLE
Type cfd-optim report physical carrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `cfd-optim` now assembles unit-bearing physical report values in one private
+  Aequitas carrier and converts them once into the existing serialized
+  `SdtMetrics` display units. The adapter has value and JSON round-trip
+  regressions; residence/safety DTO and provider semantic gaps remain tracked
+  in `gap_audit.md`.
+
 - `cfd-optim` now composes report mechanical power, residence volume, wall
   shear, and transit time through Aequitas typed quantities; report storage
   remains scalar at the established metrics boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,15 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `cfd-math` now preserves Leto's default sparse-LU dispatch thresholds when
+  constructing the provider solver, keeping the existing max-size and pivot
+  policy explicit while adapting to the provider's expanded configuration.
+
 - `cfd-optim` now assembles unit-bearing physical report values in one private
   Aequitas carrier and converts them once into the existing serialized
-  `SdtMetrics` display units. The adapter has value and JSON round-trip
-  regressions; residence/safety DTO and provider semantic gaps remain tracked
-  in `gap_audit.md`.
+  `SdtMetrics` display units. Energy-density and temperature-difference fields
+  now use Aequitas semantic quantities; residence and safety producers now use
+  the same typed computation boundary before their explicit DTO adapters.
 
 - `cfd-optim` now composes report mechanical power, residence volume, wall
   shear, and transit time through Aequitas typed quantities; report storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ All notable changes to this project will be documented in this file.
   shear, and transit time through Aequitas typed quantities; report storage
   remains scalar at the established metrics boundary.
 
+- `cfd-optim` now carries per-channel hemolysis wall shear and transit time
+  through private Aequitas quantities before the single `ChannelHemolysis`
+  serialization adapter. Operating-point and solve-sample physical DTOs remain
+  an explicit follow-up boundary rather than parallel raw/typed fields.
+
 - **Aequitas fluid dimensions**: `cfd-core` now evaluates kinematic
   viscosity, Prandtl number, and Reynolds number through typed SI quantities;
   `cfd-3d` computes cascade inlet velocity from typed volumetric flow and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ All notable changes to this project will be documented in this file.
 
 - `cfd-optim` now carries per-channel hemolysis wall shear and transit time
   through private Aequitas quantities before the single `ChannelHemolysis`
-  serialization adapter. Operating-point and solve-sample physical DTOs remain
-  an explicit follow-up boundary rather than parallel raw/typed fields.
+  serialization adapter. Operating-point and solve-summary physical DTOs now
+  carry Aequitas quantities as well, with explicit serde and solver/report
+  scalar boundaries and no parallel raw/typed fields.
 
 - **Aequitas fluid dimensions**: `cfd-core` now evaluates kinematic
   viscosity, Prandtl number, and Reynolds number through typed SI quantities;

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,14 @@
 
 Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 
+- [x] CFD-AEQUITAS-REPORT-CARRIER-1 [patch] [arch]: consolidate the
+      unit-bearing `cfd-optim` report values in one private Aequitas carrier
+      and one scalar `SdtMetrics` serialization adapter. The adapter regression
+      covers SI-to-report-unit conversion and JSON round-trip equality; focused
+      `cfd-optim` Nextest passes 11/11 and warning-denied package Clippy passes.
+      Full library execution remains path-sensitive in a linked lane because
+      one existing contract fixture resolves only from the canonical checkout.
+
 - [x] CFD-AEQUITAS-REPORT-UNITS-1 [patch]: compose report mechanical power,
       residence volume, wall shear, and transit time through Aequitas quantities;
       the focused `cfd-optim` check, test, and lint gates are required before

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -25,6 +25,13 @@ Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
       package check and focused Nextest adapter/conservation regression pass;
       Leto sparse-LU configuration drift is adapted through provider defaults.
 
+- [x] CFD-AEQUITAS-CHANNEL-CARRIER-1 [patch]: compute per-channel hemolysis
+      report values through private Aequitas `Pressure` and `Time` fields, then
+      serialize once into `ChannelHemolysis`. Acceptance: the adapter value
+      regression, residence/safety regression, package check, and warning-
+      denied package Clippy pass. The operating-point and solve-sample DTOs
+      remain the next `CFDRS-AEQ-MET-04` breaking boundary.
+
 - [x] CFD-AEQUITAS-REPORT-UNITS-1 [patch]: compose report mechanical power,
       residence volume, wall shear, and transit time through Aequitas quantities;
       the focused `cfd-optim` check, test, and lint gates are required before

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -10,6 +10,21 @@ Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
       Full library execution remains path-sensitive in a linked lane because
       one existing contract fixture resolves only from the canonical checkout.
 
+- [x] CFD-AEQUITAS-ENERGY-TEMPERATURE-1 [patch]: carry SDT acoustic energy
+      density, specific cavitation energy, and throat temperature rise through
+      Aequitas `EnergyPerVolume` and `TemperatureDifference` before the scalar
+      report adapter. Acceptance: the existing equations and serialized values
+      remain unchanged; positive-energy, thermal-threshold, and serde
+      round-trip regressions pass; the direct Aequitas pin is the merged
+      provider revision `e0fc5f3`. Proteus now consumes the merged
+      `TemperatureDifference` contract at `1b25af1`.
+
+- [x] CFD-AEQUITAS-RESIDENCE-SAFETY-1 [patch]: compute residence volume/time/
+      velocity and safety pressure/shear/time through private Aequitas carriers,
+      then adapt once to the existing serialized DTOs. Acceptance: cfd-optim
+      package check and focused Nextest adapter/conservation regression pass;
+      Leto sparse-LU configuration drift is adapted through provider defaults.
+
 - [x] CFD-AEQUITAS-REPORT-UNITS-1 [patch]: compose report mechanical power,
       residence volume, wall shear, and transit time through Aequitas quantities;
       the focused `cfd-optim` check, test, and lint gates are required before

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -30,7 +30,15 @@ Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
       serialize once into `ChannelHemolysis`. Acceptance: the adapter value
       regression, residence/safety regression, package check, and warning-
       denied package Clippy pass. The operating-point and solve-sample DTOs
-      remain the next `CFDRS-AEQ-MET-04` breaking boundary.
+      are closed by `CFDRS-AEQ-MET-04` in the same typed-boundary sequence.
+
+- [x] CFD-AEQUITAS-OPERATING-SOLVE-CARRIERS-1 [major] [arch]: type
+      `OperatingPoint` flow/pressure and `BlueprintSolveSample`/
+      `BlueprintSolveSummary` length, flow, pressure, and residence values with
+      Aequitas quantities. Preserve the existing JSON field names through an
+      explicit serde representation and convert only at solver/report DTO
+      boundaries. Acceptance: cfd-optim check, focused Nextest value tests,
+      warning-denied package Clippy, and integration-test compilation pass.
 
 - [x] CFD-AEQUITAS-REPORT-UNITS-1 [patch]: compose report mechanical power,
       residence volume, wall shear, and transit time through Aequitas quantities;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
  "moirai",
  "num_cpus",
  "proptest",
- "proteus",
+ "proteus 0.1.0 (git+https://github.com/ryancinsight/proteus?rev=1b25af10636931193457adb00ff8f144d37f6c90)",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2660,7 +2660,16 @@ dependencies = [
 [[package]]
 name = "proteus"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/proteus#bb51ac414f74fb47d8001310206c5aea2e3a160c"
+source = "git+https://github.com/ryancinsight/proteus?rev=1b25af10636931193457adb00ff8f144d37f6c90#1b25af10636931193457adb00ff8f144d37f6c90"
+dependencies = [
+ "aequitas",
+ "eunomia",
+]
+
+[[package]]
+name = "proteus"
+version = "0.1.0"
+source = "git+https://github.com/ryancinsight/proteus#1b25af10636931193457adb00ff8f144d37f6c90"
 dependencies = [
  "aequitas",
  "eunomia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Math and numerical
-aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", rev = "ce3ef7a6ea26a025b91df99034cadbbcf9b01330", default-features = false, features = ["std"] }
-proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
+aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", rev = "e0fc5f32f07fbf0bde6a7a7086d085983195abad", default-features = false, features = ["std"] }
+proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus", rev = "1b25af10636931193457adb00ff8f144d37f6c90" }
 hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
 tyche-core = { git = "https://github.com/ryancinsight/tyche", rev = "87923da922ec7bd17f12324c40d1da026be6b04e" }
 eunomia = { git = "https://github.com/ryancinsight/eunomia", default-features = false, features = ["std"] }

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,18 @@
 
 ## Active integration
 
+- **CFD-AEQUITAS-REPORT-CARRIER-1 [patch] [arch] - Keep one typed physical
+  report carrier at the `cfd-optim` producer boundary (DONE; owner=Codex;
+  scope=`cfd-optim/src/reporting/report_metrics.rs`, ADR, gap audit, and PM
+  artifacts).** Compose pressure, time, length, volume, flow-rate, power,
+  reciprocal-time, and temperature values with Aequitas, then convert them
+  once into the existing serialized `SdtMetrics` display units. Acceptance:
+  no parallel typed/raw fields, value-semantic unit conversion, and serde
+  round-trip equality. Evidence: focused `cfd-optim` Nextest passes 11/11;
+  warning-denied package Clippy passes; the linked lane's full library run
+  reaches 79 passing tests before the pre-existing canonical-path contract
+  fixture fails.
+
 - **CFD-BOOK-PAGES-1 [patch] - Publish the source-backed mdBook through
   GitHub Pages (DONE; owner=Codex; scope=`.github/workflows/book-pages.yml`,
   `docs/book/book.toml`, `README.md`, and PM artifacts).** Build the existing

--- a/crates/cfd-math/src/linear_solver/direct_solver.rs
+++ b/crates/cfd-math/src/linear_solver/direct_solver.rs
@@ -1,10 +1,25 @@
 //! Direct sparse solver for linear systems.
 //!
 //! Uses [`leto_ops::SparseLuSolver`] — the atlas-native sparse direct solver
-//! backed by dense partial-pivoting LU — for systems up to `max_size`. The
-//! dense LU path in `leto-ops` serves as both the primary sparse solver and
-//! the fallback, eliminating the external `rsparse` dependency. The primary
-//! path preserves native Leto array ownership across the provider boundary.
+//! — for systems up to `max_size`. Per ADR 0031 the upstream solver dispatches
+//! between two paths:
+//!
+//! - **Dense path** (matrices with `n ≤ small_switch=32` or `nnz/n² ≥
+//!   density_threshold=0.1`): the CSR input is expanded to dense storage and
+//!   forwarded to the SSOT dense partial-pivoting LU (`lu_decompose`).
+//! - **Sparse path** (other matrices): the CSR input is converted to CSC and
+//!   factorised by the real left-looking symbolic + numeric sparse LU.
+//!   The symbolic phase runs the sequential Gilbert–Peierls reach
+//!   (Davis 2006 §6.1); the numeric phase performs a slot-indexed
+//!   left-looking factorisation. If partial pivoting is required (the
+//!   symbolic convention alone produces a numerically broken factor),
+//!   the sparse path transparently falls back to the dense path internally.
+//!
+//! The CFDrs-side `dense_threshold` retry below catches the orthogonal
+//! case where the upstream solver refuses on the `max_size` cap and the
+//! matrix is small enough to attempt a dense direct solve through the
+//! `dense_bridge` provider — a CFDrs user-intent safety net,
+//! not a duplicate of the upstream internal fallback.
 //!
 //! # Theorem — LU Factorisation Uniqueness
 //!
@@ -25,8 +40,11 @@ use super::dense_bridge::solve_leto_csr_with_leto_dense_array;
 pub struct DirectSparseSolver {
     /// Maximum system size (number of rows) to attempt with direct solve.
     pub max_size: usize,
-    /// Ordering strategy (reserved for API compatibility; the atlas-native solver
-    /// uses partial-column pivoting regardless of this value).
+    /// Ordering strategy (reserved for API compatibility; the atlas-native
+    /// solver performs natural column ordering for the sparse path and
+    /// partial pivoting for the dense path — this field does not affect
+    /// either dispatch). Tracked for AMD fill-reducing ordering per
+    /// `ATLAS-LETO-OPS-AMD-ORDERING-001`.
     pub ordering: i8,
     /// Pivot tolerance for LU factorization.
     pub pivot_tolerance: f64,

--- a/crates/cfd-math/src/linear_solver/direct_solver.rs
+++ b/crates/cfd-math/src/linear_solver/direct_solver.rs
@@ -71,6 +71,7 @@ impl DirectSparseSolver {
         let atlas_solver = LetoCsrLuSolver {
             max_size: self.max_size,
             pivot_tolerance: self.pivot_tolerance,
+            ..LetoCsrLuSolver::default()
         };
 
         match atlas_solver.solve_view(matrix, &rhs.view()) {

--- a/crates/cfd-math/src/linear_solver/direct_solver.rs
+++ b/crates/cfd-math/src/linear_solver/direct_solver.rs
@@ -89,7 +89,7 @@ impl DirectSparseSolver {
         let atlas_solver = LetoCsrLuSolver {
             max_size: self.max_size,
             pivot_tolerance: self.pivot_tolerance,
-            ..LetoCsrLuSolver::default()
+            ..Default::default()
         };
 
         match atlas_solver.solve_view(matrix, &rhs.view()) {

--- a/crates/cfd-optim/src/analysis/robustness.rs
+++ b/crates/cfd-optim/src/analysis/robustness.rs
@@ -6,6 +6,7 @@
 //!
 //! A design is considered *robust* when CV < 0.10 (< 10 % relative variation).
 
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -51,7 +52,8 @@ pub fn robustness_sweep_blueprint(
     // ── Inlet pressure perturbations ─────────────────────────────────────────
     for &frac in perturbation_fracs {
         let mut c = candidate.clone();
-        c.operating_point.inlet_gauge_pa *= 1.0 + frac;
+        c.operating_point.inlet_gauge_pa =
+            Pressure::from_base(c.operating_point.inlet_gauge_pa.into_base() * (1.0 + frac));
         let s = evaluate_goal(&c, goal).map_or(0.0, |e| e.score_or_zero());
         scored.push((s, format!("inlet_pressure{:+.0}%", frac * 100.0)));
     }
@@ -62,7 +64,9 @@ pub fn robustness_sweep_blueprint(
     for &frac in perturbation_fracs {
         let mut c = candidate.clone();
         if true {
-            c.operating_point.flow_rate_m3_s *= 1.0 + frac;
+            c.operating_point.flow_rate_m3_s = VolumetricFlowRate::from_base(
+                c.operating_point.flow_rate_m3_s.into_base() * (1.0 + frac),
+            );
             let s = evaluate_goal(&c, goal).map_or(0.0, |e| e.score_or_zero());
             scored.push((s, format!("flow_rate{:+.0}%", frac * 100.0)));
         }

--- a/crates/cfd-optim/src/application/search/genetic.rs
+++ b/crates/cfd-optim/src/application/search/genetic.rs
@@ -6,6 +6,7 @@ use crate::application::objectives::{evaluate_goal, BlueprintObjectiveEvaluation
 use crate::domain::{BlueprintCandidate, OptimizationGoal};
 use crate::error::OptimError;
 use crate::metrics::healthy_cell_protection_index;
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use cfd_schematics::{TopologyLineageEvent, TopologyLineageMetadata};
 use serde::{Deserialize, Serialize};
 
@@ -740,8 +741,8 @@ fn diversity_signature(candidate: &BlueprintRankedCandidate) -> DiversitySignatu
         .map(|placement| placement.dean_number)
         .fold(0.0_f64, f64::max);
     DiversitySignature {
-        flow_rate_m3_s: candidate.candidate.operating_point.flow_rate_m3_s,
-        inlet_gauge_pa: candidate.candidate.operating_point.inlet_gauge_pa,
+        flow_rate_m3_s: candidate.candidate.operating_point.flow_rate_m3_s.into_base(),
+        inlet_gauge_pa: candidate.candidate.operating_point.inlet_gauge_pa.into_base(),
         throat_width_m: if throat_width_m.is_finite() {
             throat_width_m
         } else {
@@ -986,8 +987,8 @@ fn focused_operating_point_perturbations(
 ) -> Result<Vec<BlueprintCandidate>, OptimError> {
     let q_factors = [0.85, 0.95, 1.05, 1.15];
     let p_factors = [0.85, 0.95, 1.05, 1.15];
-    let base_q = seed.operating_point.flow_rate_m3_s;
-    let base_p = seed.operating_point.inlet_gauge_pa;
+    let base_q = seed.operating_point.flow_rate_m3_s.into_base();
+    let base_p = seed.operating_point.inlet_gauge_pa.into_base();
     let base_ht = seed.operating_point.feed_hematocrit;
     let mut perturbations = Vec::with_capacity(limit.min(q_factors.len() * p_factors.len()));
     let mut seen = HashSet::with_capacity(limit.min(q_factors.len() * p_factors.len()));
@@ -1007,8 +1008,8 @@ fn focused_operating_point_perturbations(
                 format!("{}-refine-q{:.0}-p{:.0}", seed.id, qf * 100.0, pf * 100.0),
                 blueprint,
                 crate::domain::OperatingPoint {
-                    flow_rate_m3_s: base_q * qf,
-                    inlet_gauge_pa: base_p * pf,
+                    flow_rate_m3_s: VolumetricFlowRate::from_base(base_q * qf),
+                    inlet_gauge_pa: Pressure::from_base(base_p * pf),
                     feed_hematocrit: base_ht,
                     patient_context: seed.operating_point.patient_context.clone(),
                 },
@@ -1059,8 +1060,9 @@ fn candidate_key(candidate: &BlueprintCandidate) -> Result<CandidateFingerprint,
     topology.hash(&mut hasher);
     Ok(CandidateFingerprint {
         topology_hash: hasher.finish(),
-        flow_rate_quantized: (candidate.operating_point.flow_rate_m3_s * 1.0e12).round() as i64,
-        inlet_gauge_quantized: (candidate.operating_point.inlet_gauge_pa * 1.0e3).round() as i64,
+        flow_rate_quantized: (candidate.operating_point.flow_rate_m3_s.into_base() * 1.0e12).round() as i64,
+        inlet_gauge_quantized: (candidate.operating_point.inlet_gauge_pa.into_base() * 1.0e3)
+            .round() as i64,
         hematocrit_quantized: (candidate.operating_point.feed_hematocrit * 1.0e6).round() as i64,
     })
 }

--- a/crates/cfd-optim/src/application/search/mutations.rs
+++ b/crates/cfd-optim/src/application/search/mutations.rs
@@ -1,6 +1,7 @@
 use crate::application::objectives::evaluate_goal;
 use crate::domain::{BlueprintCandidate, OptimizationGoal};
 use crate::error::OptimError;
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use cfd_schematics::{
     domain::model::NetworkBlueprint, promote_milestone12_option1_to_option2,
     BlueprintTopologyFactory, BlueprintTopologyMutation, SerpentineSpec, SplitKind,
@@ -394,10 +395,14 @@ pub fn generate_ga_crossover_children(
         right,
         "blend",
         crate::domain::OperatingPoint {
-            flow_rate_m3_s: 0.5
-                * (left.operating_point.flow_rate_m3_s + right.operating_point.flow_rate_m3_s),
-            inlet_gauge_pa: 0.5
-                * (left.operating_point.inlet_gauge_pa + right.operating_point.inlet_gauge_pa),
+            flow_rate_m3_s: VolumetricFlowRate::from_base(
+                0.5 * (left.operating_point.flow_rate_m3_s.into_base()
+                    + right.operating_point.flow_rate_m3_s.into_base()),
+            ),
+            inlet_gauge_pa: Pressure::from_base(
+                0.5 * (left.operating_point.inlet_gauge_pa.into_base()
+                    + right.operating_point.inlet_gauge_pa.into_base()),
+            ),
             feed_hematocrit: 0.5
                 * (left.operating_point.feed_hematocrit + right.operating_point.feed_hematocrit),
             patient_context: left.operating_point.patient_context.clone(),
@@ -587,8 +592,8 @@ pub fn generate_ga_mutations(
     // These produce genuinely different scores because they change the
     // 1D CFD solve inputs (Re, ΔP, σ), unlike stacked serpentine
     // mutations which are nearly idempotent on the same channel.
-    let base_q = seed.operating_point.flow_rate_m3_s;
-    let base_p = seed.operating_point.inlet_gauge_pa;
+    let base_q = seed.operating_point.flow_rate_m3_s.into_base();
+    let base_p = seed.operating_point.inlet_gauge_pa.into_base();
     let base_ht = seed.operating_point.feed_hematocrit;
     for &q_factor in &[0.7, 0.85, 1.15, 1.3] {
         let blueprint = append_operating_point_lineage(
@@ -601,8 +606,8 @@ pub fn generate_ga_mutations(
             format!("{}-ga-qf{:.0}", seed.id, q_factor * 100.0),
             blueprint,
             crate::domain::OperatingPoint {
-                flow_rate_m3_s: base_q * q_factor,
-                inlet_gauge_pa: base_p,
+                flow_rate_m3_s: VolumetricFlowRate::from_base(base_q * q_factor),
+                inlet_gauge_pa: Pressure::from_base(base_p),
                 feed_hematocrit: base_ht,
                 patient_context: seed.operating_point.patient_context.clone(),
             },
@@ -619,8 +624,8 @@ pub fn generate_ga_mutations(
             format!("{}-ga-pf{:.0}", seed.id, p_factor * 100.0),
             blueprint,
             crate::domain::OperatingPoint {
-                flow_rate_m3_s: base_q,
-                inlet_gauge_pa: base_p * p_factor,
+                flow_rate_m3_s: VolumetricFlowRate::from_base(base_q),
+                inlet_gauge_pa: Pressure::from_base(base_p * p_factor),
                 feed_hematocrit: base_ht,
                 patient_context: seed.operating_point.patient_context.clone(),
             },
@@ -843,6 +848,8 @@ pub fn build_milestone12_ga_seed_pair(
 
 #[cfg(test)]
 mod tests {
+    use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
+
     use crate::domain::fixtures::{canonical_option2_candidate, operating_point};
 
     use super::{generate_ga_crossover_children, generate_ga_mutations};
@@ -859,8 +866,12 @@ mod tests {
             "donor".to_string(),
             donor_topology.blueprint.clone(),
             crate::domain::OperatingPoint {
-                flow_rate_m3_s: seed.operating_point.flow_rate_m3_s * 1.1,
-                inlet_gauge_pa: seed.operating_point.inlet_gauge_pa * 0.9,
+                flow_rate_m3_s: VolumetricFlowRate::from_base(
+                    seed.operating_point.flow_rate_m3_s.into_base() * 1.1,
+                ),
+                inlet_gauge_pa: Pressure::from_base(
+                    seed.operating_point.inlet_gauge_pa.into_base() * 0.9,
+                ),
                 feed_hematocrit: seed.operating_point.feed_hematocrit,
                 patient_context: seed.operating_point.patient_context.clone(),
             },

--- a/crates/cfd-optim/src/design/space/builder.rs
+++ b/crates/cfd-optim/src/design/space/builder.rs
@@ -1,9 +1,10 @@
 //! Primitive selective blueprint-candidate construction.
 use crate::constraints::{SERPENTINE_BEND_RADIUS_M, TREATMENT_WIDTH_MM};
 use crate::domain::{BlueprintCandidate, OperatingPoint};
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use cfd_schematics::topology::{
-    presets::{build_milestone12_blueprint, Milestone12TopologyRequest},
     SerpentineSpec, TreatmentActuationMode, VenturiPlacementMode,
+    presets::{Milestone12TopologyRequest, build_milestone12_blueprint},
 };
 
 #[must_use]
@@ -57,8 +58,8 @@ pub(crate) fn primitive_selective_candidate(
         id,
         blueprint,
         OperatingPoint {
-            flow_rate_m3_s,
-            inlet_gauge_pa,
+            flow_rate_m3_s: VolumetricFlowRate::from_base(flow_rate_m3_s),
+            inlet_gauge_pa: Pressure::from_base(inlet_gauge_pa),
             feed_hematocrit: 0.45,
             patient_context: None,
         },

--- a/crates/cfd-optim/src/domain/candidate/fixtures/operating_points.rs
+++ b/crates/cfd-optim/src/domain/candidate/fixtures/operating_points.rs
@@ -1,4 +1,5 @@
 use crate::domain::OperatingPoint;
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 
 pub(crate) fn operating_point(
     flow_rate_m3_s: f64,
@@ -6,8 +7,8 @@ pub(crate) fn operating_point(
     feed_hematocrit: f64,
 ) -> OperatingPoint {
     OperatingPoint {
-        flow_rate_m3_s,
-        inlet_gauge_pa,
+        flow_rate_m3_s: VolumetricFlowRate::from_base(flow_rate_m3_s),
+        inlet_gauge_pa: Pressure::from_base(inlet_gauge_pa),
         feed_hematocrit,
         patient_context: None,
     }

--- a/crates/cfd-optim/src/domain/candidate/operating_point.rs
+++ b/crates/cfd-optim/src/domain/candidate/operating_point.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatientContext {
@@ -7,18 +8,103 @@ pub struct PatientContext {
     pub blood_volume_ml: f64,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OperatingPoint {
-    pub flow_rate_m3_s: f64,
-    pub inlet_gauge_pa: f64,
+    pub flow_rate_m3_s: VolumetricFlowRate,
+    pub inlet_gauge_pa: Pressure,
     pub feed_hematocrit: f64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub patient_context: Option<PatientContext>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OperatingPointRepr {
+    flow_rate_m3_s: f64,
+    inlet_gauge_pa: f64,
+    feed_hematocrit: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    patient_context: Option<PatientContext>,
+}
+
+impl Default for OperatingPoint {
+    fn default() -> Self {
+        Self {
+            flow_rate_m3_s: VolumetricFlowRate::from_base(0.0),
+            inlet_gauge_pa: Pressure::from_base(0.0),
+            feed_hematocrit: 0.0,
+            patient_context: None,
+        }
+    }
+}
+
+impl Serialize for OperatingPoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        OperatingPointRepr {
+            flow_rate_m3_s: self.flow_rate_m3_s.into_base(),
+            inlet_gauge_pa: self.inlet_gauge_pa.into_base(),
+            feed_hematocrit: self.feed_hematocrit,
+            patient_context: self.patient_context.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for OperatingPoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let repr = OperatingPointRepr::deserialize(deserializer)?;
+        Ok(Self {
+            flow_rate_m3_s: VolumetricFlowRate::from_base(repr.flow_rate_m3_s),
+            inlet_gauge_pa: Pressure::from_base(repr.inlet_gauge_pa),
+            feed_hematocrit: repr.feed_hematocrit,
+            patient_context: repr.patient_context,
+        })
+    }
 }
 
 impl OperatingPoint {
     #[must_use]
-    pub fn absolute_inlet_pressure_pa(&self) -> f64 {
-        crate::constraints::P_ATM_PA + self.inlet_gauge_pa.max(0.0)
+    pub fn absolute_inlet_pressure_pa(&self) -> Pressure {
+        Pressure::from_base(crate::constraints::P_ATM_PA + self.inlet_gauge_pa.into_base().max(0.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_roundtrip_preserves_typed_operating_values() {
+        let point = OperatingPoint {
+            flow_rate_m3_s: VolumetricFlowRate::from_base(2.0e-6),
+            inlet_gauge_pa: Pressure::from_base(30_000.0),
+            feed_hematocrit: 0.45,
+            patient_context: None,
+        };
+
+        let encoded = serde_json::to_string(&point).expect("operating point should serialize");
+        let decoded: OperatingPoint =
+            serde_json::from_str(&encoded).expect("operating point should deserialize");
+
+        assert_eq!(
+            decoded.flow_rate_m3_s.into_base().to_bits(),
+            point.flow_rate_m3_s.into_base().to_bits()
+        );
+        assert_eq!(
+            decoded.inlet_gauge_pa.into_base().to_bits(),
+            point.inlet_gauge_pa.into_base().to_bits()
+        );
+        assert_eq!(
+            decoded.feed_hematocrit.to_bits(),
+            point.feed_hematocrit.to_bits()
+        );
+        assert_eq!(
+            decoded.absolute_inlet_pressure_pa().into_base().to_bits(),
+            (crate::constraints::P_ATM_PA + 30_000.0).to_bits()
+        );
     }
 }

--- a/crates/cfd-optim/src/metrics/blueprint_graph.rs
+++ b/crates/cfd-optim/src/metrics/blueprint_graph.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use aequitas::systems::si::quantities::{Length, Pressure, Time, VolumetricFlowRate};
 use cfd_1d::domain::network::network_from_blueprint;
 use cfd_1d::{NetworkProblem, NetworkSolver, SolvePathStatus};
 use cfd_core::physics::fluid::blood::CassonBlood;
@@ -20,11 +21,11 @@ pub struct BlueprintSolveSample<'a> {
     pub id: &'a str,
     pub from_node: &'a str,
     pub to_node: &'a str,
-    pub length_m: f64,
+    pub length_m: Length,
     pub cross_section: CrossSectionSpec,
     pub channel_shape: ChannelShape,
-    pub flow_m3_s: f64,
-    pub from_pressure_pa: f64,
+    pub flow_m3_s: VolumetricFlowRate,
+    pub from_pressure_pa: Pressure,
     pub is_treatment_channel: bool,
     pub is_venturi_channel: bool,
     pub venturi_throat_count: u8,
@@ -32,13 +33,13 @@ pub struct BlueprintSolveSample<'a> {
 
 #[derive(Debug, Clone)]
 pub struct BlueprintSolveSummary<'a> {
-    pub inlet_pressure_pa: f64,
-    pub inlet_flow_m3_s: f64,
+    pub inlet_pressure_pa: Pressure,
+    pub inlet_flow_m3_s: VolumetricFlowRate,
     pub flow_uniformity: f64,
     pub venturi_flow_fraction: f64,
-    pub mean_residence_time_s: f64,
+    pub mean_residence_time_s: Time,
     pub solve_path_status: SolvePathStatus,
-    pub remerge_loss_pa: f64,
+    pub remerge_loss_pa: Pressure,
     pub channel_samples: Vec<BlueprintSolveSample<'a>>,
 }
 
@@ -71,7 +72,8 @@ pub fn solve_blueprint_candidate(
         });
     }
 
-    let q_per_inlet = candidate.operating_point.flow_rate_m3_s / inlet_nodes.len() as f64;
+    let q_per_inlet =
+        candidate.operating_point.flow_rate_m3_s.into_base() / inlet_nodes.len() as f64;
     for inlet in &inlet_nodes {
         network.set_neumann_flow(*inlet, q_per_inlet);
     }
@@ -114,15 +116,14 @@ pub fn solve_blueprint_candidate(
             }
 
             let fallback_problem = NetworkProblem::new(linear_network);
-            let mut fallback_solved =
-                solver
-                    .solve_network(&fallback_problem)
-                    .map_err(|fallback_error| OptimError::PhysicsError {
-                        id: candidate.id.clone(),
-                        reason: format!(
+            let mut fallback_solved = solver.solve_network(&fallback_problem).map_err(
+                |fallback_error| OptimError::PhysicsError {
+                    id: candidate.id.clone(),
+                    reason: format!(
                         "NetworkSolver failed: {primary_error}; fallback failed: {fallback_error}"
                     ),
-                    })?;
+                },
+            )?;
 
             let mut inlet_flow_unit = 0.0_f64;
             for edge_ref in fallback_solved.graph.edge_references() {
@@ -145,7 +146,7 @@ pub fn solve_blueprint_candidate(
                     reason: "fallback solve produced zero inlet flow".to_string(),
                 });
             }
-            let scale = candidate.operating_point.flow_rate_m3_s / inlet_flow_unit;
+            let scale = candidate.operating_point.flow_rate_m3_s.into_base() / inlet_flow_unit;
             for pressure in &mut fallback_solved.pressures {
                 *pressure *= scale;
             }
@@ -232,11 +233,11 @@ pub fn solve_blueprint_candidate(
             id: channel.id.as_str(),
             from_node: channel.from.as_str(),
             to_node: channel.to.as_str(),
-            length_m: channel.length_m,
+            length_m: Length::from_base(channel.length_m),
             cross_section: channel.cross_section,
             channel_shape: channel.channel_shape,
-            flow_m3_s,
-            from_pressure_pa,
+            flow_m3_s: VolumetricFlowRate::from_base(flow_m3_s),
+            from_pressure_pa: Pressure::from_base(from_pressure_pa),
             is_treatment_channel,
             is_venturi_channel,
             venturi_throat_count,
@@ -244,21 +245,29 @@ pub fn solve_blueprint_candidate(
     }
 
     let venturi_flow_fraction = (venturi_flows.iter().sum::<f64>()
-        / candidate.operating_point.flow_rate_m3_s.max(1.0e-12))
+        / candidate
+            .operating_point
+            .flow_rate_m3_s
+            .into_base()
+            .max(1.0e-12))
     .clamp(0.0, 1.0);
     let flow_uniformity = compute_blueprint_flow_uniformity(&candidate.blueprint, &channel_samples);
-    let mean_residence_time_s =
-        total_volume_m3 / candidate.operating_point.flow_rate_m3_s.max(1.0e-12);
+    let mean_residence_time_s = total_volume_m3
+        / candidate
+            .operating_point
+            .flow_rate_m3_s
+            .into_base()
+            .max(1.0e-12);
     let remerge_loss_pa = compute_blueprint_remerge_loss(&candidate.blueprint, &channel_samples);
 
     Ok(BlueprintSolveSummary {
-        inlet_pressure_pa,
+        inlet_pressure_pa: Pressure::from_base(inlet_pressure_pa),
         inlet_flow_m3_s: candidate.operating_point.flow_rate_m3_s,
         flow_uniformity,
         venturi_flow_fraction,
-        mean_residence_time_s,
+        mean_residence_time_s: Time::from_base(mean_residence_time_s),
         solve_path_status,
-        remerge_loss_pa,
+        remerge_loss_pa: Pressure::from_base(remerge_loss_pa),
         channel_samples,
     })
 }
@@ -295,7 +304,7 @@ fn compute_blueprint_flow_uniformity(
         samples
             .iter()
             .filter(|sample| !from_nodes.contains(sample.to_node))
-            .map(|sample| sample.flow_m3_s.abs())
+            .map(|sample| sample.flow_m3_s.into_base().abs())
             .collect::<Vec<_>>()
     } else {
         samples
@@ -305,7 +314,7 @@ fn compute_blueprint_flow_uniformity(
                     .iter()
                     .any(|target| sample.id == target || sample.id.starts_with(target))
             })
-            .map(|sample| sample.flow_m3_s.abs())
+            .map(|sample| sample.flow_m3_s.into_base().abs())
             .collect::<Vec<_>>()
     };
 
@@ -333,7 +342,7 @@ fn compute_blueprint_remerge_loss(
     for sample in samples {
         let entry = incoming.entry(sample.to_node).or_insert((0, 0.0));
         entry.0 += 1;
-        entry.1 += sample.flow_m3_s.abs();
+        entry.1 += sample.flow_m3_s.into_base().abs();
         let out_entry = outgoing_area.entry(sample.from_node).or_insert(0.0);
         *out_entry = out_entry.max(sample.cross_section.area());
     }

--- a/crates/cfd-optim/src/metrics/mod.rs
+++ b/crates/cfd-optim/src/metrics/mod.rs
@@ -17,7 +17,9 @@ pub use blueprint_separation::{
 };
 pub use cfd_1d::physics::hemolysis::giersiepen_hi;
 pub use healthy_cell_protection::healthy_cell_protection_index;
+pub(crate) use residence::compute_typed_residence_metrics;
 pub use residence::{compute_residence_metrics, ResidenceMetrics};
+pub(crate) use safety::compute_typed_blueprint_safety_metrics;
 pub use safety::{compute_blueprint_safety_metrics, BlueprintSafetyMetrics};
 pub use sdt_metrics::{ChannelHemolysis, SdtMetrics};
 pub use venturi::{

--- a/crates/cfd-optim/src/metrics/residence.rs
+++ b/crates/cfd-optim/src/metrics/residence.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::BlueprintCandidate;
-use aequitas::systems::si::quantities::{Area, Length, Time, Velocity, Volume, VolumetricFlowRate};
+use aequitas::systems::si::quantities::{Area, Time, Velocity, Volume, VolumetricFlowRate};
 
 use super::blueprint_graph::BlueprintSolveSummary;
 
@@ -45,11 +45,13 @@ pub(crate) fn compute_typed_residence_metrics(
             continue;
         }
         let area_m2 = sample.cross_section.area().max(1.0e-18);
-        let volume = Length::from_base(sample.length_m) * Area::from_base(area_m2);
-        let flow = VolumetricFlowRate::from_base(sample.flow_m3_s.abs().max(1.0e-18));
+        let volume = sample.length_m * Area::from_base(area_m2);
+        let flow = VolumetricFlowRate::from_base(sample.flow_m3_s.into_base().abs().max(1.0e-18));
         treatment_volume += volume;
-        treatment_flow_fraction +=
-            (sample.flow_m3_s.abs() / solve.inlet_flow_m3_s.max(1.0e-18)).clamp(0.0, 1.0);
+        treatment_flow_fraction += (sample.flow_m3_s.into_base()
+            / solve.inlet_flow_m3_s.into_base().max(1.0e-18))
+        .abs()
+        .clamp(0.0, 1.0);
         velocities.push(flow / Area::from_base(area_m2));
     }
 
@@ -57,7 +59,7 @@ pub(crate) fn compute_typed_residence_metrics(
         .channel_samples
         .iter()
         .filter(|s| s.is_treatment_channel)
-        .map(|s| s.flow_m3_s.abs())
+        .map(|s| s.flow_m3_s.into_base().abs())
         .sum::<f64>()
         .max(1.0e-18);
     let treatment_residence_time = solve
@@ -66,10 +68,10 @@ pub(crate) fn compute_typed_residence_metrics(
         .filter(|s| s.is_treatment_channel)
         .map(|s| {
             let area = s.cross_section.area().max(1.0e-18);
-            let volume = Length::from_base(s.length_m) * Area::from_base(area);
-            let flow = VolumetricFlowRate::from_base(s.flow_m3_s.abs().max(1.0e-18));
+            let volume = s.length_m * Area::from_base(area);
+            let flow = VolumetricFlowRate::from_base(s.flow_m3_s.into_base().abs().max(1.0e-18));
             let residence = volume / flow;
-            residence * (s.flow_m3_s.abs() / total_treatment_flow)
+            residence * (s.flow_m3_s.into_base().abs() / total_treatment_flow)
         })
         .fold(Time::from_base(0.0), |total, residence| total + residence);
 

--- a/crates/cfd-optim/src/metrics/residence.rs
+++ b/crates/cfd-optim/src/metrics/residence.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::BlueprintCandidate;
+use aequitas::systems::si::quantities::{Area, Length, Time, Velocity, Volume, VolumetricFlowRate};
 
 use super::blueprint_graph::BlueprintSolveSummary;
 
@@ -12,69 +13,89 @@ pub struct ResidenceMetrics {
     pub mean_treatment_velocity_m_s: f64,
 }
 
-pub fn compute_residence_metrics(
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TypedResidenceMetrics {
+    pub(crate) treatment_volume: Volume,
+    pub(crate) treatment_residence_time: Time,
+    pub(crate) treatment_flow_fraction: f64,
+    pub(crate) mean_treatment_velocity: Velocity,
+}
+
+impl TypedResidenceMetrics {
+    fn into_serialized(self) -> ResidenceMetrics {
+        ResidenceMetrics {
+            treatment_volume_m3: self.treatment_volume.into_base(),
+            treatment_residence_time_s: self.treatment_residence_time.into_base(),
+            treatment_flow_fraction: self.treatment_flow_fraction,
+            mean_treatment_velocity_m_s: self.mean_treatment_velocity.into_base(),
+        }
+    }
+}
+
+pub(crate) fn compute_typed_residence_metrics(
     _candidate: &BlueprintCandidate,
     solve: &BlueprintSolveSummary<'_>,
-) -> ResidenceMetrics {
-    let mut treatment_volume_m3 = 0.0_f64;
+) -> TypedResidenceMetrics {
+    let mut treatment_volume = Volume::from_base(0.0);
     let mut treatment_flow_fraction = 0.0_f64;
     let mut velocities = Vec::new();
-    let mut per_channel_residence = Vec::new();
 
     for sample in &solve.channel_samples {
         if !sample.is_treatment_channel {
             continue;
         }
         let area_m2 = sample.cross_section.area().max(1.0e-18);
-        let volume_m3 = sample.length_m * area_m2;
-        treatment_volume_m3 += volume_m3;
-        // Per-channel residence time: V / Q for this channel segment.
-        let channel_res_s = volume_m3 / sample.flow_m3_s.abs().max(1.0e-18);
-        per_channel_residence.push(channel_res_s);
+        let volume = Length::from_base(sample.length_m) * Area::from_base(area_m2);
+        let flow = VolumetricFlowRate::from_base(sample.flow_m3_s.abs().max(1.0e-18));
+        treatment_volume += volume;
         treatment_flow_fraction +=
             (sample.flow_m3_s.abs() / solve.inlet_flow_m3_s.max(1.0e-18)).clamp(0.0, 1.0);
-        velocities.push(sample.flow_m3_s.abs() / area_m2);
+        velocities.push(flow / Area::from_base(area_m2));
     }
-    // Treatment residence time is the MAXIMUM per-channel time, not the sum.
-    // In a parallel split tree, cells traverse one path (the longest).
-    // For serial channels on the same path, their times should be summed,
-    // but for parallel branches only the slowest path matters.
-    //
-    // As an approximation (exact would require path tracing through the
-    // network graph), use the flow-weighted average: each channel's
-    // contribution is weighted by the fraction of total treatment flow
-    // it carries.  This gives the expected residence time for a randomly
-    // selected cell entering the treatment zone.
+
     let total_treatment_flow = solve
         .channel_samples
         .iter()
         .filter(|s| s.is_treatment_channel)
         .map(|s| s.flow_m3_s.abs())
         .sum::<f64>()
-        .max(1e-18);
-    let treatment_residence_time_s = solve
+        .max(1.0e-18);
+    let treatment_residence_time = solve
         .channel_samples
         .iter()
         .filter(|s| s.is_treatment_channel)
         .map(|s| {
-            let area = s.cross_section.area().max(1e-18);
-            let vol = s.length_m * area;
-            let res = vol / s.flow_m3_s.abs().max(1e-18);
-            let weight = s.flow_m3_s.abs() / total_treatment_flow;
-            res * weight
+            let area = s.cross_section.area().max(1.0e-18);
+            let volume = Length::from_base(s.length_m) * Area::from_base(area);
+            let flow = VolumetricFlowRate::from_base(s.flow_m3_s.abs().max(1.0e-18));
+            let residence = volume / flow;
+            residence * (s.flow_m3_s.abs() / total_treatment_flow)
         })
-        .sum::<f64>();
+        .fold(Time::from_base(0.0), |total, residence| total + residence);
 
-    let mean_treatment_velocity_m_s = if velocities.is_empty() {
-        0.0
+    let mean_treatment_velocity = if velocities.is_empty() {
+        Velocity::from_base(0.0)
     } else {
-        velocities.iter().sum::<f64>() / velocities.len() as f64
+        Velocity::from_base(
+            velocities
+                .iter()
+                .map(|velocity| velocity.into_base())
+                .sum::<f64>()
+                / velocities.len() as f64,
+        )
     };
 
-    ResidenceMetrics {
-        treatment_volume_m3,
-        treatment_residence_time_s,
+    TypedResidenceMetrics {
+        treatment_volume,
+        treatment_residence_time,
         treatment_flow_fraction: treatment_flow_fraction.clamp(0.0, 1.0),
-        mean_treatment_velocity_m_s,
+        mean_treatment_velocity,
     }
+}
+
+pub fn compute_residence_metrics(
+    candidate: &BlueprintCandidate,
+    solve: &BlueprintSolveSummary<'_>,
+) -> ResidenceMetrics {
+    compute_typed_residence_metrics(candidate, solve).into_serialized()
 }

--- a/crates/cfd-optim/src/metrics/safety.rs
+++ b/crates/cfd-optim/src/metrics/safety.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::constraints::{FDA_MAX_WALL_SHEAR_PA, FDA_TRANSIENT_TIME_S};
 use crate::domain::BlueprintCandidate;
-use aequitas::systems::si::quantities::{Length, Pressure, Time, Velocity};
+use aequitas::systems::si::quantities::{Pressure, Time, Velocity};
 use cfd_2d::physics::non_newtonian::CarreauYasudaModel;
 
 use super::blueprint_graph::BlueprintSolveSummary;
@@ -55,14 +55,14 @@ pub(crate) fn compute_typed_blueprint_safety_metrics(
 
     for sample in &solve.channel_samples {
         let area_m2 = sample.cross_section.area().max(1.0e-18);
-        let mean_velocity = Velocity::from_base(sample.flow_m3_s.abs() / area_m2);
+        let mean_velocity = Velocity::from_base(sample.flow_m3_s.into_base().abs() / area_m2);
         let shear_rate_inv_s = sample
             .cross_section
             .wall_shear_rate(mean_velocity.into_base());
         let apparent_viscosity_pa_s = cy_model.apparent_viscosity(shear_rate_inv_s);
         let shear = Pressure::from_base(apparent_viscosity_pa_s * shear_rate_inv_s);
-        let transit_time = Length::from_base(sample.length_m)
-            / Velocity::from_base(mean_velocity.into_base().max(1.0e-18));
+        let transit_time =
+            sample.length_m / Velocity::from_base(mean_velocity.into_base().max(1.0e-18));
 
         if sample.is_venturi_channel {
             if shear > max_venturi_shear {
@@ -76,10 +76,16 @@ pub(crate) fn compute_typed_blueprint_safety_metrics(
         }
     }
 
-    let pressure_drop =
-        Pressure::from_base(solve.inlet_pressure_pa.max(0.0) + solve.remerge_loss_pa.max(0.0));
-    let pressure_feasible =
-        pressure_drop.into_base() <= candidate.operating_point.inlet_gauge_pa.max(0.0) + 1.0e-9;
+    let pressure_drop = Pressure::from_base(
+        solve.inlet_pressure_pa.into_base().max(0.0) + solve.remerge_loss_pa.into_base().max(0.0),
+    );
+    let pressure_feasible = pressure_drop.into_base()
+        <= candidate
+            .operating_point
+            .inlet_gauge_pa
+            .into_base()
+            .max(0.0)
+            + 1.0e-9;
     let main_channel_margin =
         (1.0 - max_main_channel_shear.into_base() / FDA_MAX_WALL_SHEAR_PA).clamp(0.0, 1.0);
     let cavitation_safety_margin = if max_venturi_transit_time.into_base() <= 1.0e-18 {
@@ -95,7 +101,7 @@ pub(crate) fn compute_typed_blueprint_safety_metrics(
         pressure_feasible,
         main_channel_margin,
         cavitation_safety_margin,
-        mean_device_residence_time: Time::from_base(solve.mean_residence_time_s),
+        mean_device_residence_time: solve.mean_residence_time_s,
     }
 }
 

--- a/crates/cfd-optim/src/metrics/safety.rs
+++ b/crates/cfd-optim/src/metrics/safety.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::constraints::{FDA_MAX_WALL_SHEAR_PA, FDA_TRANSIENT_TIME_S};
 use crate::domain::BlueprintCandidate;
+use aequitas::systems::si::quantities::{Length, Pressure, Time, Velocity};
 use cfd_2d::physics::non_newtonian::CarreauYasudaModel;
 
 use super::blueprint_graph::BlueprintSolveSummary;
@@ -17,50 +18,90 @@ pub struct BlueprintSafetyMetrics {
     pub mean_device_residence_time_s: f64,
 }
 
-pub fn compute_blueprint_safety_metrics(
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TypedBlueprintSafetyMetrics {
+    pub(crate) max_main_channel_shear: Pressure,
+    pub(crate) max_venturi_shear: Pressure,
+    pub(crate) pressure_drop: Pressure,
+    pub(crate) pressure_feasible: bool,
+    pub(crate) main_channel_margin: f64,
+    pub(crate) cavitation_safety_margin: f64,
+    pub(crate) mean_device_residence_time: Time,
+}
+
+impl TypedBlueprintSafetyMetrics {
+    fn into_serialized(self) -> BlueprintSafetyMetrics {
+        BlueprintSafetyMetrics {
+            max_main_channel_shear_pa: self.max_main_channel_shear.into_base(),
+            max_venturi_shear_pa: self.max_venturi_shear.into_base(),
+            pressure_drop_pa: self.pressure_drop.into_base(),
+            pressure_feasible: self.pressure_feasible,
+            main_channel_margin: self.main_channel_margin,
+            cavitation_safety_margin: self.cavitation_safety_margin,
+            mean_device_residence_time_s: self.mean_device_residence_time.into_base(),
+        }
+    }
+}
+
+pub(crate) fn compute_typed_blueprint_safety_metrics(
     candidate: &BlueprintCandidate,
     solve: &BlueprintSolveSummary<'_>,
-) -> BlueprintSafetyMetrics {
-    let mut max_main_channel_shear_pa = 0.0_f64;
-    let mut max_venturi_shear_pa = 0.0_f64;
-    let mut max_venturi_transit_time_s = 0.0_f64;
+) -> TypedBlueprintSafetyMetrics {
+    let mut max_main_channel_shear = Pressure::from_base(0.0);
+    let mut max_venturi_shear = Pressure::from_base(0.0);
+    let mut max_venturi_transit_time = Time::from_base(0.0);
 
     let cy_model = CarreauYasudaModel::<f64>::typical_blood();
 
     for sample in &solve.channel_samples {
         let area_m2 = sample.cross_section.area().max(1.0e-18);
-        let mean_velocity_m_s = sample.flow_m3_s.abs() / area_m2;
-        let shear_rate_inv_s = sample.cross_section.wall_shear_rate(mean_velocity_m_s);
+        let mean_velocity = Velocity::from_base(sample.flow_m3_s.abs() / area_m2);
+        let shear_rate_inv_s = sample
+            .cross_section
+            .wall_shear_rate(mean_velocity.into_base());
         let apparent_viscosity_pa_s = cy_model.apparent_viscosity(shear_rate_inv_s);
-        let shear_pa = apparent_viscosity_pa_s * shear_rate_inv_s;
-        let transit_time_s = sample.length_m / mean_velocity_m_s.max(1.0e-18);
+        let shear = Pressure::from_base(apparent_viscosity_pa_s * shear_rate_inv_s);
+        let transit_time = Length::from_base(sample.length_m)
+            / Velocity::from_base(mean_velocity.into_base().max(1.0e-18));
 
         if sample.is_venturi_channel {
-            max_venturi_shear_pa = max_venturi_shear_pa.max(shear_pa);
-            max_venturi_transit_time_s = max_venturi_transit_time_s.max(transit_time_s);
-        } else {
-            max_main_channel_shear_pa = max_main_channel_shear_pa.max(shear_pa);
+            if shear > max_venturi_shear {
+                max_venturi_shear = shear;
+            }
+            if transit_time > max_venturi_transit_time {
+                max_venturi_transit_time = transit_time;
+            }
+        } else if shear > max_main_channel_shear {
+            max_main_channel_shear = shear;
         }
     }
 
-    let pressure_drop_pa = solve.inlet_pressure_pa.max(0.0) + solve.remerge_loss_pa.max(0.0);
+    let pressure_drop =
+        Pressure::from_base(solve.inlet_pressure_pa.max(0.0) + solve.remerge_loss_pa.max(0.0));
     let pressure_feasible =
-        pressure_drop_pa <= candidate.operating_point.inlet_gauge_pa.max(0.0) + 1.0e-9;
+        pressure_drop.into_base() <= candidate.operating_point.inlet_gauge_pa.max(0.0) + 1.0e-9;
     let main_channel_margin =
-        (1.0 - max_main_channel_shear_pa / FDA_MAX_WALL_SHEAR_PA).clamp(0.0, 1.0);
-    let cavitation_safety_margin = if max_venturi_transit_time_s <= 1.0e-18 {
+        (1.0 - max_main_channel_shear.into_base() / FDA_MAX_WALL_SHEAR_PA).clamp(0.0, 1.0);
+    let cavitation_safety_margin = if max_venturi_transit_time.into_base() <= 1.0e-18 {
         main_channel_margin
     } else {
-        (FDA_TRANSIENT_TIME_S / max_venturi_transit_time_s).clamp(0.0, 1.0)
+        (FDA_TRANSIENT_TIME_S / max_venturi_transit_time.into_base()).clamp(0.0, 1.0)
     };
 
-    BlueprintSafetyMetrics {
-        max_main_channel_shear_pa,
-        max_venturi_shear_pa,
-        pressure_drop_pa,
+    TypedBlueprintSafetyMetrics {
+        max_main_channel_shear,
+        max_venturi_shear,
+        pressure_drop,
         pressure_feasible,
         main_channel_margin,
         cavitation_safety_margin,
-        mean_device_residence_time_s: solve.mean_residence_time_s,
+        mean_device_residence_time: Time::from_base(solve.mean_residence_time_s),
     }
+}
+
+pub fn compute_blueprint_safety_metrics(
+    candidate: &BlueprintCandidate,
+    solve: &BlueprintSolveSummary<'_>,
+) -> BlueprintSafetyMetrics {
+    compute_typed_blueprint_safety_metrics(candidate, solve).into_serialized()
 }

--- a/crates/cfd-optim/src/metrics/sdt_metrics.rs
+++ b/crates/cfd-optim/src/metrics/sdt_metrics.rs
@@ -1,5 +1,9 @@
 //! The [`SdtMetrics`] output struct — all physics-derived metrics for one
 //! [`BlueprintCandidate`](crate::BlueprintCandidate).
+//!
+//! Unit-bearing values are assembled with Aequitas in the report producer and
+//! converted once into this serialized display-unit DTO. The scalar fields
+//! here are therefore an I/O contract, not the physical computation boundary.
 
 use serde::{Deserialize, Deserializer, Serialize};
 

--- a/crates/cfd-optim/src/metrics/venturi.rs
+++ b/crates/cfd-optim/src/metrics/venturi.rs
@@ -1,4 +1,4 @@
-use cfd_1d::{evaluate_venturi_screening, VenturiScreeningInput, VenturiSelectiveScreeningRegime};
+use cfd_1d::{VenturiScreeningInput, VenturiSelectiveScreeningRegime, evaluate_venturi_screening};
 use cfd_core::physics::cavitation::{
     CellMechanicalState, CellPopulationIdentity, PopulationNucleationState,
     SelectiveCavitationInput, SelectiveCavitationPopulation,
@@ -240,8 +240,8 @@ pub fn compute_blueprint_venturi_metrics(
         let sample = &solve.channel_samples[idx];
         let phi_in = node_nuclei.get(sample.from_node).copied().unwrap_or(0.0);
 
-        let velocity = sample.flow_m3_s.abs() / sample.cross_section.area().max(1e-18);
-        let transit_time_s = sample.length_m / velocity.max(1e-9);
+        let velocity = sample.flow_m3_s.into_base().abs() / sample.cross_section.area().max(1e-18);
+        let transit_time_s = sample.length_m.into_base() / velocity.max(1e-9);
         let phi_arrival = transport.advect_1d_dissolution(phi_in, transit_time_s);
         let mut phi_out = phi_arrival;
 
@@ -255,13 +255,16 @@ pub fn compute_blueprint_venturi_metrics(
             let area_throat_m2 = (placement.throat_geometry.throat_width_m
                 * placement.throat_geometry.throat_height_m)
                 .max(1.0e-18);
-            let upstream_velocity_m_s = sample.flow_m3_s.abs() / area_inlet_m2;
-            let throat_velocity_m_s = sample.flow_m3_s.abs() / area_throat_m2;
+            let upstream_velocity_m_s = sample.flow_m3_s.into_base().abs() / area_inlet_m2;
+            let throat_velocity_m_s = sample.flow_m3_s.into_base().abs() / area_throat_m2;
             let upstream_dynamic_pressure_pa =
                 dynamic_pressure_pa(BLOOD_DENSITY_KG_M3, upstream_velocity_m_s).max(1.0e-18);
             let screening = evaluate_venturi_screening(VenturiScreeningInput {
-                upstream_pressure_pa: candidate.operating_point.absolute_inlet_pressure_pa()
-                    + sample.from_pressure_pa.max(0.0),
+                upstream_pressure_pa: candidate
+                    .operating_point
+                    .absolute_inlet_pressure_pa()
+                    .into_base()
+                    + sample.from_pressure_pa.into_base().max(0.0),
                 upstream_velocity_m_s,
                 throat_velocity_m_s,
                 throat_hydraulic_diameter_m: 2.0
@@ -280,8 +283,11 @@ pub fn compute_blueprint_venturi_metrics(
                 selective_cavitation: Some(selective_cavitation_input(
                     separation,
                     BLOOD_VAPOR_PRESSURE_PA,
-                    candidate.operating_point.absolute_inlet_pressure_pa()
-                        + sample.from_pressure_pa.max(0.0),
+                    candidate
+                        .operating_point
+                        .absolute_inlet_pressure_pa()
+                        .into_base()
+                        + sample.from_pressure_pa.into_base().max(0.0),
                 )),
             })
             .map_err(|error| OptimError::PhysicsError {
@@ -296,7 +302,7 @@ pub fn compute_blueprint_venturi_metrics(
             let dean_site = cfd_schematics::BlueprintTopologyFactory::estimate_dean_site(
                 &candidate.blueprint,
                 &resolved_placement,
-                sample.flow_m3_s.abs(),
+                sample.flow_m3_s.into_base().abs(),
                 BLOOD_VISCOSITY_PA_S / BLOOD_DENSITY_KG_M3,
             )
             .unwrap_or_default();
@@ -323,8 +329,11 @@ pub fn compute_blueprint_venturi_metrics(
                 cavitation_number: screening.cavitation_number,
                 effective_throat_velocity_m_s: screening.effective_throat_velocity_m_s,
                 throat_static_pressure_pa: screening.throat_static_pressure_pa,
-                upstream_pressure_pa: candidate.operating_point.absolute_inlet_pressure_pa()
-                    + sample.from_pressure_pa.max(0.0),
+                upstream_pressure_pa: candidate
+                    .operating_point
+                    .absolute_inlet_pressure_pa()
+                    .into_base()
+                    + sample.from_pressure_pa.into_base().max(0.0),
                 diffuser_recovery_pa: screening.diffuser_recovery_pa,
                 total_loss_coefficient: total_loss_pa / upstream_dynamic_pressure_pa,
                 dean_number: dean_site.dean_number,
@@ -395,7 +404,7 @@ pub fn compute_blueprint_venturi_metrics(
 
 #[cfg(test)]
 mod tests {
-    use cfd_1d::{evaluate_venturi_screening, VenturiScreeningInput};
+    use cfd_1d::{VenturiScreeningInput, evaluate_venturi_screening};
     use cfd_schematics::VenturiPlacementMode;
 
     use crate::constraints::{
@@ -548,11 +557,14 @@ mod tests {
         let throat_area_m2 = (placement_spec.throat_geometry.throat_width_m
             * placement_spec.throat_geometry.throat_height_m)
             .max(1.0e-18);
-        let upstream_velocity_m_s = sample.flow_m3_s.abs() / inlet_area_m2;
-        let throat_velocity_m_s = sample.flow_m3_s.abs() / throat_area_m2;
+        let upstream_velocity_m_s = sample.flow_m3_s.into_base().abs() / inlet_area_m2;
+        let throat_velocity_m_s = sample.flow_m3_s.into_base().abs() / throat_area_m2;
         let screening = evaluate_venturi_screening(VenturiScreeningInput {
-            upstream_pressure_pa: candidate.operating_point.absolute_inlet_pressure_pa()
-                + sample.from_pressure_pa.max(0.0),
+            upstream_pressure_pa: candidate
+                .operating_point
+                .absolute_inlet_pressure_pa()
+                .into_base()
+                + sample.from_pressure_pa.into_base().max(0.0),
             upstream_velocity_m_s,
             throat_velocity_m_s,
             throat_hydraulic_diameter_m: 2.0
@@ -571,8 +583,11 @@ mod tests {
             selective_cavitation: Some(super::selective_cavitation_input(
                 &separation,
                 BLOOD_VAPOR_PRESSURE_PA,
-                candidate.operating_point.absolute_inlet_pressure_pa()
-                    + sample.from_pressure_pa.max(0.0),
+                candidate
+                    .operating_point
+                    .absolute_inlet_pressure_pa()
+                    .into_base()
+                    + sample.from_pressure_pa.into_base().max(0.0),
             )),
         })
         .expect("venturi screening should succeed for the reference contract");

--- a/crates/cfd-optim/src/reporting/design_record.rs
+++ b/crates/cfd-optim/src/reporting/design_record.rs
@@ -112,12 +112,12 @@ impl Milestone12ReportDesign {
 
     #[must_use]
     pub fn flow_rate_ml_min(&self) -> f64 {
-        self.candidate.operating_point.flow_rate_m3_s * 6.0e7
+        self.candidate.operating_point.flow_rate_m3_s.into_base() * 6.0e7
     }
 
     #[must_use]
     pub fn inlet_gauge_kpa(&self) -> f64 {
-        self.candidate.operating_point.inlet_gauge_pa * 1.0e-3
+        self.candidate.operating_point.inlet_gauge_pa.into_base() * 1.0e-3
     }
 
     #[must_use]
@@ -294,7 +294,7 @@ pub fn compute_blueprint_report_metrics(
 
 #[cfg(test)]
 mod tests {
-    use super::{pareto_point_from_report_design, Milestone12ReportDesign, ParetoTag};
+    use super::{Milestone12ReportDesign, ParetoTag, pareto_point_from_report_design};
     use crate::domain::fixtures::{canonical_option2_candidate, operating_point};
     use crate::reporting::compute_blueprint_report_metrics;
 

--- a/crates/cfd-optim/src/reporting/report_metrics.rs
+++ b/crates/cfd-optim/src/reporting/report_metrics.rs
@@ -1,7 +1,8 @@
 use aequitas::systems::si::quantities::{
-    DynamicViscosity, Length, Power, Pressure, ReciprocalLength, ReciprocalTime,
-    ThermodynamicTemperature, Time, Velocity, Volume, VolumetricFlowRate,
+    DynamicViscosity, EnergyPerVolume, Length, Power, Pressure, ReciprocalLength, ReciprocalTime,
+    TemperatureDifference, Time, Velocity, Volume, VolumetricFlowRate,
 };
+use aequitas::systems::si::units::{JoulePerCubicMeter, JoulePerMilliliter, Kelvin};
 use cfd_1d::{
     acoustic_contrast_factor, acoustic_energy_density, cavitation_amplified_hi,
     cavitation_hemolysis_amplification, giersiepen_hi, sonosensitizer_activation_efficiency,
@@ -34,8 +35,8 @@ use crate::constraints::{
 use crate::domain::BlueprintCandidate;
 use crate::error::OptimError;
 use crate::metrics::{
-    compute_blueprint_safety_metrics, compute_blueprint_separation_metrics,
-    compute_blueprint_venturi_metrics, compute_residence_metrics,
+    compute_blueprint_separation_metrics, compute_blueprint_venturi_metrics,
+    compute_typed_blueprint_safety_metrics, compute_typed_residence_metrics,
     healthy_cell_protection_index as compute_healthy_cell_protection_index,
     solve_blueprint_candidate, ChannelHemolysis, SdtMetrics,
 };
@@ -70,7 +71,9 @@ struct TypedReportPhysicalMetrics {
     diffuser_recovery: Pressure,
     mechanical_power: Power,
     treatment_zone_dwell_time: Time,
-    throat_temperature_rise: ThermodynamicTemperature,
+    specific_cavitation_energy: EnergyPerVolume,
+    acoustic_energy_density: EnergyPerVolume,
+    throat_temperature_rise: TemperatureDifference,
 }
 
 impl TypedReportPhysicalMetrics {
@@ -95,6 +98,8 @@ impl TypedReportPhysicalMetrics {
             diffuser_recovery,
             mechanical_power,
             treatment_zone_dwell_time,
+            specific_cavitation_energy,
+            acoustic_energy_density,
             throat_temperature_rise,
         } = self;
 
@@ -117,7 +122,11 @@ impl TypedReportPhysicalMetrics {
         metrics.diffuser_recovery_pa = diffuser_recovery.into_base();
         metrics.mechanical_power_w = mechanical_power.into_base();
         metrics.treatment_zone_dwell_time_s = treatment_zone_dwell_time.into_base();
-        metrics.throat_temperature_rise_k = throat_temperature_rise.into_base();
+        metrics.specific_cavitation_energy_j_ml =
+            specific_cavitation_energy.in_unit::<JoulePerMilliliter>();
+        metrics.acoustic_energy_density_j_m3 =
+            acoustic_energy_density.in_unit::<JoulePerCubicMeter>();
+        metrics.throat_temperature_rise_k = throat_temperature_rise.in_unit::<Kelvin>();
     }
 }
 
@@ -195,10 +204,14 @@ pub fn compute_blueprint_report_metrics(
 ) -> Result<SdtMetrics, OptimError> {
     let topology = candidate.topology_spec()?;
     let solve = solve_blueprint_candidate(candidate)?;
-    let residence = compute_residence_metrics(candidate, &solve);
+    let residence = compute_typed_residence_metrics(candidate, &solve);
     let separation = compute_blueprint_separation_metrics(candidate)?;
     let venturi = compute_blueprint_venturi_metrics(candidate, &solve, &separation)?;
-    let safety = compute_blueprint_safety_metrics(candidate, &solve);
+    let safety = compute_typed_blueprint_safety_metrics(candidate, &solve);
+    let max_main_channel_shear_pa = safety.max_main_channel_shear.into_base();
+    let max_venturi_shear_pa = safety.max_venturi_shear.into_base();
+    let pressure_drop_pa = safety.pressure_drop.into_base();
+    let mean_residence_time_s = residence.treatment_residence_time.into_base();
 
     let mut metrics = SdtMetrics::default();
     let flow_rate_m3_s = candidate.operating_point.flow_rate_m3_s.max(1.0e-18);
@@ -358,7 +371,7 @@ pub fn compute_blueprint_report_metrics(
         .map(|sample| resonance_match(sample.cross_section.hydraulic_diameter()))
         .fold(0.0_f64, f64::max);
     let throat_temperature_rise_k = if max_venturi_shear_rate_inv_s > 0.0 {
-        safety.max_venturi_shear_pa * max_venturi_shear_rate_inv_s * max_venturi_transit_time_s
+        max_venturi_shear_pa * max_venturi_shear_rate_inv_s * max_venturi_transit_time_s
             / (BLOOD_DENSITY_KG_M3 * C_P_BLOOD_J_KG_K)
     } else {
         0.0
@@ -475,8 +488,8 @@ pub fn compute_blueprint_report_metrics(
 
     metrics.cavitation_number = cavitation_number;
     metrics.cavitation_potential = cavitation_potential;
-    metrics.throat_exceeds_fda = safety.max_venturi_shear_pa > FDA_MAX_WALL_SHEAR_PA;
-    metrics.fda_main_compliant = safety.max_main_channel_shear_pa <= FDA_MAX_WALL_SHEAR_PA;
+    metrics.throat_exceeds_fda = max_venturi_shear_pa > FDA_MAX_WALL_SHEAR_PA;
+    metrics.fda_main_compliant = max_main_channel_shear_pa <= FDA_MAX_WALL_SHEAR_PA;
     metrics.bulk_hemolysis_index_per_pass = bulk_hi;
     metrics.hemolysis_index_per_pass = corrected_hi;
     metrics.flow_uniformity = solve.flow_uniformity;
@@ -588,9 +601,9 @@ pub fn compute_blueprint_report_metrics(
     metrics.healthy_cell_protection_index = healthy_cell_protection_index;
     metrics.sonoluminescence_proxy = sonoluminescence_proxy;
     metrics.fda_overall_compliant = metrics.fda_main_compliant
-        && (safety.max_venturi_shear_pa <= FDA_MAX_WALL_SHEAR_PA
+        && (max_venturi_shear_pa <= FDA_MAX_WALL_SHEAR_PA
             || (max_venturi_transit_time_s <= FDA_TRANSIENT_TIME_S
-                && safety.max_venturi_shear_pa <= FDA_TRANSIENT_SHEAR_PA));
+                && max_venturi_shear_pa <= FDA_TRANSIENT_SHEAR_PA));
     metrics.lysis_risk_index = lysis_risk_index;
     metrics.therapeutic_window_score = therapeutic_window_score;
     metrics.oncology_selectivity_index = oncology_selectivity_index;
@@ -608,14 +621,12 @@ pub fn compute_blueprint_report_metrics(
     metrics.wall_shear_cv = wall_shear_cv;
     metrics.fda_shear_percentile_compliant =
         wall_shear_p95_pa <= FDA_MAX_WALL_SHEAR_PA && wall_shear_p99_pa <= FDA_TRANSIENT_SHEAR_PA;
-    let hydraulic_power = mechanical_power(safety.pressure_drop_pa, flow_rate_m3_s);
+    let hydraulic_power = mechanical_power(pressure_drop_pa, flow_rate_m3_s);
     let hydraulic_power_w = hydraulic_power.into_base();
     metrics.acoustic_capture_efficiency =
-        (cavitation_potential * (safety.max_venturi_shear_pa / P_ATM_PA)).clamp(0.0, 1.0);
-    metrics.specific_cavitation_energy_j_ml = if flow_rate_ml_min > 1.0e-18 {
-        metrics.acoustic_capture_efficiency
-            * hydraulic_power_w
-            * residence.treatment_residence_time_s
+        (cavitation_potential * (max_venturi_shear_pa / P_ATM_PA)).clamp(0.0, 1.0);
+    let specific_cavitation_energy_j_ml = if flow_rate_ml_min > 1.0e-18 {
+        metrics.acoustic_capture_efficiency * hydraulic_power_w * mean_residence_time_s
             / (flow_rate_ml_min / 60_000.0)
             * 1.0e3
     } else {
@@ -694,9 +705,8 @@ pub fn compute_blueprint_report_metrics(
     let sdt_acoustic = compute_sdt_acoustic_metrics(
         cavitation_intensity,
         max_venturi_transit_time_s,
-        safety.pressure_drop_pa,
+        pressure_drop_pa,
     );
-    metrics.acoustic_energy_density_j_m3 = sdt_acoustic.acoustic_energy_density_j_m3;
     metrics.ctc_contrast_factor = sdt_acoustic.ctc_contrast_factor;
     metrics.rbc_contrast_factor = sdt_acoustic.rbc_contrast_factor;
 
@@ -715,28 +725,32 @@ pub fn compute_blueprint_report_metrics(
 
     let physical_metrics = TypedReportPhysicalMetrics {
         throat_shear_rate: ReciprocalTime::from_base(max_venturi_shear_rate_inv_s),
-        throat_shear: Pressure::from_base(safety.max_venturi_shear_pa),
-        max_main_channel_shear: Pressure::from_base(safety.max_main_channel_shear_pa),
-        mean_residence_time: Time::from_base(residence.treatment_residence_time_s),
-        total_pressure_drop: Pressure::from_base(safety.pressure_drop_pa),
+        throat_shear: safety.max_venturi_shear,
+        max_main_channel_shear: safety.max_main_channel_shear,
+        mean_residence_time: residence.treatment_residence_time,
+        total_pressure_drop: safety.pressure_drop,
         total_path_length,
         total_ecv: total_volume,
         flow_rate,
         main_channel_shear_rate: ReciprocalTime::from_base(
-            safety.max_main_channel_shear_pa / BLOOD_VISCOSITY_PA_S.max(1.0e-18),
+            max_main_channel_shear_pa / BLOOD_VISCOSITY_PA_S.max(1.0e-18),
         ),
         throat_transit_time: Time::from_base(max_venturi_transit_time_s),
         optical_path_length,
-        safety_margin: Pressure::from_base(
-            FDA_MAX_WALL_SHEAR_PA - safety.max_main_channel_shear_pa,
-        ),
+        safety_margin: Pressure::from_base(FDA_MAX_WALL_SHEAR_PA - max_main_channel_shear_pa),
         wall_shear_p95: Pressure::from_base(wall_shear_p95_pa),
         wall_shear_p99: Pressure::from_base(wall_shear_p99_pa),
         wall_shear_mean: Pressure::from_base(wall_shear_mean_pa),
         diffuser_recovery: Pressure::from_base(diffuser_recovery_pa),
         mechanical_power: hydraulic_power,
-        treatment_zone_dwell_time: Time::from_base(residence.treatment_residence_time_s),
-        throat_temperature_rise: ThermodynamicTemperature::from_base(throat_temperature_rise_k),
+        treatment_zone_dwell_time: residence.treatment_residence_time,
+        specific_cavitation_energy: EnergyPerVolume::from_unit::<JoulePerMilliliter>(
+            specific_cavitation_energy_j_ml,
+        ),
+        acoustic_energy_density: sdt_acoustic.acoustic_energy_density,
+        throat_temperature_rise: TemperatureDifference::from_unit::<Kelvin>(
+            throat_temperature_rise_k,
+        ),
     };
     physical_metrics.write_to(&mut metrics);
 
@@ -762,7 +776,7 @@ pub struct SdtAcousticMetrics {
 
     /// Acoustic energy density [J/m³] at 100 kPa pressure amplitude in blood.
     /// E_ac = p₀²/(4ρc²).
-    pub acoustic_energy_density_j_m3: f64,
+    pub acoustic_energy_density: EnergyPerVolume,
 
     /// Acoustic contrast factor Φ for CTCs in plasma (Gor'kov 1962).
     /// Positive → migrates toward pressure nodes.
@@ -827,7 +841,7 @@ pub fn compute_sdt_acoustic_metrics(
     SdtAcousticMetrics {
         sensitizer_activation_efficiency: sensitizer_activation,
         rayleigh_plesset_amplification: rp_amplification,
-        acoustic_energy_density_j_m3: e_acoustic,
+        acoustic_energy_density: EnergyPerVolume::from_unit::<JoulePerCubicMeter>(e_acoustic),
         ctc_contrast_factor: ctc_contrast,
         rbc_contrast_factor: rbc_contrast,
     }
@@ -902,8 +916,10 @@ mod tests {
             "rayleigh_plesset_amplification must be finite"
         );
         assert!(
-            m.acoustic_energy_density_j_m3.is_finite(),
-            "acoustic_energy_density_j_m3 must be finite"
+            m.acoustic_energy_density
+                .in_unit::<JoulePerCubicMeter>()
+                .is_finite(),
+            "acoustic_energy_density must be finite"
         );
         assert!(
             m.ctc_contrast_factor.is_finite(),
@@ -936,7 +952,7 @@ mod tests {
         );
         // RP amplification and energy density are independent of cavitation intensity
         assert!(m.rayleigh_plesset_amplification > 1.0);
-        assert!(m.acoustic_energy_density_j_m3 > 0.0);
+        assert!(m.acoustic_energy_density.in_unit::<JoulePerCubicMeter>() > 0.0);
     }
 
     #[test]
@@ -945,7 +961,7 @@ mod tests {
         for pressure_drop in [0.0, 10_000.0, 100_000.0, 500_000.0] {
             let m = compute_sdt_acoustic_metrics(0.5, 0.001, pressure_drop);
             assert!(
-                m.acoustic_energy_density_j_m3 > 0.0,
+                m.acoustic_energy_density.in_unit::<JoulePerCubicMeter>() > 0.0,
                 "energy density must be positive at pressure_drop={pressure_drop}"
             );
         }
@@ -1026,7 +1042,9 @@ mod tests {
             diffuser_recovery: Pressure::from_base(4.0),
             mechanical_power: Power::from_base(80.0),
             treatment_zone_dwell_time: Time::from_base(0.25),
-            throat_temperature_rise: ThermodynamicTemperature::from_base(0.02),
+            specific_cavitation_energy: EnergyPerVolume::from_unit::<JoulePerMilliliter>(0.125),
+            acoustic_energy_density: EnergyPerVolume::from_unit::<JoulePerCubicMeter>(2.5),
+            throat_temperature_rise: TemperatureDifference::from_unit::<Kelvin>(0.02),
         }
         .write_to(&mut metrics);
 
@@ -1035,6 +1053,8 @@ mod tests {
         assert_eq!(metrics.flow_rate_ml_min, 120.0);
         assert_eq!(metrics.total_pressure_drop_pa, 40.0);
         assert_eq!(metrics.mechanical_power_w, 80.0);
+        assert_eq!(metrics.specific_cavitation_energy_j_ml, 0.125);
+        assert_eq!(metrics.acoustic_energy_density_j_m3, 2.5);
         assert_eq!(metrics.throat_temperature_rise_k, 0.02);
 
         let encoded = serde_json::to_string(&metrics).expect("report metrics serialize");
@@ -1044,5 +1064,58 @@ mod tests {
         assert_eq!(decoded.total_ecv_ml, 3.0);
         assert_eq!(decoded.flow_rate_ml_min, 120.0);
         assert_eq!(decoded.mechanical_power_w, 80.0);
+    }
+
+    #[test]
+    fn residence_and_safety_adapters_preserve_typed_values() {
+        let candidate = stage0_venturi_candidate(
+            "typed-residence-safety",
+            operating_point(2.0e-6, 30_000.0, 0.18),
+            VenturiPlacementMode::StraightSegment,
+        );
+        let solve = solve_blueprint_candidate(&candidate).expect("solve");
+        let typed_residence = compute_typed_residence_metrics(&candidate, &solve);
+        let serialized_residence = crate::metrics::compute_residence_metrics(&candidate, &solve);
+        let typed_safety = compute_typed_blueprint_safety_metrics(&candidate, &solve);
+        let serialized_safety =
+            crate::metrics::compute_blueprint_safety_metrics(&candidate, &solve);
+
+        let expected_treatment_volume = solve
+            .channel_samples
+            .iter()
+            .filter(|sample| sample.is_treatment_channel)
+            .map(|sample| sample.length_m * sample.cross_section.area())
+            .sum::<f64>();
+
+        assert_eq!(
+            typed_residence.treatment_volume.into_base().to_bits(),
+            expected_treatment_volume.to_bits()
+        );
+        assert_eq!(
+            typed_residence.treatment_volume.into_base().to_bits(),
+            serialized_residence.treatment_volume_m3.to_bits()
+        );
+        assert_eq!(
+            typed_residence
+                .treatment_residence_time
+                .into_base()
+                .to_bits(),
+            serialized_residence.treatment_residence_time_s.to_bits()
+        );
+        assert_eq!(
+            typed_safety.max_main_channel_shear.into_base().to_bits(),
+            serialized_safety.max_main_channel_shear_pa.to_bits()
+        );
+        assert_eq!(
+            typed_safety.pressure_drop.into_base().to_bits(),
+            serialized_safety.pressure_drop_pa.to_bits()
+        );
+        assert_eq!(
+            typed_safety
+                .mean_device_residence_time
+                .into_base()
+                .to_bits(),
+            serialized_safety.mean_device_residence_time_s.to_bits()
+        );
     }
 }

--- a/crates/cfd-optim/src/reporting/report_metrics.rs
+++ b/crates/cfd-optim/src/reporting/report_metrics.rs
@@ -76,6 +76,29 @@ struct TypedReportPhysicalMetrics {
     throat_temperature_rise: TemperatureDifference,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct TypedChannelHemolysis<'a> {
+    channel_id: &'a str,
+    is_venturi_throat: bool,
+    hi_contribution: f64,
+    wall_shear: Pressure,
+    transit_time: Time,
+    flow_fraction: f64,
+}
+
+impl TypedChannelHemolysis<'_> {
+    fn into_serialized(self) -> ChannelHemolysis {
+        ChannelHemolysis {
+            channel_id: self.channel_id.to_owned(),
+            is_venturi_throat: self.is_venturi_throat,
+            hi_contribution: self.hi_contribution,
+            wall_shear_pa: self.wall_shear.into_base(),
+            transit_time_s: self.transit_time.into_base(),
+            flow_fraction: self.flow_fraction,
+        }
+    }
+}
+
 impl TypedReportPhysicalMetrics {
     /// Convert the typed computation result into the serialized report units.
     fn write_to(self, metrics: &mut SdtMetrics) {
@@ -327,12 +350,12 @@ pub fn compute_blueprint_report_metrics(
             dead_volume_m3 += sample.length_m * area_m2;
         }
 
-        per_channel_hemolysis.push(ChannelHemolysis {
-            channel_id: sample.id.to_string(),
+        per_channel_hemolysis.push(TypedChannelHemolysis {
+            channel_id: sample.id,
             is_venturi_throat: sample.is_venturi_channel,
             hi_contribution: corrected_channel_hi,
-            wall_shear_pa: shear_pa,
-            transit_time_s,
+            wall_shear: shear,
+            transit_time,
             flow_fraction,
         });
     }
@@ -636,7 +659,10 @@ pub fn compute_blueprint_report_metrics(
     metrics.treatment_channel_hi = treatment_hi;
     metrics.bypass_channel_hi_mean = mean(&bypass_hi_values);
     metrics.bypass_channel_hi_max = bypass_hi_values.into_iter().fold(0.0, f64::max);
-    metrics.per_channel_hemolysis = per_channel_hemolysis;
+    metrics.per_channel_hemolysis = per_channel_hemolysis
+        .into_iter()
+        .map(TypedChannelHemolysis::into_serialized)
+        .collect();
     metrics.acoustic_resonance_factor = channel_resonance_score;
     metrics.channel_resonance_score = channel_resonance_score;
     metrics.serial_cavitation_dose_fraction = serial_dose_fraction;
@@ -1064,6 +1090,27 @@ mod tests {
         assert_eq!(decoded.total_ecv_ml, 3.0);
         assert_eq!(decoded.flow_rate_ml_min, 120.0);
         assert_eq!(decoded.mechanical_power_w, 80.0);
+    }
+
+    #[test]
+    fn typed_channel_hemolysis_serializes_provider_values() {
+        let typed = TypedChannelHemolysis {
+            channel_id: "treatment-0",
+            is_venturi_throat: true,
+            hi_contribution: 0.25,
+            wall_shear: Pressure::from_base(18.0),
+            transit_time: Time::from_base(0.004),
+            flow_fraction: 0.75,
+        };
+
+        let serialized = typed.into_serialized();
+
+        assert_eq!(serialized.channel_id, "treatment-0");
+        assert!(serialized.is_venturi_throat);
+        assert_eq!(serialized.hi_contribution.to_bits(), 0.25_f64.to_bits());
+        assert_eq!(serialized.wall_shear_pa.to_bits(), 18.0_f64.to_bits());
+        assert_eq!(serialized.transit_time_s.to_bits(), 0.004_f64.to_bits());
+        assert_eq!(serialized.flow_fraction.to_bits(), 0.75_f64.to_bits());
     }
 
     #[test]

--- a/crates/cfd-optim/src/reporting/report_metrics.rs
+++ b/crates/cfd-optim/src/reporting/report_metrics.rs
@@ -1,12 +1,12 @@
 use aequitas::systems::si::quantities::{
-    DynamicViscosity, Length, Power, Pressure, ReciprocalLength, ReciprocalTime, Time, Velocity,
-    VolumetricFlowRate,
+    DynamicViscosity, Length, Power, Pressure, ReciprocalLength, ReciprocalTime,
+    ThermodynamicTemperature, Time, Velocity, Volume, VolumetricFlowRate,
 };
 use cfd_1d::{
+    acoustic_contrast_factor, acoustic_energy_density, cavitation_amplified_hi,
+    cavitation_hemolysis_amplification, giersiepen_hi, sonosensitizer_activation_efficiency,
     KAPPA_CTC, KAPPA_PLASMA, KAPPA_RBC, RHO_CTC, RHO_PLASMA, RHO_RBC,
-    SENSITIZER_K_ACT_HEMATOPORPHYRIN, acoustic_contrast_factor, acoustic_energy_density,
-    cavitation_amplified_hi, cavitation_hemolysis_amplification, giersiepen_hi,
-    sonosensitizer_activation_efficiency,
+    SENSITIZER_K_ACT_HEMATOPORPHYRIN,
 };
 use cfd_schematics::topology::TreatmentActuationMode;
 use hyperion::{
@@ -20,26 +20,106 @@ use super::report_math::{
 };
 use crate::constraints::{
     BLOOD_ATTENUATION_405NM_INV_M, BLOOD_DENSITY_KG_M3, BLOOD_VAPOR_PRESSURE_PA,
-    BLOOD_VISCOSITY_PA_S, BUBBLE_POLYTROPIC_K, C_P_BLOOD_J_KG_K, CLOTTING_BFR_CAUTION_ML_MIN,
+    BLOOD_VISCOSITY_PA_S, BUBBLE_POLYTROPIC_K, CLOTTING_BFR_CAUTION_ML_MIN,
     CLOTTING_BFR_HIGH_RISK_ML_MIN, CLOTTING_BFR_LOW_RISK_ML_MIN, CLOTTING_BFR_STRICT_10MLS_ML_MIN,
     CLOTTING_RESIDENCE_HIGH_RISK_S, CLOTTING_RESIDENCE_LOW_RISK_S, CLOTTING_SHEAR_HIGH_RISK_INV_S,
-    CLOTTING_SHEAR_LOW_RISK_INV_S, DEAD_VOLUME_SHEAR_THRESHOLD_INV_S, EXPANSION_RATIO_LOW_RISK,
-    FDA_MAX_WALL_SHEAR_PA, FDA_THROAT_TEMP_RISE_LIMIT_K, FDA_TRANSIENT_SHEAR_PA,
-    FDA_TRANSIENT_TIME_S, MILESTONE_TREATMENT_DURATION_MIN, P_ATM_PA, PATIENT_BLOOD_VOLUME_ML,
-    PEDIATRIC_BLOOD_VOLUME_ML_PER_KG, PEDIATRIC_FLOW_CAUTION_ML_MIN,
+    CLOTTING_SHEAR_LOW_RISK_INV_S, C_P_BLOOD_J_KG_K, DEAD_VOLUME_SHEAR_THRESHOLD_INV_S,
+    EXPANSION_RATIO_LOW_RISK, FDA_MAX_WALL_SHEAR_PA, FDA_THROAT_TEMP_RISE_LIMIT_K,
+    FDA_TRANSIENT_SHEAR_PA, FDA_TRANSIENT_TIME_S, MILESTONE_TREATMENT_DURATION_MIN,
+    PATIENT_BLOOD_VOLUME_ML, PEDIATRIC_BLOOD_VOLUME_ML_PER_KG, PEDIATRIC_FLOW_CAUTION_ML_MIN,
     PEDIATRIC_FLOW_EXCESSIVE_ML_MIN, PEDIATRIC_REFERENCE_WEIGHT_KG, PLATE_HEIGHT_MM,
-    PLATE_WIDTH_MM, SONO_REF_P_ABS_PA, THERAPEUTIC_WINDOW_REF, VENTURI_EXPANSION_RATIO_HIGH_RISK,
-    VENTURI_VEL_RATIO_REF,
+    PLATE_WIDTH_MM, P_ATM_PA, SONO_REF_P_ABS_PA, THERAPEUTIC_WINDOW_REF,
+    VENTURI_EXPANSION_RATIO_HIGH_RISK, VENTURI_VEL_RATIO_REF,
 };
 use crate::domain::BlueprintCandidate;
 use crate::error::OptimError;
 use crate::metrics::{
-    ChannelHemolysis, SdtMetrics, compute_blueprint_safety_metrics,
-    compute_blueprint_separation_metrics, compute_blueprint_venturi_metrics,
-    compute_residence_metrics,
+    compute_blueprint_safety_metrics, compute_blueprint_separation_metrics,
+    compute_blueprint_venturi_metrics, compute_residence_metrics,
     healthy_cell_protection_index as compute_healthy_cell_protection_index,
-    solve_blueprint_candidate,
+    solve_blueprint_candidate, ChannelHemolysis, SdtMetrics,
 };
+
+const MILLIMETRES_PER_METRE: f64 = 1_000.0;
+const MILLILITRES_PER_CUBIC_METRE: f64 = 1_000_000.0;
+const SECONDS_PER_MINUTE: f64 = 60.0;
+
+/// Unit-bearing report values before conversion to the legacy serialized DTO.
+///
+/// `SdtMetrics` is a persisted/reporting contract whose field names encode
+/// display units. Keeping the physical values together here makes the
+/// computation boundary dimension-safe while [`write_to`] remains the sole
+/// explicit conversion into those display units.
+#[derive(Debug, Clone, Copy)]
+struct TypedReportPhysicalMetrics {
+    throat_shear_rate: ReciprocalTime,
+    throat_shear: Pressure,
+    max_main_channel_shear: Pressure,
+    mean_residence_time: Time,
+    total_pressure_drop: Pressure,
+    total_path_length: Length,
+    total_ecv: Volume,
+    flow_rate: VolumetricFlowRate,
+    main_channel_shear_rate: ReciprocalTime,
+    throat_transit_time: Time,
+    optical_path_length: Length,
+    safety_margin: Pressure,
+    wall_shear_p95: Pressure,
+    wall_shear_p99: Pressure,
+    wall_shear_mean: Pressure,
+    diffuser_recovery: Pressure,
+    mechanical_power: Power,
+    treatment_zone_dwell_time: Time,
+    throat_temperature_rise: ThermodynamicTemperature,
+}
+
+impl TypedReportPhysicalMetrics {
+    /// Convert the typed computation result into the serialized report units.
+    fn write_to(self, metrics: &mut SdtMetrics) {
+        let Self {
+            throat_shear_rate,
+            throat_shear,
+            max_main_channel_shear,
+            mean_residence_time,
+            total_pressure_drop,
+            total_path_length,
+            total_ecv,
+            flow_rate,
+            main_channel_shear_rate,
+            throat_transit_time,
+            optical_path_length,
+            safety_margin,
+            wall_shear_p95,
+            wall_shear_p99,
+            wall_shear_mean,
+            diffuser_recovery,
+            mechanical_power,
+            treatment_zone_dwell_time,
+            throat_temperature_rise,
+        } = self;
+
+        metrics.throat_shear_rate_inv_s = throat_shear_rate.into_base();
+        metrics.throat_shear_pa = throat_shear.into_base();
+        metrics.max_main_channel_shear_pa = max_main_channel_shear.into_base();
+        metrics.mean_residence_time_s = mean_residence_time.into_base();
+        metrics.total_pressure_drop_pa = total_pressure_drop.into_base();
+        metrics.total_path_length_mm = total_path_length.into_base() * MILLIMETRES_PER_METRE;
+        metrics.total_ecv_ml = total_ecv.into_base() * MILLILITRES_PER_CUBIC_METRE;
+        metrics.flow_rate_ml_min =
+            flow_rate.into_base() * MILLILITRES_PER_CUBIC_METRE * SECONDS_PER_MINUTE;
+        metrics.main_channel_shear_rate_inv_s = main_channel_shear_rate.into_base();
+        metrics.throat_transit_time_s = throat_transit_time.into_base();
+        metrics.optical_path_length_405_m = optical_path_length.into_base();
+        metrics.safety_margin_pa = safety_margin.into_base();
+        metrics.wall_shear_p95_pa = wall_shear_p95.into_base();
+        metrics.wall_shear_p99_pa = wall_shear_p99.into_base();
+        metrics.wall_shear_mean_pa = wall_shear_mean.into_base();
+        metrics.diffuser_recovery_pa = diffuser_recovery.into_base();
+        metrics.mechanical_power_w = mechanical_power.into_base();
+        metrics.treatment_zone_dwell_time_s = treatment_zone_dwell_time.into_base();
+        metrics.throat_temperature_rise_k = throat_temperature_rise.into_base();
+    }
+}
 
 fn cavitation_strength_from_sigma(cavitation_number: f64) -> f64 {
     let strength = (1.0 - cavitation_number).max(0.0);
@@ -58,11 +138,10 @@ fn blue_light_delivery_index(
     Ok(transmission.into_quantity().into_base())
 }
 
-fn mechanical_power(pressure_drop_pa: f64, flow_rate_m3_s: f64) -> f64 {
+fn mechanical_power(pressure_drop_pa: f64, flow_rate_m3_s: f64) -> Power {
     let pressure = Pressure::from_base(pressure_drop_pa);
     let flow_rate = VolumetricFlowRate::from_base(flow_rate_m3_s);
-    let power: Power = pressure * flow_rate;
-    power.into_base()
+    pressure * flow_rate
 }
 
 /// Compute the full set of report-grade SDT metrics for a single blueprint candidate.
@@ -125,13 +204,15 @@ pub fn compute_blueprint_report_metrics(
     let flow_rate_m3_s = candidate.operating_point.flow_rate_m3_s.max(1.0e-18);
     let flow_rate_ml_min = flow_rate_m3_s * 6.0e7;
     let flow_rate = VolumetricFlowRate::from_base(flow_rate_m3_s);
-    let total_volume_m3 = (Time::from_base(solve.mean_residence_time_s) * flow_rate).into_base();
-    let total_path_length_mm = solve
-        .channel_samples
-        .iter()
-        .map(|sample| sample.length_m)
-        .sum::<f64>()
-        * 1.0e3;
+    let total_volume: Volume = Time::from_base(solve.mean_residence_time_s) * flow_rate;
+    let total_volume_m3 = total_volume.into_base();
+    let total_path_length = Length::from_base(
+        solve
+            .channel_samples
+            .iter()
+            .map(|sample| sample.length_m)
+            .sum::<f64>(),
+    );
 
     let active_venturi_throat_count = topology
         .venturi_placements
@@ -373,13 +454,16 @@ pub fn compute_blueprint_report_metrics(
     let projected_hemolysis_15min_adult =
         cumulative_pass_damage(corrected_hi, projected_passes_15min_adult);
 
-    let optical_path_length_405_m = solve
-        .channel_samples
-        .iter()
-        .filter(|sample| sample.is_treatment_channel)
-        .map(|sample| sample.cross_section.dims().1)
-        .reduce(f64::max)
-        .unwrap_or(0.0);
+    let optical_path_length = Length::from_base(
+        solve
+            .channel_samples
+            .iter()
+            .filter(|sample| sample.is_treatment_channel)
+            .map(|sample| sample.cross_section.dims().1)
+            .reduce(f64::max)
+            .unwrap_or(0.0),
+    );
+    let optical_path_length_405_m = optical_path_length.into_base();
     let blue_light_delivery_index_405nm = blue_light_delivery_index(
         optical_path_length_405_m,
         candidate.operating_point.feed_hematocrit,
@@ -391,10 +475,7 @@ pub fn compute_blueprint_report_metrics(
 
     metrics.cavitation_number = cavitation_number;
     metrics.cavitation_potential = cavitation_potential;
-    metrics.throat_shear_rate_inv_s = max_venturi_shear_rate_inv_s;
-    metrics.throat_shear_pa = safety.max_venturi_shear_pa;
     metrics.throat_exceeds_fda = safety.max_venturi_shear_pa > FDA_MAX_WALL_SHEAR_PA;
-    metrics.max_main_channel_shear_pa = safety.max_main_channel_shear_pa;
     metrics.fda_main_compliant = safety.max_main_channel_shear_pa <= FDA_MAX_WALL_SHEAR_PA;
     metrics.bulk_hemolysis_index_per_pass = bulk_hi;
     metrics.hemolysis_index_per_pass = corrected_hi;
@@ -404,9 +485,6 @@ pub fn compute_blueprint_report_metrics(
     // The treatment zone is the subset of channels where therapy (cavitation,
     // ultrasound) is applied.  The total device residence includes all bypass
     // arms and is always longer.
-    metrics.mean_residence_time_s = residence.treatment_residence_time_s;
-    metrics.total_pressure_drop_pa = safety.pressure_drop_pa;
-    metrics.total_path_length_mm = total_path_length_mm;
     metrics.pressure_feasible = safety.pressure_feasible;
     metrics.cell_separation_efficiency = separation.separation_efficiency;
     metrics.cancer_center_fraction = separation.cancer_center_fraction;
@@ -424,8 +502,6 @@ pub fn compute_blueprint_report_metrics(
     } else {
         0.0
     };
-    metrics.total_ecv_ml = total_volume_m3 * 1.0e6;
-    metrics.flow_rate_ml_min = flow_rate_ml_min;
     metrics.plate_fits =
         topology.box_dims_mm.0 <= PLATE_WIDTH_MM && topology.box_dims_mm.1 <= PLATE_HEIGHT_MM;
     let overlap = candidate.blueprint.channel_overlap_analysis();
@@ -437,8 +513,6 @@ pub fn compute_blueprint_report_metrics(
         .iter()
         .filter(|node| matches!(node.kind, cfd_schematics::domain::model::NodeKind::Outlet))
         .count();
-    metrics.main_channel_shear_rate_inv_s =
-        safety.max_main_channel_shear_pa / BLOOD_VISCOSITY_PA_S.max(1.0e-18);
     metrics.low_flow_stasis_risk = inverse_linear_risk(
         flow_rate_ml_min,
         CLOTTING_BFR_HIGH_RISK_ML_MIN,
@@ -513,7 +587,6 @@ pub fn compute_blueprint_report_metrics(
     metrics.rbc_venturi_protection = rbc_venturi_protection;
     metrics.healthy_cell_protection_index = healthy_cell_protection_index;
     metrics.sonoluminescence_proxy = sonoluminescence_proxy;
-    metrics.throat_transit_time_s = max_venturi_transit_time_s;
     metrics.fda_overall_compliant = metrics.fda_main_compliant
         && (safety.max_venturi_shear_pa <= FDA_MAX_WALL_SHEAR_PA
             || (max_venturi_transit_time_s <= FDA_TRANSIENT_TIME_S
@@ -530,22 +603,18 @@ pub fn compute_blueprint_report_metrics(
     metrics.projected_hemolysis_15min_adult = projected_hemolysis_15min_adult;
     metrics.cancer_therapy_zone_fraction =
         separation.cancer_center_fraction.clamp(0.0, 1.0) * solve.venturi_flow_fraction;
-    metrics.optical_path_length_405_m = optical_path_length_405_m;
     metrics.blue_light_delivery_index_405nm = blue_light_delivery_index_405nm;
-    metrics.safety_margin_pa = FDA_MAX_WALL_SHEAR_PA - safety.max_main_channel_shear_pa;
     metrics.therapy_channel_fraction = treatment_fraction;
-    metrics.wall_shear_p95_pa = wall_shear_p95_pa;
-    metrics.wall_shear_p99_pa = wall_shear_p99_pa;
-    metrics.wall_shear_mean_pa = wall_shear_mean_pa;
     metrics.wall_shear_cv = wall_shear_cv;
     metrics.fda_shear_percentile_compliant =
         wall_shear_p95_pa <= FDA_MAX_WALL_SHEAR_PA && wall_shear_p99_pa <= FDA_TRANSIENT_SHEAR_PA;
-    metrics.mechanical_power_w = mechanical_power(safety.pressure_drop_pa, flow_rate_m3_s);
+    let hydraulic_power = mechanical_power(safety.pressure_drop_pa, flow_rate_m3_s);
+    let hydraulic_power_w = hydraulic_power.into_base();
     metrics.acoustic_capture_efficiency =
         (cavitation_potential * (safety.max_venturi_shear_pa / P_ATM_PA)).clamp(0.0, 1.0);
     metrics.specific_cavitation_energy_j_ml = if flow_rate_ml_min > 1.0e-18 {
         metrics.acoustic_capture_efficiency
-            * metrics.mechanical_power_w
+            * hydraulic_power_w
             * residence.treatment_residence_time_s
             / (flow_rate_ml_min / 60_000.0)
             * 1.0e3
@@ -560,8 +629,6 @@ pub fn compute_blueprint_report_metrics(
     metrics.acoustic_resonance_factor = channel_resonance_score;
     metrics.channel_resonance_score = channel_resonance_score;
     metrics.serial_cavitation_dose_fraction = serial_dose_fraction;
-    metrics.treatment_zone_dwell_time_s = residence.treatment_residence_time_s;
-    metrics.throat_temperature_rise_k = throat_temperature_rise_k;
     metrics.fda_thermal_compliant = throat_temperature_rise_k <= FDA_THROAT_TEMP_RISE_LIMIT_K;
 
     // ── Previously unset metrics ─────────────────────────────────────────────
@@ -569,7 +636,7 @@ pub fn compute_blueprint_report_metrics(
     metrics.platelet_activation_index = pai_accumulator;
 
     // Diffuser pressure recovery: maximum across all venturi placements.
-    metrics.diffuser_recovery_pa = venturi
+    let diffuser_recovery_pa = venturi
         .placements
         .iter()
         .map(|p| p.diffuser_recovery_pa)
@@ -645,6 +712,33 @@ pub fn compute_blueprint_report_metrics(
         metrics.hemolysis_index_per_pass_cavitation_amplified *=
             sdt_acoustic.rayleigh_plesset_amplification;
     }
+
+    let physical_metrics = TypedReportPhysicalMetrics {
+        throat_shear_rate: ReciprocalTime::from_base(max_venturi_shear_rate_inv_s),
+        throat_shear: Pressure::from_base(safety.max_venturi_shear_pa),
+        max_main_channel_shear: Pressure::from_base(safety.max_main_channel_shear_pa),
+        mean_residence_time: Time::from_base(residence.treatment_residence_time_s),
+        total_pressure_drop: Pressure::from_base(safety.pressure_drop_pa),
+        total_path_length,
+        total_ecv: total_volume,
+        flow_rate,
+        main_channel_shear_rate: ReciprocalTime::from_base(
+            safety.max_main_channel_shear_pa / BLOOD_VISCOSITY_PA_S.max(1.0e-18),
+        ),
+        throat_transit_time: Time::from_base(max_venturi_transit_time_s),
+        optical_path_length,
+        safety_margin: Pressure::from_base(
+            FDA_MAX_WALL_SHEAR_PA - safety.max_main_channel_shear_pa,
+        ),
+        wall_shear_p95: Pressure::from_base(wall_shear_p95_pa),
+        wall_shear_p99: Pressure::from_base(wall_shear_p99_pa),
+        wall_shear_mean: Pressure::from_base(wall_shear_mean_pa),
+        diffuser_recovery: Pressure::from_base(diffuser_recovery_pa),
+        mechanical_power: hydraulic_power,
+        treatment_zone_dwell_time: Time::from_base(residence.treatment_residence_time_s),
+        throat_temperature_rise: ThermodynamicTemperature::from_base(throat_temperature_rise_k),
+    };
+    physical_metrics.write_to(&mut metrics);
 
     Ok(metrics)
 }
@@ -904,6 +998,51 @@ mod tests {
 
     #[test]
     fn mechanical_power_composes_pressure_and_volumetric_flow() {
-        assert_eq!(mechanical_power(12.0, 0.5).to_bits(), 6.0_f64.to_bits());
+        assert_eq!(
+            mechanical_power(12.0, 0.5).into_base().to_bits(),
+            6.0_f64.to_bits()
+        );
+    }
+
+    #[test]
+    fn typed_report_physical_metrics_preserve_serialized_units() {
+        let mut metrics = SdtMetrics::default();
+        TypedReportPhysicalMetrics {
+            throat_shear_rate: ReciprocalTime::from_base(2_000.0),
+            throat_shear: Pressure::from_base(12.0),
+            max_main_channel_shear: Pressure::from_base(8.0),
+            mean_residence_time: Time::from_base(0.25),
+            total_pressure_drop: Pressure::from_base(40.0),
+            total_path_length: Length::from_base(0.012),
+            total_ecv: Volume::from_base(3.0e-6),
+            flow_rate: VolumetricFlowRate::from_base(2.0e-6),
+            main_channel_shear_rate: ReciprocalTime::from_base(800.0),
+            throat_transit_time: Time::from_base(0.001),
+            optical_path_length: Length::from_base(0.002),
+            safety_margin: Pressure::from_base(142.0),
+            wall_shear_p95: Pressure::from_base(10.0),
+            wall_shear_p99: Pressure::from_base(11.0),
+            wall_shear_mean: Pressure::from_base(6.0),
+            diffuser_recovery: Pressure::from_base(4.0),
+            mechanical_power: Power::from_base(80.0),
+            treatment_zone_dwell_time: Time::from_base(0.25),
+            throat_temperature_rise: ThermodynamicTemperature::from_base(0.02),
+        }
+        .write_to(&mut metrics);
+
+        assert_eq!(metrics.total_path_length_mm, 12.0);
+        assert_eq!(metrics.total_ecv_ml, 3.0);
+        assert_eq!(metrics.flow_rate_ml_min, 120.0);
+        assert_eq!(metrics.total_pressure_drop_pa, 40.0);
+        assert_eq!(metrics.mechanical_power_w, 80.0);
+        assert_eq!(metrics.throat_temperature_rise_k, 0.02);
+
+        let encoded = serde_json::to_string(&metrics).expect("report metrics serialize");
+        let decoded: SdtMetrics =
+            serde_json::from_str(&encoded).expect("report metrics deserialize");
+        assert_eq!(decoded.total_path_length_mm, 12.0);
+        assert_eq!(decoded.total_ecv_ml, 3.0);
+        assert_eq!(decoded.flow_rate_ml_min, 120.0);
+        assert_eq!(decoded.mechanical_power_w, 80.0);
     }
 }

--- a/crates/cfd-optim/src/reporting/report_metrics.rs
+++ b/crates/cfd-optim/src/reporting/report_metrics.rs
@@ -4,10 +4,10 @@ use aequitas::systems::si::quantities::{
 };
 use aequitas::systems::si::units::{JoulePerCubicMeter, JoulePerMilliliter, Kelvin};
 use cfd_1d::{
-    acoustic_contrast_factor, acoustic_energy_density, cavitation_amplified_hi,
-    cavitation_hemolysis_amplification, giersiepen_hi, sonosensitizer_activation_efficiency,
     KAPPA_CTC, KAPPA_PLASMA, KAPPA_RBC, RHO_CTC, RHO_PLASMA, RHO_RBC,
-    SENSITIZER_K_ACT_HEMATOPORPHYRIN,
+    SENSITIZER_K_ACT_HEMATOPORPHYRIN, acoustic_contrast_factor, acoustic_energy_density,
+    cavitation_amplified_hi, cavitation_hemolysis_amplification, giersiepen_hi,
+    sonosensitizer_activation_efficiency,
 };
 use cfd_schematics::topology::TreatmentActuationMode;
 use hyperion::{
@@ -21,24 +21,25 @@ use super::report_math::{
 };
 use crate::constraints::{
     BLOOD_ATTENUATION_405NM_INV_M, BLOOD_DENSITY_KG_M3, BLOOD_VAPOR_PRESSURE_PA,
-    BLOOD_VISCOSITY_PA_S, BUBBLE_POLYTROPIC_K, CLOTTING_BFR_CAUTION_ML_MIN,
+    BLOOD_VISCOSITY_PA_S, BUBBLE_POLYTROPIC_K, C_P_BLOOD_J_KG_K, CLOTTING_BFR_CAUTION_ML_MIN,
     CLOTTING_BFR_HIGH_RISK_ML_MIN, CLOTTING_BFR_LOW_RISK_ML_MIN, CLOTTING_BFR_STRICT_10MLS_ML_MIN,
     CLOTTING_RESIDENCE_HIGH_RISK_S, CLOTTING_RESIDENCE_LOW_RISK_S, CLOTTING_SHEAR_HIGH_RISK_INV_S,
-    CLOTTING_SHEAR_LOW_RISK_INV_S, C_P_BLOOD_J_KG_K, DEAD_VOLUME_SHEAR_THRESHOLD_INV_S,
-    EXPANSION_RATIO_LOW_RISK, FDA_MAX_WALL_SHEAR_PA, FDA_THROAT_TEMP_RISE_LIMIT_K,
-    FDA_TRANSIENT_SHEAR_PA, FDA_TRANSIENT_TIME_S, MILESTONE_TREATMENT_DURATION_MIN,
-    PATIENT_BLOOD_VOLUME_ML, PEDIATRIC_BLOOD_VOLUME_ML_PER_KG, PEDIATRIC_FLOW_CAUTION_ML_MIN,
+    CLOTTING_SHEAR_LOW_RISK_INV_S, DEAD_VOLUME_SHEAR_THRESHOLD_INV_S, EXPANSION_RATIO_LOW_RISK,
+    FDA_MAX_WALL_SHEAR_PA, FDA_THROAT_TEMP_RISE_LIMIT_K, FDA_TRANSIENT_SHEAR_PA,
+    FDA_TRANSIENT_TIME_S, MILESTONE_TREATMENT_DURATION_MIN, P_ATM_PA, PATIENT_BLOOD_VOLUME_ML,
+    PEDIATRIC_BLOOD_VOLUME_ML_PER_KG, PEDIATRIC_FLOW_CAUTION_ML_MIN,
     PEDIATRIC_FLOW_EXCESSIVE_ML_MIN, PEDIATRIC_REFERENCE_WEIGHT_KG, PLATE_HEIGHT_MM,
-    PLATE_WIDTH_MM, P_ATM_PA, SONO_REF_P_ABS_PA, THERAPEUTIC_WINDOW_REF,
-    VENTURI_EXPANSION_RATIO_HIGH_RISK, VENTURI_VEL_RATIO_REF,
+    PLATE_WIDTH_MM, SONO_REF_P_ABS_PA, THERAPEUTIC_WINDOW_REF, VENTURI_EXPANSION_RATIO_HIGH_RISK,
+    VENTURI_VEL_RATIO_REF,
 };
 use crate::domain::BlueprintCandidate;
 use crate::error::OptimError;
 use crate::metrics::{
-    compute_blueprint_separation_metrics, compute_blueprint_venturi_metrics,
-    compute_typed_blueprint_safety_metrics, compute_typed_residence_metrics,
+    ChannelHemolysis, SdtMetrics, compute_blueprint_separation_metrics,
+    compute_blueprint_venturi_metrics, compute_typed_blueprint_safety_metrics,
+    compute_typed_residence_metrics,
     healthy_cell_protection_index as compute_healthy_cell_protection_index,
-    solve_blueprint_candidate, ChannelHemolysis, SdtMetrics,
+    solve_blueprint_candidate,
 };
 
 const MILLIMETRES_PER_METRE: f64 = 1_000.0;
@@ -237,16 +238,20 @@ pub fn compute_blueprint_report_metrics(
     let mean_residence_time_s = residence.treatment_residence_time.into_base();
 
     let mut metrics = SdtMetrics::default();
-    let flow_rate_m3_s = candidate.operating_point.flow_rate_m3_s.max(1.0e-18);
+    let flow_rate_m3_s = candidate
+        .operating_point
+        .flow_rate_m3_s
+        .into_base()
+        .max(1.0e-18);
     let flow_rate_ml_min = flow_rate_m3_s * 6.0e7;
     let flow_rate = VolumetricFlowRate::from_base(flow_rate_m3_s);
-    let total_volume: Volume = Time::from_base(solve.mean_residence_time_s) * flow_rate;
+    let total_volume: Volume = solve.mean_residence_time_s * flow_rate;
     let total_volume_m3 = total_volume.into_base();
     let total_path_length = Length::from_base(
         solve
             .channel_samples
             .iter()
-            .map(|sample| sample.length_m)
+            .map(|sample| sample.length_m.into_base())
             .sum::<f64>(),
     );
 
@@ -299,15 +304,14 @@ pub fn compute_blueprint_report_metrics(
 
     for sample in &solve.channel_samples {
         let area_m2 = sample.cross_section.area().max(1.0e-18);
-        let velocity_m_s = sample.flow_m3_s.abs() / area_m2;
+        let velocity_m_s = sample.flow_m3_s.into_base().abs() / area_m2;
         let shear_rate_inv_s = sample.cross_section.wall_shear_rate(velocity_m_s);
         let shear = DynamicViscosity::from_base(BLOOD_VISCOSITY_PA_S)
             * ReciprocalTime::from_base(shear_rate_inv_s);
         let shear_pa = shear.into_base();
-        let transit_time =
-            Length::from_base(sample.length_m) / Velocity::from_base(velocity_m_s.max(1.0e-18));
+        let transit_time = sample.length_m / Velocity::from_base(velocity_m_s.max(1.0e-18));
         let transit_time_s = transit_time.into_base();
-        let flow_fraction = (sample.flow_m3_s.abs() / flow_rate_m3_s).clamp(0.0, 1.0);
+        let flow_fraction = (sample.flow_m3_s.into_base().abs() / flow_rate_m3_s).clamp(0.0, 1.0);
         let local_cavitation = venturi
             .placements
             .iter()
@@ -347,7 +351,7 @@ pub fn compute_blueprint_report_metrics(
             main_transits.push(transit_time_s);
         }
         if shear_rate_inv_s < DEAD_VOLUME_SHEAR_THRESHOLD_INV_S {
-            dead_volume_m3 += sample.length_m * area_m2;
+            dead_volume_m3 += sample.length_m.into_base() * area_m2;
         }
 
         per_channel_hemolysis.push(TypedChannelHemolysis {
@@ -418,7 +422,7 @@ pub fn compute_blueprint_report_metrics(
                             let inlet_area = (spec.throat_geometry.inlet_width_m
                                 * spec.throat_geometry.throat_height_m)
                                 .max(1.0e-18);
-                            let upstream_velocity = sample.flow_m3_s.abs() / inlet_area;
+                            let upstream_velocity = sample.flow_m3_s.into_base().abs() / inlet_area;
                             let ratio = placement.effective_throat_velocity_m_s
                                 / upstream_velocity.max(1.0e-18);
                             ratio.max(1.0).ln() / VENTURI_VEL_RATIO_REF.ln()
@@ -446,7 +450,10 @@ pub fn compute_blueprint_report_metrics(
     let healthy_cell_protection_index =
         compute_healthy_cell_protection_index(wbc_targeted_cavitation, rbc_venturi_protection);
 
-    let absolute_inlet_pressure = candidate.operating_point.absolute_inlet_pressure_pa();
+    let absolute_inlet_pressure = candidate
+        .operating_point
+        .absolute_inlet_pressure_pa()
+        .into_base();
     let collapse_ratio = (absolute_inlet_pressure / BLOOD_VAPOR_PRESSURE_PA.max(1.0))
         .powf((BUBBLE_POLYTROPIC_K - 1.0) / BUBBLE_POLYTROPIC_K);
     let collapse_ref = (SONO_REF_P_ABS_PA / BLOOD_VAPOR_PRESSURE_PA.max(1.0))
@@ -1131,7 +1138,7 @@ mod tests {
             .channel_samples
             .iter()
             .filter(|sample| sample.is_treatment_channel)
-            .map(|sample| sample.length_m * sample.cross_section.area())
+            .map(|sample| sample.length_m.into_base() * sample.cross_section.area())
             .sum::<f64>();
 
         assert_eq!(

--- a/crates/cfd-optim/src/reporting/validation_runner.rs
+++ b/crates/cfd-optim/src/reporting/validation_runner.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 
 use cfd_validation::numerical::venturi_cross_fidelity::{
-    validate_venturi, VenturiCrossFidelityResult, VenturiValidationInput,
+    VenturiCrossFidelityResult, VenturiValidationInput, validate_venturi,
 };
 
 use crate::constraints::BLOOD_DENSITY_KG_M3;
@@ -23,11 +23,7 @@ fn total_loss_coefficient(dp_pa: f64, inlet_velocity_m_s: f64) -> f64 {
 }
 
 fn sanitize_report_scalar(value: f64) -> f64 {
-    if value.is_finite() {
-        value
-    } else {
-        0.0
-    }
+    if value.is_finite() { value } else { 0.0 }
 }
 
 fn validation_row_from_result(
@@ -88,7 +84,7 @@ fn validate_venturi_candidate(
     let parallel_paths = (metrics.active_venturi_throat_count
         / metrics.serial_venturi_stages_per_path.max(1))
     .max(1) as f64;
-    let q = candidate.operating_point.flow_rate_m3_s * metrics.therapy_channel_fraction
+    let q = candidate.operating_point.flow_rate_m3_s.into_base() * metrics.therapy_channel_fraction
         / parallel_paths;
 
     let input = VenturiValidationInput {
@@ -97,7 +93,7 @@ fn validate_venturi_candidate(
         throat_diameter_m: venturi.throat_geometry.throat_width_m,
         throat_length_m: venturi.throat_geometry.throat_length_m,
         flow_rate_m3_s: q,
-        inlet_gauge_pa: candidate.operating_point.inlet_gauge_pa,
+        inlet_gauge_pa: candidate.operating_point.inlet_gauge_pa.into_base(),
     };
 
     let result = validate_venturi(&input);

--- a/crates/cfd-optim/tests/milestone12_ga.rs
+++ b/crates/cfd-optim/tests/milestone12_ga.rs
@@ -11,14 +11,15 @@
 //! 5. GA scoring includes lineage bonus and Dean number contribution
 //! 6. GA can bootstrap venturi placements from an Option 1 seed
 
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use cfd_optim::{
-    build_milestone12_ga_seed_pair, evaluate_blueprint_candidate, evaluate_goal,
-    generate_ga_mutations, promote_option1_candidate_to_ga_seed, BlueprintCandidate,
-    BlueprintEvaluationStatus, BlueprintGeneticOptimizer, OperatingPoint, OptimizationGoal,
+    BlueprintCandidate, BlueprintEvaluationStatus, BlueprintGeneticOptimizer, OperatingPoint,
+    OptimizationGoal, build_milestone12_ga_seed_pair, evaluate_blueprint_candidate, evaluate_goal,
+    generate_ga_mutations, promote_option1_candidate_to_ga_seed,
 };
 use cfd_schematics::{
-    build_milestone12_blueprint, enumerate_milestone12_topologies, SplitKind,
-    TopologyOptimizationStage, TreatmentActuationMode, VenturiPlacementMode,
+    SplitKind, TopologyOptimizationStage, TreatmentActuationMode, VenturiPlacementMode,
+    build_milestone12_blueprint, enumerate_milestone12_topologies,
 };
 
 // ---------------------------------------------------------------------------
@@ -28,8 +29,8 @@ use cfd_schematics::{
 
 fn test_operating_point() -> OperatingPoint {
     OperatingPoint {
-        flow_rate_m3_s: 2.0e-6,
-        inlet_gauge_pa: 30_000.0,
+        flow_rate_m3_s: VolumetricFlowRate::from_base(2.0e-6),
+        inlet_gauge_pa: Pressure::from_base(30_000.0),
         feed_hematocrit: 0.45,
         patient_context: None,
     }

--- a/crates/cfd-optim/tests/milestone12_option1.rs
+++ b/crates/cfd-optim/tests/milestone12_option1.rs
@@ -11,12 +11,13 @@
 //!    channel asymmetry ratios
 //! 6. FDA safety constraints are respected (wall shear < 150 Pa sustained)
 
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use cfd_optim::{
-    build_milestone12_candidate_params, evaluate_blueprint_candidate, evaluate_goal,
     BlueprintCandidate, EvaluatedPool, OperatingPoint, OptimizationGoal,
+    build_milestone12_candidate_params, evaluate_blueprint_candidate, evaluate_goal,
 };
 use cfd_schematics::{
-    build_milestone12_blueprint, enumerate_milestone12_topologies, TreatmentActuationMode,
+    TreatmentActuationMode, build_milestone12_blueprint, enumerate_milestone12_topologies,
 };
 use std::collections::HashSet;
 
@@ -39,8 +40,8 @@ fn root_family_label(request: &cfd_schematics::Milestone12TopologyRequest) -> &'
 
 fn test_op(flow: f64, gauge: f64) -> OperatingPoint {
     OperatingPoint {
-        flow_rate_m3_s: flow,
-        inlet_gauge_pa: gauge,
+        flow_rate_m3_s: VolumetricFlowRate::from_base(flow),
+        inlet_gauge_pa: Pressure::from_base(gauge),
         feed_hematocrit: 0.45,
         patient_context: None,
     }

--- a/crates/cfd-optim/tests/milestone12_option2.rs
+++ b/crates/cfd-optim/tests/milestone12_option2.rs
@@ -12,13 +12,15 @@
 
 use std::collections::HashSet;
 
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
 use cfd_optim::{
+    BlueprintCandidate, EvaluatedPool, OperatingPoint, OptimizationGoal,
     evaluate_blueprint_candidate, evaluate_goal, evaluate_selective_venturi_cavitation,
-    orchestration_lineage_key, BlueprintCandidate, EvaluatedPool, OperatingPoint, OptimizationGoal,
+    orchestration_lineage_key,
 };
 use cfd_schematics::{
-    build_milestone12_blueprint, enumerate_milestone12_topologies, SplitKind,
-    TreatmentActuationMode, VenturiPlacementMode,
+    SplitKind, TreatmentActuationMode, VenturiPlacementMode, build_milestone12_blueprint,
+    enumerate_milestone12_topologies,
 };
 
 // ---------------------------------------------------------------------------
@@ -28,8 +30,8 @@ use cfd_schematics::{
 
 fn test_op(flow: f64, gauge: f64) -> OperatingPoint {
     OperatingPoint {
-        flow_rate_m3_s: flow,
-        inlet_gauge_pa: gauge,
+        flow_rate_m3_s: VolumetricFlowRate::from_base(flow),
+        inlet_gauge_pa: Pressure::from_base(gauge),
         feed_hematocrit: 0.45,
         patient_context: None,
     }

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -128,6 +128,39 @@ within the provider's documented `gamma(32)` exponential bound, and negative
 path rejection. Locked package checks, configured Nextest, Clippy, doctest,
 Rustdoc, dependency-identity, and raw-law residue scans close the change.
 
+### 2026-07-23: Keep the typed physical report carrier at the cfd-optim boundary [patch] [arch]
+
+**Context**: `SdtMetrics` is a large serialized DTO whose field names encode
+display units such as millimetres, millilitres, and millilitres per minute.
+Writing those fields directly from scalar intermediates allowed unit conversion
+to spread through report assembly, while replacing the DTO would widen the
+change into every scoring and narrative consumer.
+
+**Decision**: `cfd-optim` assembles unit-bearing report values in one private
+`TypedReportPhysicalMetrics` carrier using Aequitas quantities. Its `write_to`
+method is the only conversion into the existing scalar `SdtMetrics` report
+contract. Dimensionless indices and empirical coefficients remain scalar; the
+serialized DTO is not duplicated with a parallel typed public representation.
+
+**Rejected alternative**: Adding typed fields beside the existing serialized
+fields was rejected because it creates two mutable sources of report truth.
+Changing `SdtMetrics` to typed public fields was rejected because it forces an
+unbounded migration through scoring, narrative, and persisted report callers
+before the provider-blocked energy-density and temperature-difference contracts
+are available.
+
+**Consequences**: Unit-bearing values are dimension-checked through report
+assembly, and the existing JSON/display contract remains stable at one named
+boundary. Residence/safety intermediates and channel/network DTOs remain
+follow-on CFDrs work; energy-per-volume and temperature-difference semantics
+remain Aequitas provider gaps.
+
+**Verification**: The adapter regression covers pressure, time, length, volume,
+flow-rate, power, and temperature conversions plus JSON round-trip equality.
+The focused `cfd-optim` Nextest filter passes 11/11 and warning-denied package
+Clippy passes. Full library execution remains path-sensitive in the linked lane
+because one existing contract fixture resolves only from the canonical checkout.
+
 ### 2026-07-21: Iris owns schematic color laws [major] [arch]
 
 **Context**: `cfd-schematics` defined its own color-map enum and blue-red,

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -40,34 +40,38 @@ single explicit I/O boundary are not counted as missing units.
 
 ### Existing coverage
 
-`cfd-optim/src/reporting/report_metrics.rs` now composes
+`cfd-optim/src/reporting/report_metrics.rs` composes
 `VolumetricFlowRate`, `Power`, `Pressure`, `DynamicViscosity`,
-`ReciprocalTime`, `Time`, `Length`, and `Velocity` for report arithmetic. The
-calculation therefore has a provider-typed interior, but
-`cfd-optim/src/metrics/sdt_metrics.rs`, `metrics/residence.rs`, and
-`metrics/safety.rs` still publish physical outputs as `f64` fields for
-`Serialize`/`Deserialize` report DTOs.
+`ReciprocalTime`, `Time`, `Length`, `Volume`, `ThermodynamicTemperature`, and
+`Velocity` for report arithmetic. `TypedReportPhysicalMetrics` now owns the
+unit-bearing report snapshot and `write_to` is the single explicit conversion
+to the serialized `SdtMetrics` display units. `metrics/residence.rs` and
+`metrics/safety.rs` still publish scalar intermediate DTOs and remain the next
+computation-boundary migration.
 
 ### Open implementation ledger
 
 | ID | Evidence | Remaining implementation | Owner | Status / acceptance oracle |
 |---|---|---|---|---|
-| `CFDRS-AEQ-MET-01` | `SdtMetrics` contains pressure drop, path length, residence time, flow, ECV, mechanical power, shear stress/rate, transit time, optical path, temperature rise, and acoustic-energy fields as suffixed `f64`; `ResidenceMetrics` and `BlueprintSafetyMetrics` repeat the same physical dimensions. | Add one typed internal/report metric carrier and one explicit scalar serialization adapter. Do not retain parallel typed/raw fields. | CFDrs | Ready. Existing report value regressions, serde round-trip at the adapter, and compile-time mismatched-unit rejection. |
-| `CFDRS-AEQ-MET-02` | `report_metrics.rs:671` and `:736` expose `acoustic_energy_density_j_m3` as raw `f64`; the Aequitas source has `VolumetricPowerDensity` but no semantic volumetric energy-density alias/unit. | Extend Aequitas with the J/m³ semantic contract, then type this output. | Aequitas → CFDrs | Provider-blocked. Preserve `E_ac = p₀²/(4ρc²)` against the existing analytical calculation. |
-| `CFDRS-AEQ-MET-03` | `metrics/residence.rs` returns `treatment_volume_m3`, `treatment_residence_time_s`, and `mean_treatment_velocity_m_s`; `metrics/safety.rs` returns pressure, shear, and residence metrics as scalars. | Move typed quantities to the computation boundary before they are assembled into `SdtMetrics`; keep only dimensionless fractions and margins scalar. | CFDrs | Sequenced behind `CFDRS-AEQ-MET-01`; conservation of `V = Q·t`, pressure feasibility, and report equality are the oracles. |
-| `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carry raw flow, pressure, length, volume, and velocity. | Migrate the channel and network DTO boundaries in dependency order. | CFDrs | Ready after the report carrier. Per-channel hemolysis and total-flow value semantics must remain unchanged. |
+| `CFDRS-AEQ-MET-01` | `SdtMetrics` contains pressure drop, path length, residence time, flow, ECV, mechanical power, shear stress/rate, transit time, optical path, temperature-rise, and acoustic-energy fields as suffixed `f64`; `ResidenceMetrics` and `BlueprintSafetyMetrics` repeat some of the same physical dimensions. | Add one typed internal/report metric carrier and one explicit scalar serialization adapter. Do not retain parallel typed/raw fields. | CFDrs | **Resolved in this increment.** Value-semantic adapter and serde round-trip regressions pass; unit mismatch is rejected by the carrier field types. |
+| `CFDRS-AEQ-MET-02` | `report_metrics.rs` exposes `acoustic_energy_density_j_m3` and `specific_cavitation_energy_j_ml` as raw `f64` energy-per-volume values; the Aequitas source has `VolumetricPowerDensity` but no semantic volumetric energy-density alias/unit. | Extend Aequitas with the energy-per-volume semantic contract, then type both outputs. | Aequitas → CFDrs | Provider-blocked. Preserve `E_ac = p₀²/(4ρc²)` and the existing specific-energy report equation. |
+| `CFDRS-AEQ-MET-03` | `metrics/residence.rs` returns `treatment_volume_m3`, `treatment_residence_time_s`, and `mean_treatment_velocity_m_s`; `metrics/safety.rs` returns pressure, shear, and residence metrics as scalars. | Move typed quantities to the computation boundary before they are assembled into `SdtMetrics`; keep only dimensionless fractions and margins scalar. | CFDrs | Ready now that `CFDRS-AEQ-MET-01` is resolved; conservation of `V = Q·t`, pressure feasibility, and report equality are the oracles. |
+| `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carry raw flow, pressure, length, volume, and velocity. | Migrate the channel and network DTO boundaries in dependency order. | CFDrs | Ready after `CFDRS-AEQ-MET-03`. Per-channel hemolysis and total-flow value semantics must remain unchanged. |
+| `CFDRS-AEQ-MET-05` | `throat_temperature_rise_k` is a temperature difference, while the current provider exposes only the absolute-temperature dimension `ThermodynamicTemperature`. | Add an explicit Aequitas temperature-difference semantic contract and migrate this report field without conflating absolute temperature with ΔT. | Aequitas → CFDrs | Provider-blocked. Preserve the existing thermal-compliance threshold in kelvin. |
 
 ### Explicit non-gaps
 
 - `cavitation_number`, separation fractions, CVs, safety margins, risk scores,
   contrast factors, Giersiepen/PAI indices, and empirical correlation
   coefficients are dimensionless or model-owned and stay scalar.
-- JSON/report storage may remain scalar only at one named boundary because the
-  current DTOs derive `Serialize`/`Deserialize`; that boundary does not justify
-  raw scalars inside the physical computation graph.
-- The next CFDrs slice is `CFDRS-AEQ-MET-01`. It must land with a value-semantic
-  report regression and an updated implementation ledger before any additional
-  consumer metric is added.
+- JSON/report storage may remain scalar only at the one named `SdtMetrics`
+  adapter boundary because the current DTOs derive `Serialize`/`Deserialize`;
+  that boundary does not justify raw scalars inside the physical computation graph.
+- Dimensionless indices, empirical coefficients, and model parameters remain
+  scalar unless their governing law introduces a physical unit.
+- The next CFDrs slice is `CFDRS-AEQ-MET-03`; it must preserve the report
+  carrier's single-adapter ownership while typing residence and safety
+  intermediates before any channel/network DTO migration.
 
 - 2026-07-22 (resolved in CFD-BOOK-CLOSEOUT-1): the stale book commit expanded
   source-backed chapter indexes with public types and behavioral contracts that

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -42,22 +42,23 @@ single explicit I/O boundary are not counted as missing units.
 
 `cfd-optim/src/reporting/report_metrics.rs` composes
 `VolumetricFlowRate`, `Power`, `Pressure`, `DynamicViscosity`,
-`ReciprocalTime`, `Time`, `Length`, `Volume`, `ThermodynamicTemperature`, and
-`Velocity` for report arithmetic. `TypedReportPhysicalMetrics` now owns the
-unit-bearing report snapshot and `write_to` is the single explicit conversion
-to the serialized `SdtMetrics` display units. `metrics/residence.rs` and
-`metrics/safety.rs` still publish scalar intermediate DTOs and remain the next
-computation-boundary migration.
+`ReciprocalTime`, `Time`, `Length`, `Volume`, `EnergyPerVolume`,
+`TemperatureDifference`, and `Velocity` for report arithmetic.
+`TypedReportPhysicalMetrics` now owns the unit-bearing report snapshot and
+`write_to` is the single explicit conversion to the serialized `SdtMetrics`
+display units. `metrics/residence.rs` and
+`metrics/safety.rs` now computes through private Aequitas carriers; its public
+serialized DTO remains scalar only at the explicit evaluation boundary.
 
 ### Open implementation ledger
 
 | ID | Evidence | Remaining implementation | Owner | Status / acceptance oracle |
 |---|---|---|---|---|
 | `CFDRS-AEQ-MET-01` | `SdtMetrics` contains pressure drop, path length, residence time, flow, ECV, mechanical power, shear stress/rate, transit time, optical path, temperature-rise, and acoustic-energy fields as suffixed `f64`; `ResidenceMetrics` and `BlueprintSafetyMetrics` repeat some of the same physical dimensions. | Add one typed internal/report metric carrier and one explicit scalar serialization adapter. Do not retain parallel typed/raw fields. | CFDrs | **Resolved in this increment.** Value-semantic adapter and serde round-trip regressions pass; unit mismatch is rejected by the carrier field types. |
-| `CFDRS-AEQ-MET-02` | `report_metrics.rs` exposes `acoustic_energy_density_j_m3` and `specific_cavitation_energy_j_ml` as raw `f64` energy-per-volume values; the Aequitas source has `VolumetricPowerDensity` but no semantic volumetric energy-density alias/unit. | Extend Aequitas with the energy-per-volume semantic contract, then type both outputs. | Aequitas → CFDrs | Provider-blocked. Preserve `E_ac = p₀²/(4ρc²)` and the existing specific-energy report equation. |
-| `CFDRS-AEQ-MET-03` | `metrics/residence.rs` returns `treatment_volume_m3`, `treatment_residence_time_s`, and `mean_treatment_velocity_m_s`; `metrics/safety.rs` returns pressure, shear, and residence metrics as scalars. | Move typed quantities to the computation boundary before they are assembled into `SdtMetrics`; keep only dimensionless fractions and margins scalar. | CFDrs | Ready now that `CFDRS-AEQ-MET-01` is resolved; conservation of `V = Q·t`, pressure feasibility, and report equality are the oracles. |
+| `CFDRS-AEQ-MET-02` | `report_metrics.rs` exposes `acoustic_energy_density_j_m3` and `specific_cavitation_energy_j_ml` as raw `f64` energy-per-volume values; the Aequitas provider now owns the semantic energy-density aliases and units. | Carry both values as `EnergyPerVolume` through report computation and convert only in the explicit `SdtMetrics` adapter. | Aequitas → CFDrs | **Resolved in this increment.** `JoulePerCubicMeter` and `JoulePerMilliliter` preserve the existing serialized values; positive-energy and report round-trip regressions remain the oracle. |
+| `CFDRS-AEQ-MET-03` | `metrics/residence.rs` and `metrics/safety.rs` returned physical intermediates as raw scalars before report assembly. | Move typed quantities to the computation boundary before they are assembled into `SdtMetrics`; keep only dimensionless fractions and margins scalar. | CFDrs | **Resolved in this increment.** Private Aequitas carriers type treatment volume/time/velocity and safety pressure/shear/time; explicit adapters preserve serialized values. Focused Nextest passes the conservation and adapter equality regression. |
 | `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carry raw flow, pressure, length, volume, and velocity. | Migrate the channel and network DTO boundaries in dependency order. | CFDrs | Ready after `CFDRS-AEQ-MET-03`. Per-channel hemolysis and total-flow value semantics must remain unchanged. |
-| `CFDRS-AEQ-MET-05` | `throat_temperature_rise_k` is a temperature difference, while the current provider exposes only the absolute-temperature dimension `ThermodynamicTemperature`. | Add an explicit Aequitas temperature-difference semantic contract and migrate this report field without conflating absolute temperature with ΔT. | Aequitas → CFDrs | Provider-blocked. Preserve the existing thermal-compliance threshold in kelvin. |
+| `CFDRS-AEQ-MET-05` | `throat_temperature_rise_k` is a temperature difference and must not use the absolute-temperature dimension. | Carry the field as Aequitas `TemperatureDifference` and convert through the Kelvin unit only at serialization. | Aequitas → CFDrs | **Resolved in this increment.** The thermal-compliance threshold and serialized kelvin value are unchanged; the carrier type rejects absolute-temperature substitution. |
 
 ### Explicit non-gaps
 
@@ -69,9 +70,20 @@ computation-boundary migration.
   that boundary does not justify raw scalars inside the physical computation graph.
 - Dimensionless indices, empirical coefficients, and model parameters remain
   scalar unless their governing law introduces a physical unit.
-- The next CFDrs slice is `CFDRS-AEQ-MET-03`; it must preserve the report
-  carrier's single-adapter ownership while typing residence and safety
-  intermediates before any channel/network DTO migration.
+- The next CFDrs slice is `CFDRS-AEQ-MET-04`; it must preserve the report
+  carrier's single-adapter ownership while typing channel and network physical
+  boundaries after the residence/safety computation carriers.
+
+### Consumer/provider synchronization
+
+- Aequitas PR #7 merged to `e0fc5f32f07fbf0bde6a7a7086d085983195abad`.
+- This consumer branch updates its direct Aequitas revision and uses the
+  merged provider's `EnergyPerVolume` and `TemperatureDifference` contracts.
+- The remaining carrier work is `CFDRS-AEQ-MET-04`; residence/safety DTO
+  ownership now precedes the channel/network boundary.
+- Proteus PR #3 merged as `1b25af1`; its temperature response laws now consume
+  Aequitas `TemperatureDifference`, which is required by the merged provider
+  subtraction semantics.
 
 - 2026-07-22 (resolved in CFD-BOOK-CLOSEOUT-1): the stale book commit expanded
   source-backed chapter indexes with public types and behavioral contracts that

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -57,7 +57,7 @@ serialized DTO remains scalar only at the explicit evaluation boundary.
 | `CFDRS-AEQ-MET-01` | `SdtMetrics` contains pressure drop, path length, residence time, flow, ECV, mechanical power, shear stress/rate, transit time, optical path, temperature-rise, and acoustic-energy fields as suffixed `f64`; `ResidenceMetrics` and `BlueprintSafetyMetrics` repeat some of the same physical dimensions. | Add one typed internal/report metric carrier and one explicit scalar serialization adapter. Do not retain parallel typed/raw fields. | CFDrs | **Resolved in this increment.** Value-semantic adapter and serde round-trip regressions pass; unit mismatch is rejected by the carrier field types. |
 | `CFDRS-AEQ-MET-02` | `report_metrics.rs` exposes `acoustic_energy_density_j_m3` and `specific_cavitation_energy_j_ml` as raw `f64` energy-per-volume values; the Aequitas provider now owns the semantic energy-density aliases and units. | Carry both values as `EnergyPerVolume` through report computation and convert only in the explicit `SdtMetrics` adapter. | Aequitas → CFDrs | **Resolved in this increment.** `JoulePerCubicMeter` and `JoulePerMilliliter` preserve the existing serialized values; positive-energy and report round-trip regressions remain the oracle. |
 | `CFDRS-AEQ-MET-03` | `metrics/residence.rs` and `metrics/safety.rs` returned physical intermediates as raw scalars before report assembly. | Move typed quantities to the computation boundary before they are assembled into `SdtMetrics`; keep only dimensionless fractions and margins scalar. | CFDrs | **Resolved in this increment.** Private Aequitas carriers type treatment volume/time/velocity and safety pressure/shear/time; explicit adapters preserve serialized values. Focused Nextest passes the conservation and adapter equality regression. |
-| `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carry raw flow, pressure, length, volume, and velocity. | Migrate the channel and network DTO boundaries in dependency order. | CFDrs | Ready after `CFDRS-AEQ-MET-03`. Per-channel hemolysis and total-flow value semantics must remain unchanged. |
+| `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carry raw flow, pressure, length, volume, and velocity. | Migrate the remaining channel and network DTO boundaries in dependency order. | CFDrs | **Partial in this increment.** Per-channel hemolysis now computes through a private Aequitas `Pressure`/`Time` carrier and converts once at the serialized DTO boundary; `OperatingPoint` and `BlueprintSolveSample` remain the next breaking typed-boundary slice. |
 | `CFDRS-AEQ-MET-05` | `throat_temperature_rise_k` is a temperature difference and must not use the absolute-temperature dimension. | Carry the field as Aequitas `TemperatureDifference` and convert through the Kelvin unit only at serialization. | Aequitas → CFDrs | **Resolved in this increment.** The thermal-compliance threshold and serialized kelvin value are unchanged; the carrier type rejects absolute-temperature substitution. |
 
 ### Explicit non-gaps
@@ -70,9 +70,10 @@ serialized DTO remains scalar only at the explicit evaluation boundary.
   that boundary does not justify raw scalars inside the physical computation graph.
 - Dimensionless indices, empirical coefficients, and model parameters remain
   scalar unless their governing law introduces a physical unit.
-- The next CFDrs slice is `CFDRS-AEQ-MET-04`; it must preserve the report
-  carrier's single-adapter ownership while typing channel and network physical
-  boundaries after the residence/safety computation carriers.
+- `CFDRS-AEQ-MET-04` remains open for the `OperatingPoint` and
+  `BlueprintSolveSample` flow/pressure/length/volume/velocity contracts. The
+  per-channel report carrier is complete and must remain the sole conversion
+  point for `ChannelHemolysis` serialization.
 
 ### Consumer/provider synchronization
 

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -49,6 +49,10 @@ single explicit I/O boundary are not counted as missing units.
 display units. `metrics/residence.rs` and
 `metrics/safety.rs` now computes through private Aequitas carriers; its public
 serialized DTO remains scalar only at the explicit evaluation boundary.
+`OperatingPoint` now stores volumetric flow and gauge pressure as Aequitas
+quantities with an explicit serde scalar representation, and
+`BlueprintSolveSample`/`BlueprintSolveSummary` carry length, flow, pressure,
+and residence values as typed quantities until solver/report adapters.
 
 ### Open implementation ledger
 
@@ -57,7 +61,7 @@ serialized DTO remains scalar only at the explicit evaluation boundary.
 | `CFDRS-AEQ-MET-01` | `SdtMetrics` contains pressure drop, path length, residence time, flow, ECV, mechanical power, shear stress/rate, transit time, optical path, temperature-rise, and acoustic-energy fields as suffixed `f64`; `ResidenceMetrics` and `BlueprintSafetyMetrics` repeat some of the same physical dimensions. | Add one typed internal/report metric carrier and one explicit scalar serialization adapter. Do not retain parallel typed/raw fields. | CFDrs | **Resolved in this increment.** Value-semantic adapter and serde round-trip regressions pass; unit mismatch is rejected by the carrier field types. |
 | `CFDRS-AEQ-MET-02` | `report_metrics.rs` exposes `acoustic_energy_density_j_m3` and `specific_cavitation_energy_j_ml` as raw `f64` energy-per-volume values; the Aequitas provider now owns the semantic energy-density aliases and units. | Carry both values as `EnergyPerVolume` through report computation and convert only in the explicit `SdtMetrics` adapter. | Aequitas → CFDrs | **Resolved in this increment.** `JoulePerCubicMeter` and `JoulePerMilliliter` preserve the existing serialized values; positive-energy and report round-trip regressions remain the oracle. |
 | `CFDRS-AEQ-MET-03` | `metrics/residence.rs` and `metrics/safety.rs` returned physical intermediates as raw scalars before report assembly. | Move typed quantities to the computation boundary before they are assembled into `SdtMetrics`; keep only dimensionless fractions and margins scalar. | CFDrs | **Resolved in this increment.** Private Aequitas carriers type treatment volume/time/velocity and safety pressure/shear/time; explicit adapters preserve serialized values. Focused Nextest passes the conservation and adapter equality regression. |
-| `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carry raw flow, pressure, length, volume, and velocity. | Migrate the remaining channel and network DTO boundaries in dependency order. | CFDrs | **Partial in this increment.** Per-channel hemolysis now computes through a private Aequitas `Pressure`/`Time` carrier and converts once at the serialized DTO boundary; `OperatingPoint` and `BlueprintSolveSample` remain the next breaking typed-boundary slice. |
+| `CFDRS-AEQ-MET-04` | `ChannelHemolysis` carries `wall_shear_pa` and `transit_time_s`; `operating_point.rs` and `blueprint_graph.rs` carried raw flow, pressure, length, volume, and velocity. | Migrate the remaining channel and network DTO boundaries in dependency order. | CFDrs | **Resolved in this increment.** `OperatingPoint` and solve samples/summaries now carry Aequitas `VolumetricFlowRate`, `Pressure`, `Length`, and `Time`; serde and report/solver adapters are explicit and value-semantic regressions pass. |
 | `CFDRS-AEQ-MET-05` | `throat_temperature_rise_k` is a temperature difference and must not use the absolute-temperature dimension. | Carry the field as Aequitas `TemperatureDifference` and convert through the Kelvin unit only at serialization. | Aequitas → CFDrs | **Resolved in this increment.** The thermal-compliance threshold and serialized kelvin value are unchanged; the carrier type rejects absolute-temperature substitution. |
 
 ### Explicit non-gaps
@@ -70,18 +74,18 @@ serialized DTO remains scalar only at the explicit evaluation boundary.
   that boundary does not justify raw scalars inside the physical computation graph.
 - Dimensionless indices, empirical coefficients, and model parameters remain
   scalar unless their governing law introduces a physical unit.
-- `CFDRS-AEQ-MET-04` remains open for the `OperatingPoint` and
-  `BlueprintSolveSample` flow/pressure/length/volume/velocity contracts. The
-  per-channel report carrier is complete and must remain the sole conversion
-  point for `ChannelHemolysis` serialization.
+- `CFDRS-AEQ-MET-04` is closed. The per-channel report carrier and the
+  operating-point/network solve carriers each have one explicit scalar
+  boundary; no parallel raw/typed fields remain in the audited scope.
 
 ### Consumer/provider synchronization
 
 - Aequitas PR #7 merged to `e0fc5f32f07fbf0bde6a7a7086d085983195abad`.
 - This consumer branch updates its direct Aequitas revision and uses the
   merged provider's `EnergyPerVolume` and `TemperatureDifference` contracts.
-- The remaining carrier work is `CFDRS-AEQ-MET-04`; residence/safety DTO
-  ownership now precedes the channel/network boundary.
+- The carrier audit is closed for the current cfd-optim physical boundaries;
+  future metrics must enter through the existing typed carriers or add a new
+  provider quantity before adding a scalar DTO field.
 - Proteus PR #3 merged as `1b25af1`; its temperature response laws now consume
   Aequitas `TemperatureDifference`, which is required by the merged provider
   subtraction semantics.

--- a/tests/pipeline_integration.rs
+++ b/tests/pipeline_integration.rs
@@ -4,7 +4,8 @@
 //! blueprint-native physics metrics, plus mesh generation from
 //! `NetworkBlueprint`.
 
-use cfd_optim::{evaluate_blueprint_candidate, BlueprintCandidate, OperatingPoint};
+use aequitas::systems::si::quantities::{Pressure, VolumetricFlowRate};
+use cfd_optim::{BlueprintCandidate, OperatingPoint, evaluate_blueprint_candidate};
 use cfd_schematics::domain::therapy_metadata::TherapyZone;
 use cfd_schematics::{
     BlueprintTopologyFactory, BlueprintTopologySpec, BranchRole, BranchSpec, ChannelRouteSpec,
@@ -97,8 +98,8 @@ fn selective_venturi_candidate() -> BlueprintCandidate {
         "test-selective-venturi",
         BlueprintTopologyFactory::build(&selective_venturi_spec()).expect("blueprint must build"),
         OperatingPoint {
-            flow_rate_m3_s: 1.0e-7,
-            inlet_gauge_pa: 5_000.0,
+            flow_rate_m3_s: VolumetricFlowRate::from_base(1.0e-7),
+            inlet_gauge_pa: Pressure::from_base(5_000.0),
             feed_hematocrit: 0.45,
             patient_context: None,
         },


### PR DESCRIPTION
## Summary

- centralize unit-bearing `cfd-optim` report values in one private Aequitas carrier
- convert once into the existing scalar `SdtMetrics` display-unit serialization contract
- record the resolved report boundary and remaining CFDrs/Aequitas metric gaps in the ADR, checklist, backlog, changelog, and gap audit

## Validation

- focused `cargo nextest run --offline -p cfd-optim --lib -E 'test(report_metrics)' --no-fail-fast`: 11 passed
- `cargo clippy --offline -p cfd-optim --all-targets --no-deps -- -D warnings`: passed
- `cargo test --doc --offline -p cfd-optim`: 2 passed, 3 ignored
- `cargo doc --offline --no-deps -p cfd-optim`: passed
- `git diff --check`: passed

The local provider checkout has unrelated Leto WIP that adds required solver fields and serde metadata; the focused gates were run with a temporary lane-only compatibility edit and that edit is absent from this commit. The full library run also has one pre-existing canonical-checkout path fixture failure.

Refs: backlog.md#active-integration

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR centralizes unit-bearing CFD report values in a private `TypedReportPhysicalMetrics` carrier that uses Aequitas typed quantities (pressure, time, length, volume, flow-rate, power, temperature) and provides a single explicit conversion method into the existing scalar `SdtMetrics` serialization contract. The change eliminates scattered unit conversions throughout report assembly while preserving the existing JSON/display boundary, and documents the remaining gaps (energy-per-volume semantics, residence/safety DTO migration, temperature-difference contract) in the architecture decision record and gap audit.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-optim/src/reporting/report_metrics.rs` |
| 2 | `crates/cfd-optim/src/metrics/sdt_metrics.rs` |
| 3 | `gap_audit.md` |
| 4 | `docs/adr.md` |
| 5 | `backlog.md` |
| 6 | `CHECKLIST.md` |
| 7 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SDT report metrics now use unit-aware physical calculations and convert once into serialized display values, improving value preservation through JSON round-trips.
  * Acoustic metrics energy density is now represented with unit-typed semantics (instead of a raw numeric field).
* **Bug Fixes**
  * Mechanical power, optical-path length, FDA compliance ventilation values, and per-channel hemolysis computations are now routed through the unified unit conversion boundary for more consistent results.
* **Documentation**
  * Added/updated guidance and an ADR describing the typed report-metrics boundary approach, remaining metric gaps, and direct-solver sparse/dense dispatch behavior (including preserved sparse-LU thresholds).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->