### PR TITLE
docs(cfdrs-math): Migrate direct_solver doc to ADR 0031 real sparse LU (ATLAS-CFDRS-LETO-SPARSE-MIGRATION-001 partial)

### DIFF
--- a/crates/cfd-math/src/linear_solver/direct_solver.rs
+++ b/crates/cfd-math/src/linear_solver/direct_solver.rs
@@ -1,10 +1,25 @@
 //! Direct sparse solver for linear systems.
 //!
 //! Uses [`leto_ops::SparseLuSolver`] — the atlas-native sparse direct solver
-//! backed by dense partial-pivoting LU — for systems up to `max_size`. The
-//! dense LU path in `leto-ops` serves as both the primary sparse solver and
-//! the fallback, eliminating the external `rsparse` dependency. The primary
-//! path preserves native Leto array ownership across the provider boundary.
+//! — for systems up to `max_size`. Per ADR 0031 the upstream solver dispatches
+//! between two paths:
+//!
+//! - **Dense path** (matrices with `n ≤ small_switch=32` or `nnz/n² ≥
+//!   density_threshold=0.1`): the CSR input is expanded to dense storage and
+//!   forwarded to the SSOT dense partial-pivoting LU (`lu_decompose`).
+//! - **Sparse path** (other matrices): the CSR input is converted to CSC and
+//!   factorised by the real left-looking symbolic + numeric sparse LU.
+//!   The symbolic phase runs the sequential Gilbert–Peierls reach
+//!   (Davis 2006 §6.1); the numeric phase performs a slot-indexed
+//!   left-looking factorisation. If partial pivoting is required (the
+//!   symbolic convention alone produces a numerically broken factor),
+//!   the sparse path transparently falls back to the dense path internally.
+//!
+//! The CFDrs-side `dense_threshold` retry below catches the orthogonal
+//! case where the upstream solver refuses on the `max_size` cap and the
+//! matrix is small enough to attempt a dense direct solve through the
+//! `dense_bridge` provider — a CFDrs user-intent safety net,
+//! not a duplicate of the upstream internal fallback.
 //!
 //! # Theorem — LU Factorisation Uniqueness
 //!
@@ -25,8 +40,11 @@ use super::dense_bridge::solve_leto_csr_with_leto_dense_array;
 pub struct DirectSparseSolver {
     /// Maximum system size (number of rows) to attempt with direct solve.
     pub max_size: usize,
-    /// Ordering strategy (reserved for API compatibility; the atlas-native solver
-    /// uses partial-column pivoting regardless of this value).
+    /// Ordering strategy (reserved for API compatibility; the atlas-native
+    /// solver performs natural column ordering for the sparse path and
+    /// partial pivoting for the dense path — this field does not affect
+    /// either dispatch). Tracked for AMD fill-reducing ordering per
+    /// `ATLAS-LETO-OPS-AMD-ORDERING-001`.
     pub ordering: i8,
     /// Pivot tolerance for LU factorization.
     pub pivot_tolerance: f64,
@@ -71,6 +89,7 @@ impl DirectSparseSolver {
         let atlas_solver = LetoCsrLuSolver {
             max_size: self.max_size,
             pivot_tolerance: self.pivot_tolerance,
+            ..Default::default()
         };
 
         match atlas_solver.solve_view(matrix, &rhs.view()) {


### PR DESCRIPTION
## Summary

Sync the `DirectSparseSolver` module doc with the real CSC sparse LU that landed at leto `687b670` via PR #74 (ADR 0031). The pre-merge module doc claimed the atlas-native sparse solver was "backed by dense partial-pivoting LU" — that misnomer was the same root cause filed for the Session 13 `CFDRS-PERF-SLOW-001` timeout closure and is now stale per ADR 0031.

## Changes

- `crates/cfd-math/src/linear_solver/direct_solver.rs` module doc:
  - Describes the real CSC sparse LU per ADR 0031: dispatch between dense path (`n ≤ small_switch=32` or `nnz/n² ≥ density_threshold=0.1`) and real CSC sparse LU path (Gilbert–Peierls symbolic reach per Davis 2006 §6.1 + slot-indexed left-looking numeric factorization with internal dense fallback when partial pivoting is required).
  - Documents the CFDrs-side `dense_threshold=1024` retry as the orthogonal catch case for the `max_size`-cap + small-`n` user-intent safety net (NOT a duplicate of the upstream internal fallback).
- `ordering` field doc corrected: the atlas-native solver performs natural column ordering for the sparse path and partial pivoting for the dense path. Field reserved for the AMD fill-reducing ordering follow-up `ATLAS-LETO-OPS-AMD-ORDERING-001`.
- Convergence composition: peer's pending `..Default::default()` adaptation to `LetoCsrLuSolver { max_size, pivot_tolerance, .. }` is preserved — that adapts CFDrs to the upstream `SparseLuSolver` struct expansion (`small_switch` + `density_threshold` fields per ADR 0031) required for the file to compile against merged leto origin/main `687b670`.

## Verification

Verified before commit on the CFDrs local `main` HEAD (peer's unpushed `2686b86d` + peer's dirty working-tree Cargo.lock + peer's WIP leto checkout at `406497a` which is a descendant of merged `687b670`):

- `cargo check -p cfd-math` Finished clean (14.6s after build-cache lock wait)
- `cargo nextest run -p cfd-math --no-fail-fast -E 'test(direct_solver) | test(dense_lu_fallback)'` 4/4 PASS in 0.193s:
  - `direct_solver_solves_small_system` 0.169s
  - `direct_solver_singular_system_does_not_panic` 0.161s
  - `direct_solver_falls_back_to_dense_for_small_system_exceeding_atlas_limit` 0.155s (validates the CFDrs-side `dense_threshold=1024` retry safety net for the `max_size`-cap + small-`n` case — preserved by this commit)
  - `dense_lu_fallback_uses_leto_provider` 0.190s (validates the `dense_bridge` path used by both `direct_solver.rs` retry and multigrid `cycles.rs` coarsest-level solve)

**Verification limit (truthful per verification_policy):** isolated cherry-picked-onto-`origin/main` build could not be verified because the CFDrs `origin/main` baseline Cargo.lock pin for proteus at `bb51ac4` does not currently compile against the local eunomia checkout at `f6cd644` — `proteus/src/constitutive/temperature/law.rs:170` expected `AbsoluteTemperatureSemantics`, found `TemperatureDifferenceSemantics`. This is a pre-existing stale-pin issue that peer's CFDrs WIP Cargo.lock adjustments (outside this slice's scope) address. The doc-only diff carries zero semantic risk; the verification above on the dirty-tree-with-peer-WIP passed clean.

## Acceptance (this partial slice of `ATLAS-CFDRS-LETO-SPARSE-MIGRATION-001`)

1. ✅ `direct_solver.rs` no longer documents itself as "atlas-native sparse direct solver backed by dense partial-pivoting LU" — stale misnomer removed.
2. ⏳ Partial — cfd-3d end-to-end re-verification of `validate_poiseuille_flow` (PR #311 root-caused fix) under the new upstream sparse LU path is DEFERRED: cfd-3d has heavy peer-WIP (`trifurcation/solver.rs` dirty); will re-profile post peer integration.
3. ⏳ Partial — `direct_threshold` field assessment deferred: the CFDrs-side `dense_threshold=1024` retry is preserved as a user-intent safety net; ADR 0031 functional analysis shows it's orthogonal to (not redundant with) the upstream internal fallback.

## Out of scope

Peer-held WIP, left unstaged in working tree per `concurrent_agents` disjoint-scope rule:
- `cfd-math/src/lib.rs` SSOT re-exports of `leto_ops` iterative/`interp`/`fd`/`quadrature` (peer's consolidation work per the user directive to consolidate math redundancy into leto for SSOT)
- `crates/cfd-math/src/lib.rs` `quadrature_rules` doctest path-mismatch (peer doctest bug recorded as watchpoint — NOT this slice's scope per integrity "do not fix unrelated bugs outside scope")
- `cfd-math/src/error.rs` `From<LetoError>` bridge doc
- `crates/cfd-3d/src/trifurcation/solver.rs` rsparse-comment cleanup
- `Cargo.lock` mnemosyne 0.5.0 → 0.6.0 bump + proteus/eunomia coherence
- `docs/book/*` and `xtask/*` book and prebook deterministic-figure work

## Refs

- backlog: `ATLAS-CFDRS-LETO-SPARSE-MIGRATION-001`
- ADR 0031: `docs/adr/0031-leto-ops-real-sparse-lu.md` (atlas-meta)
- leto PR #74 squash-merged as `687b670`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `DirectSparseSolver` module documentation to accurately reflect the real CSC sparse LU implementation that was merged into leto at commit `687b670` via PR #74 (ADR 0031). The previous documentation incorrectly claimed the solver was "backed by dense partial-pivoting LU", which has been replaced with precise details about the two-path dispatch logic: a dense path for small or dense matrices (`n ≤ 32` or `nnz/n² ≥ 0.1`) using partial-pivoting LU, and a sparse path using Gilbert–Peierls symbolic reach with left-looking numeric factorization. The `ordering` field documentation is also corrected to clarify it's reserved for future AMD fill-reducing ordering work. Additionally, the code is adapted to support the upstream `SparseLuSolver` struct expansion by adding `..Default::default()` to handle new fields (`small_switch` and `density_threshold`).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-math/src/linear_solver/direct_solver.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->