### PR TITLE
feat(cfd-schematic-mesh)!: Type geometry config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout Atlas path dependencies
-        uses: ryancinsight/atlas/.github/actions/checkout-path-dependencies@51d8600cf3077e6ad6aafa5603b3289444b1719f
+        uses: ryancinsight/atlas/.github/actions/checkout-path-dependencies@11581413ddd1da6fd849dd2c4ad11fdbb6ce673a
         with:
           manifest: Cargo.toml
           destination: ..
-          atlas_ref: 51d8600cf3077e6ad6aafa5603b3289444b1719f
+          atlas_ref: 11581413ddd1da6fd849dd2c4ad11fdbb6ce673a
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Breaking**: Type `cfd-schematic-mesh` runtime geometry configuration and
+  `SegmentCenterline` output with Aequitas `Angle`, `Length`, and
+  `Dimensionless` values. Mesh-provider, trigonometric, routing, and CSG
+  boundaries extract scalars explicitly. The geometry remains real-valued
+  under Eunomia; no imaginary-unit physical metric is introduced. See
+  [`schematic-mesh-geometry-metrics.md`](docs/atlas-migration/schematic-mesh-geometry-metrics.md).
+
 - **Breaking**: Remove the no-op `cfd-3d::turbulence` facade and expose the
   canonical Eunomia-backed implementations from `cfd-3d::physics::turbulence`
   through the crate-level module path. Migrate in-tree turbulence regressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** Type schematic-mesh runtime geometry configuration and emitted
+  centerline coordinates/diameters with Aequitas `Angle`, `Length`, and
+  `Dimensionless` quantities. Scalar extraction remains at mesh, trigonometric,
+  routing, and CSG formula boundaries; real geometry introduces no imaginary
+  physical unit for Eunomia representations.
+- Refresh the standalone provider lock and Atlas checkout pin to the current
+  `moirai-runtime`/`mnemosyne-memory` graph so the focused `cfd-schematic-mesh`
+  locked package check resolves and passes.
+
 ### Added
 
 - Add `SIMPLEConfig::pressure_sweep_cap` so consumers with a measured

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -64,10 +64,12 @@
       doctests, Rustdoc, and diff checks pass.
 
 Evidence: `cargo check --offline --locked --package cfd-schematic-mesh
---all-targets`, Clippy with `-D warnings`, Nextest (29/29), doctests, and
-Rustdoc pass against the regenerated standalone provider lock. The workflow
-uses the current immutable Atlas checkout action; no provider-resolution
-residual remains for this geometry slice.
+--all-targets`, Clippy with `-D warnings`, Nextest run
+`5091fabe-e3da-4e76-a6ed-8c0377b0b0ee` (29/29), doctests, and Rustdoc pass
+against the regenerated standalone provider lock. The workflow uses the
+current immutable Atlas checkout action; no provider-resolution residual
+remains for this geometry slice. The semver baseline limitation is recorded
+in `gap_audit.md`.
 
 ## Owner: current Codex session — CFDRS-AEQ-MET-43 schematic volume metrics [major] — verified 2026-07-31
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -49,18 +49,25 @@
 - [x] Keep scalar extraction inside the volume-weighted interpolation formula;
       verify f64 and f32 value semantics and the real-only Eunomia boundary.
 
-## Owner: current Codex session — CFDRS-AEQ-MET-46 schematic mesh geometry metrics [major] — in progress 2026-08-02
+## Owner: current Codex session — CFDRS-AEQ-MET-46 schematic mesh geometry metrics [major] — done 2026-08-02
 
 - [x] Audit the live `cfd-schematic-mesh` runtime configuration and emitted
       centerline contracts; classify mesh-provider, trigonometric, routing,
       CSG, serialization, and Eunomia real/complex boundaries.
 - [x] Replace public scalar angles, lengths, clearances, overlap fractions,
-      cavity dimensions, centerline coordinates, and diameters with Aequitas
-      quantities; migrate the OpenFOAM example without compatibility fields.
+      cavity dimensions, centerline coordinates, diameters, SBS plate bounds,
+      and wall-clearance constraint metrics with Aequitas quantities; migrate
+      the OpenFOAM example without compatibility fields.
 - [x] Synchronize the design note, `gap_audit.md`, `docs/adr.md`,
-      `CHANGELOG.md`, `backlog.md`, and this checklist. Metadata, residue, and
-      diff checks pass; focused compilation is blocked by the recorded locked
-      Moirai/Mnemosyne provider-resolution residual.
+      `CHANGELOG.md`, `backlog.md`, and this checklist. Metadata, residue,
+      focused locked package all-target compilation, Clippy, Nextest 29/29,
+      doctests, Rustdoc, and diff checks pass.
+
+Evidence: `cargo check --offline --locked --package cfd-schematic-mesh
+--all-targets`, Clippy with `-D warnings`, Nextest (29/29), doctests, and
+Rustdoc pass against the regenerated standalone provider lock. The workflow
+uses the current immutable Atlas checkout action; no provider-resolution
+residual remains for this geometry slice.
 
 ## Owner: current Codex session — CFDRS-AEQ-MET-43 schematic volume metrics [major] — verified 2026-07-31
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -49,6 +49,19 @@
 - [x] Keep scalar extraction inside the volume-weighted interpolation formula;
       verify f64 and f32 value semantics and the real-only Eunomia boundary.
 
+## Owner: current Codex session — CFDRS-AEQ-MET-46 schematic mesh geometry metrics [major] — in progress 2026-08-02
+
+- [x] Audit the live `cfd-schematic-mesh` runtime configuration and emitted
+      centerline contracts; classify mesh-provider, trigonometric, routing,
+      CSG, serialization, and Eunomia real/complex boundaries.
+- [x] Replace public scalar angles, lengths, clearances, overlap fractions,
+      cavity dimensions, centerline coordinates, and diameters with Aequitas
+      quantities; migrate the OpenFOAM example without compatibility fields.
+- [x] Synchronize the design note, `gap_audit.md`, `docs/adr.md`,
+      `CHANGELOG.md`, `backlog.md`, and this checklist. Metadata, residue, and
+      diff checks pass; focused compilation is blocked by the recorded locked
+      Moirai/Mnemosyne provider-resolution residual.
+
 ## Owner: current Codex session — CFDRS-AEQ-MET-43 schematic volume metrics [major] — verified 2026-07-31
 
 - [x] Type `cfd-schematics` `FluidVolumeSummary` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aequitas"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/aequitas#8e75ee395591762af07e8a750aa8729a43811c3b"
+source = "git+https://github.com/ryancinsight/aequitas#8f9974350fd12b2a0e9c62973ae73199bd372d7c"
 dependencies = [
  "eunomia",
  "serde",
@@ -127,7 +127,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "apollo-fft"
 version = "0.25.0"
-source = "git+https://github.com/ryancinsight/apollo#496d262ddbeb7b99e7cc204375d7afa0105da943"
+source = "git+https://github.com/ryancinsight/apollo#0167b2f8a97d1f97d3c3d2cd53ed86104f0ac908"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -136,8 +136,8 @@ dependencies = [
  "half",
  "hermes-simd",
  "leto",
- "mnemosyne",
- "moirai",
+ "mnemosyne-memory",
+ "moirai-runtime",
  "once_cell",
  "parking_lot",
  "rand 0.10.2",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "apollo-fft-macros"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/apollo#496d262ddbeb7b99e7cc204375d7afa0105da943"
+source = "git+https://github.com/ryancinsight/apollo#0167b2f8a97d1f97d3c3d2cd53ed86104f0ac908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -159,7 +159,7 @@ dependencies = [
 [[package]]
 name = "apollo-leto-interop"
 version = "0.17.0"
-source = "git+https://github.com/ryancinsight/apollo#496d262ddbeb7b99e7cc204375d7afa0105da943"
+source = "git+https://github.com/ryancinsight/apollo#0167b2f8a97d1f97d3c3d2cd53ed86104f0ac908"
 dependencies = [
  "leto",
 ]
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "apollo-nufft"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/apollo#496d262ddbeb7b99e7cc204375d7afa0105da943"
+source = "git+https://github.com/ryancinsight/apollo#0167b2f8a97d1f97d3c3d2cd53ed86104f0ac908"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -175,8 +175,8 @@ dependencies = [
  "eunomia",
  "hermes-simd",
  "leto",
- "mnemosyne",
- "moirai",
+ "mnemosyne-memory",
+ "moirai-runtime",
  "serde",
  "thiserror 2.0.19",
 ]
@@ -474,7 +474,7 @@ dependencies = [
  "iris",
  "leto",
  "leto-ops",
- "moirai",
+ "moirai-runtime",
  "petgraph",
  "plotters",
  "proptest",
@@ -506,7 +506,7 @@ dependencies = [
  "gaia",
  "leto",
  "leto-ops",
- "moirai",
+ "moirai-runtime",
  "proptest",
  "serde",
  "thiserror 1.0.69",
@@ -528,7 +528,7 @@ dependencies = [
  "indexmap",
  "leto",
  "leto-ops",
- "moirai",
+ "moirai-runtime",
  "num_cpus",
  "proptest",
  "proteus",
@@ -575,7 +575,7 @@ dependencies = [
  "hermes-simd",
  "leto",
  "leto-ops",
- "moirai",
+ "moirai-runtime",
  "proptest",
  "rand 0.8.7",
  "serde",
@@ -600,7 +600,7 @@ dependencies = [
  "chrono",
  "gaia",
  "hyperion",
- "moirai",
+ "moirai-runtime",
  "petgraph",
  "plotters",
  "proptest",
@@ -681,7 +681,7 @@ dependencies = [
  "gaia",
  "leto",
  "leto-ops",
- "moirai",
+ "moirai-runtime",
  "num_cpus",
  "petgraph",
  "proptest",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "coeus-autograd"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -822,13 +822,13 @@ dependencies = [
 [[package]]
 name = "coeus-core"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "bytemuck",
  "eunomia",
  "hermes-simd",
- "mnemosyne",
- "moirai",
+ "mnemosyne-memory",
+ "moirai-runtime",
  "smallvec",
  "thiserror 2.0.19",
 ]
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "coeus-leto"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "coeus-core",
  "leto",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "coeus-nn"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "coeus-ops"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "coeus-optim"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "coeus-sparse"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "coeus-tensor"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#d1a1cd65a07fa2b682403a8fdb6cd2c46500fbb6"
+source = "git+https://github.com/ryancinsight/Coeus.git#54cefedb126d2a06d2c8ae1b58a40498bcbda7f8"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -928,7 +928,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "consus-compression"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#f0c28690f867bb1d892102e9ffa2e18a91ef7451"
+source = "git+https://github.com/ryancinsight/consus.git#247391a395d55d972b698ca609574d87a1cbe8bf"
 dependencies = [
  "byteorder",
  "consus-core",
@@ -937,7 +937,7 @@ dependencies = [
 [[package]]
 name = "consus-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#f0c28690f867bb1d892102e9ffa2e18a91ef7451"
+source = "git+https://github.com/ryancinsight/consus.git#247391a395d55d972b698ca609574d87a1cbe8bf"
 dependencies = [
  "byteorder",
  "smallvec",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "consus-hdf5"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#f0c28690f867bb1d892102e9ffa2e18a91ef7451"
+source = "git+https://github.com/ryancinsight/consus.git#247391a395d55d972b698ca609574d87a1cbe8bf"
 dependencies = [
  "byteorder",
  "consus-compression",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "consus-io"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#f0c28690f867bb1d892102e9ffa2e18a91ef7451"
+source = "git+https://github.com/ryancinsight/consus.git#247391a395d55d972b698ca609574d87a1cbe8bf"
 dependencies = [
  "consus-core",
 ]
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "eunomia"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/eunomia#18459875ad8eb7a67e3fd7f512193cde80947b54"
+source = "git+https://github.com/ryancinsight/eunomia#98f853711a4832a2d3eea58e0fd3dc0f2a8810b3"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "gaia"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/gaia#cde7395c5a49014df45365c86911b08224cf6d13"
+source = "git+https://github.com/ryancinsight/gaia#9a7b2edeb772202c6a73d6fca478d02771760112"
 dependencies = [
  "anyhow",
  "eunomia",
@@ -1614,31 +1614,32 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hephaestus-core"
 version = "0.18.0"
-source = "git+https://github.com/ryancinsight/hephaestus#98ef33974bad876ebda780259c87f39c12ffbb7e"
+source = "git+https://github.com/ryancinsight/hephaestus#ac52a75c3e887e18d4dae68dc4877fa4c0d8e1c4"
 dependencies = [
  "aequitas",
  "bytemuck",
+ "eunomia",
  "leto",
- "themis",
+ "themis-topology",
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "hephaestus-wgpu"
 version = "0.18.0"
-source = "git+https://github.com/ryancinsight/hephaestus#98ef33974bad876ebda780259c87f39c12ffbb7e"
+source = "git+https://github.com/ryancinsight/hephaestus#ac52a75c3e887e18d4dae68dc4877fa4c0d8e1c4"
 dependencies = [
  "bytemuck",
  "eunomia",
  "hephaestus-core",
  "leto",
  "leto-ops",
- "mnemosyne-core",
- "moirai",
+ "mnemosyne-memory-core",
  "moirai-gpu",
+ "moirai-runtime",
  "moirai-sync",
  "smallvec",
- "themis",
+ "themis-topology",
  "wgpu",
  "windows 0.62.2",
 ]
@@ -1646,32 +1647,32 @@ dependencies = [
 [[package]]
 name = "hermes-simd"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#40084ac85125abd976d645b5640a2d47656ed712"
+source = "git+https://github.com/ryancinsight/hermes.git#b628ca26e5c52f15a3a11d91fab2c3471d602e93"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
  "hermes-simd-intrinsics",
  "hermes-simd-macros",
  "hermes-simd-types",
- "themis",
+ "themis-topology",
 ]
 
 [[package]]
 name = "hermes-simd-core"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#40084ac85125abd976d645b5640a2d47656ed712"
+source = "git+https://github.com/ryancinsight/hermes.git#b628ca26e5c52f15a3a11d91fab2c3471d602e93"
 dependencies = [
  "bytemuck",
  "eunomia",
- "mnemosyne",
+ "mnemosyne-memory",
  "rkyv 0.7.46",
- "themis",
+ "themis-topology",
 ]
 
 [[package]]
 name = "hermes-simd-intrinsics"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#40084ac85125abd976d645b5640a2d47656ed712"
+source = "git+https://github.com/ryancinsight/hermes.git#b628ca26e5c52f15a3a11d91fab2c3471d602e93"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1680,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-macros"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#40084ac85125abd976d645b5640a2d47656ed712"
+source = "git+https://github.com/ryancinsight/hermes.git#b628ca26e5c52f15a3a11d91fab2c3471d602e93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1690,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-types"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#40084ac85125abd976d645b5640a2d47656ed712"
+source = "git+https://github.com/ryancinsight/hermes.git#b628ca26e5c52f15a3a11d91fab2c3471d602e93"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1763,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "iris"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/iris#fd3d36fad082f92c526ebdb69562f989da06185b"
+source = "git+https://github.com/ryancinsight/iris#2382c3289cda99e1773676f3fa43b8462e80de55"
 
 [[package]]
 name = "is-terminal"
@@ -1833,12 +1834,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leto"
 version = "0.40.0"
-source = "git+https://github.com/ryancinsight/leto.git#aa5c283d9f9abba548c7ee1cf0ac6352e2fa9859"
+source = "git+https://github.com/ryancinsight/leto.git#94f914d6ce1131889e64e3bba4f0990225c984f3"
 dependencies = [
  "aequitas",
  "bytemuck",
  "eunomia",
- "mnemosyne",
+ "mnemosyne-memory",
  "serde",
  "thiserror 2.0.19",
 ]
@@ -1846,15 +1847,15 @@ dependencies = [
 [[package]]
 name = "leto-ops"
 version = "0.40.0"
-source = "git+https://github.com/ryancinsight/leto.git#aa5c283d9f9abba548c7ee1cf0ac6352e2fa9859"
+source = "git+https://github.com/ryancinsight/leto.git#94f914d6ce1131889e64e3bba4f0990225c984f3"
 dependencies = [
  "bytemuck",
  "eunomia",
  "hermes-simd",
  "leto",
- "moirai",
+ "moirai-runtime",
  "serde",
- "themis",
+ "themis-topology",
  "thiserror 2.0.19",
 ]
 
@@ -1882,9 +1883,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -1938,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "melinoe"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/melinoe.git#258dda57cc71ee497acaf743c84640103f72f9e1"
+source = "git+https://github.com/ryancinsight/melinoe.git#0287db3e87458ac882f299ee0682af5dc8da6ca3"
 
 [[package]]
 name = "memchr"
@@ -1957,129 +1958,111 @@ dependencies = [
 ]
 
 [[package]]
-name = "mnemosyne"
-version = "0.6.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
-dependencies = [
- "eunomia",
- "mnemosyne-arena",
- "mnemosyne-backend",
- "mnemosyne-core",
- "mnemosyne-decay",
- "mnemosyne-hardened",
- "mnemosyne-heap",
- "mnemosyne-local",
- "mnemosyne-prof",
-]
-
-[[package]]
 name = "mnemosyne-arena"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
- "mnemosyne-core",
- "themis",
+ "mnemosyne-memory-core",
+ "themis-topology",
 ]
 
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
-
-[[package]]
-name = "mnemosyne-core"
-version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "mnemosyne-hardened"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "mnemosyne-heap"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
  "mnemosyne-backend",
- "mnemosyne-core",
  "mnemosyne-local",
+ "mnemosyne-memory-core",
  "mnemosyne-prof",
- "themis",
+ "themis-topology",
 ]
 
 [[package]]
 name = "mnemosyne-local"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
  "mnemosyne-backend",
  "mnemosyne-build-util",
- "mnemosyne-core",
  "mnemosyne-decay",
+ "mnemosyne-memory-core",
  "mnemosyne-prof",
- "themis",
+ "themis-topology",
 ]
+
+[[package]]
+name = "mnemosyne-memory"
+version = "0.6.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
+dependencies = [
+ "eunomia",
+ "mnemosyne-arena",
+ "mnemosyne-backend",
+ "mnemosyne-decay",
+ "mnemosyne-hardened",
+ "mnemosyne-heap",
+ "mnemosyne-local",
+ "mnemosyne-memory-core",
+ "mnemosyne-prof",
+]
+
+[[package]]
+name = "mnemosyne-memory-core"
+version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 
 [[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#3bbe9819315ed3cd178893ad2ca9d102ce0476f1"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#705706e65468ee23096a7814c8c100285beed0f9"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
- "mnemosyne-core",
-]
-
-[[package]]
-name = "moirai"
-version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
-dependencies = [
- "melinoe",
- "mnemosyne",
- "moirai-async",
- "moirai-core",
- "moirai-executor",
- "moirai-iter",
- "moirai-parallel",
- "moirai-scheduler",
- "moirai-sync",
- "moirai-transport",
- "moirai-utils",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "moirai-async"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "futures",
  "libc",
@@ -2095,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "moirai-async-macros"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2105,21 +2088,21 @@ dependencies = [
 [[package]]
 name = "moirai-core"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "bytemuck",
  "libc",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-utils",
 ]
 
 [[package]]
 name = "moirai-executor"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "melinoe",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-core",
  "moirai-pal",
  "moirai-scheduler",
@@ -2129,18 +2112,18 @@ dependencies = [
 [[package]]
 name = "moirai-gpu"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
- "mnemosyne-core",
+ "mnemosyne-memory-core",
  "moirai-core",
  "moirai-utils",
- "themis",
+ "themis-topology",
 ]
 
 [[package]]
 name = "moirai-iter"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "futures",
  "libc",
@@ -2149,14 +2132,14 @@ dependencies = [
  "moirai-scheduler",
  "moirai-utils",
  "num_cpus",
- "themis",
+ "themis-topology",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "moirai-pal"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "js-sys",
  "libc",
@@ -2171,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "moirai-parallel"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "melinoe",
  "moirai-core",
@@ -2179,21 +2162,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "moirai-runtime"
+version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
+dependencies = [
+ "melinoe",
+ "mnemosyne-memory",
+ "moirai-async",
+ "moirai-core",
+ "moirai-executor",
+ "moirai-iter",
+ "moirai-parallel",
+ "moirai-scheduler",
+ "moirai-sync",
+ "moirai-transport",
+ "moirai-utils",
+]
+
+[[package]]
 name = "moirai-scheduler"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-core",
  "moirai-utils",
  "num_cpus",
- "themis",
+ "themis-topology",
 ]
 
 [[package]]
 name = "moirai-sync"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "libc",
  "moirai-core",
@@ -2203,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "moirai-transport"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 dependencies = [
  "bytemuck",
  "moirai-core",
@@ -2214,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "moirai-utils"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#8f8b88ad229834a980fdd251a20d8d27c3dc8925"
+source = "git+https://github.com/ryancinsight/Moirai#96c9f1ddd0920ce93312eeab416347a2072ec284"
 
 [[package]]
 name = "munge"
@@ -3017,7 +3018,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "ritk-image"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#d3d3d8114072e39510415476a08abf4824e24091"
+source = "git+https://github.com/ryancinsight/ritk#1eddee42d132c9c90f0c47fb6549043eea559bf6"
 dependencies = [
  "anyhow",
  "coeus-autograd",
@@ -3034,16 +3035,17 @@ dependencies = [
 [[package]]
 name = "ritk-spatial"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/ritk#d3d3d8114072e39510415476a08abf4824e24091"
+source = "git+https://github.com/ryancinsight/ritk#1eddee42d132c9c90f0c47fb6549043eea559bf6"
 dependencies = [
  "leto",
  "serde",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ritk-vtk"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/ritk#d3d3d8114072e39510415476a08abf4824e24091"
+source = "git+https://github.com/ryancinsight/ritk#1eddee42d132c9c90f0c47fb6549043eea559bf6"
 dependencies = [
  "anyhow",
  "coeus-core",
@@ -3059,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "ritk-wgpu-compat"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/ritk#d3d3d8114072e39510415476a08abf4824e24091"
+source = "git+https://github.com/ryancinsight/ritk#1eddee42d132c9c90f0c47fb6549043eea559bf6"
 
 [[package]]
 name = "rkyv"
@@ -3412,9 +3414,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "themis"
+name = "themis-topology"
 version = "0.10.1"
-source = "git+https://github.com/ryancinsight/themis#035445f493754815e4580d59389580dfa0dc48df"
+source = "git+https://github.com/ryancinsight/themis#96ddc272aaa10b718a3841d2fe6bc5a5a9a94a6f"
 dependencies = [
  "melinoe",
 ]
@@ -3604,7 +3606,7 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 [[package]]
 name = "tyche-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/tyche#df8ae8f5aeadfff058cf9fa5577c1f589ff5d765"
+source = "git+https://github.com/ryancinsight/tyche#2bd74c299a27836e166bb7fd9d3b1fc5c41b1ff4"
 dependencies = [
  "eunomia",
 ]
@@ -3785,12 +3787,16 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.17.1",
+ "js-sys",
  "log",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "wgpu-core",
  "wgpu-hal",
  "wgpu-types",
@@ -3908,10 +3914,12 @@ checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
+ "js-sys",
  "log",
  "naga-types",
  "raw-window-handle",
  "static_assertions",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ ritk-vtk = { version = "0.1.0", git = "https://github.com/ryancinsight/ritk" }
 hermes-simd = { version = "0.5.0", git = "https://github.com/ryancinsight/hermes.git" }
 # moirai: unified concurrency runtime replacing tokio + rayon. Moirai's parallel,
 # Mnemosyne, and Melinoe surfaces are enabled for the CFDrs workspace.
-moirai = { version = "0.4.0", git = "https://github.com/ryancinsight/Moirai", default-features = false, features = ["parallel", "mnemosyne", "melinoe"] }
+moirai = { version = "0.4.0", git = "https://github.com/ryancinsight/Moirai", package = "moirai-runtime", default-features = false, features = ["parallel", "mnemosyne-memory", "melinoe"] }
 # hephaestus-wgpu: Atlas GPU provider used for device acquisition and the
 # ongoing replacement of CFDrs-owned raw WGPU kernels.
 hephaestus-wgpu = { version = "0.18.0", git = "https://github.com/ryancinsight/hephaestus" }

--- a/backlog.md
+++ b/backlog.md
@@ -32,12 +32,16 @@
 ## Active integration
 
 - **CFDRS-AEQ-MET-46 [major] - Type schematic mesh geometry configuration
-  (in progress 2026-08-02; owner=current Codex session; scope=
+  (done 2026-08-02; owner=current Codex session; scope=
   `cfd-schematic-mesh` pipeline configuration and emitted centerline geometry).**
-  Carry angles, lengths, clearances, overlap fractions, and centerline
-  diameters through Aequitas at the public mesh boundary. Scalar extraction is
-  limited to mesh-provider and trigonometric formula calls; serialized
-  interchange payloads remain a separate unit-labelled format boundary.
+  Carry angles, lengths, clearances, overlap fractions, centerline diameters,
+  SBS plate bounds, and wall-clearance constraint metrics through Aequitas at
+  the public mesh boundary. Scalar extraction is limited to mesh-provider,
+  trigonometric, routing, comparison, and CSG formula calls; serialized
+  interchange payloads remain a separate unit-labelled format boundary. The
+  standalone provider lock and Atlas checkout pin are aligned with the current
+  `moirai-runtime`/`mnemosyne-memory` graph; focused check, Clippy, Nextest
+  29/29, doctests, and Rustdoc pass.
 
 
 - **CFDRS-CI-LOCK-1 [patch] - Restore standalone provider lock and hosted

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,15 @@
 
 ## Active integration
 
+- **CFDRS-AEQ-MET-46 [major] - Type schematic mesh geometry configuration
+  (in progress 2026-08-02; owner=current Codex session; scope=
+  `cfd-schematic-mesh` pipeline configuration and emitted centerline geometry).**
+  Carry angles, lengths, clearances, overlap fractions, and centerline
+  diameters through Aequitas at the public mesh boundary. Scalar extraction is
+  limited to mesh-provider and trigonometric formula calls; serialized
+  interchange payloads remain a separate unit-labelled format boundary.
+
+
 - **CFDRS-CI-LOCK-1 [patch] - Restore standalone provider lock and hosted
   documentation gates (done 2026-07-31; owner=current Codex session).** The
   Aequitas provider lock now records the Eunomia git source, CFDrs `Cargo.lock`

--- a/crates/cfd-schematic-mesh/examples/schematic_to_openfoam.rs
+++ b/crates/cfd-schematic-mesh/examples/schematic_to_openfoam.rs
@@ -46,7 +46,7 @@ use std::io::BufWriter;
 use std::path::Path;
 
 use aequitas::systems::si::quantities::{Dimensionless, Volume};
-use aequitas::systems::si::units::CubicMillimeter;
+use aequitas::systems::si::units::{CubicMillimeter, Millimeter};
 use cfd_mesh::application::channel::path::ChannelPath;
 use cfd_mesh::application::channel::substrate::SubstrateBuilder;
 use cfd_mesh::application::channel::sweep::SweepMesher;
@@ -117,7 +117,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     println!(
         "  Running {} designs with chip_height = {} mm",
-        n, config.chip_height_mm
+        n,
+        config.chip_height.in_unit::<Millimeter>()
     );
     println!("  Output root: {}", out_root.display());
     println!("{}", "─".repeat(60));
@@ -277,7 +278,7 @@ fn mesh_output_from_blueprint(
 ) -> Result<PipelineOutput, Box<dyn std::error::Error>> {
     let schematic3d = scheme_io::from_blueprint(
         system,
-        config.chip_height_mm as Real,
+        config.chip_height.in_unit::<Millimeter>() as Real,
         config.circular_segments,
     )?;
 
@@ -327,7 +328,8 @@ fn mesh_output_from_blueprint(
     label_inlet_outlet_from_system(&mut fluid_mesh, &schematic3d)?;
 
     let chip_mesh = if config.include_chip_body {
-        let substrate = SubstrateBuilder::well_plate_96(config.chip_height_mm).build_indexed()?;
+        let substrate = SubstrateBuilder::well_plate_96(config.chip_height.in_unit::<Millimeter>())
+            .build_indexed()?;
         let void_union = if void_meshes.len() == 1 {
             void_meshes.into_iter().next().unwrap()
         } else {

--- a/crates/cfd-schematic-mesh/src/blueprint_mesh.rs
+++ b/crates/cfd-schematic-mesh/src/blueprint_mesh.rs
@@ -227,7 +227,7 @@ impl BlueprintMeshPipeline {
         let chip_height_mm = config.chip_height.in_unit::<Millimeter>();
         let wall_clearance_mm = config.wall_clearance.in_unit::<Millimeter>();
         let z_mid = chip_height_mm / 2.0;
-        let y_center = SbsWellPlate96::center_y();
+        let y_center = SbsWellPlate96::center_y().in_unit::<Millimeter>();
         // segment_count = number of *blueprint* channels (not synthesised 3-D segments).
         // The serpentine zigzag inserts synthetic turn segments that don't map to
         // blueprint channels, so we cannot use layout.len() here.
@@ -241,19 +241,25 @@ impl BlueprintMeshPipeline {
         };
 
         // Step 4 — wall clearance (routing bounds)
-        // Inlet/outlet ports are allowed to touch the x=0 and x=WIDTH_MM faces;
+        // Inlet/outlet ports are allowed to touch the x=0 and x=WIDTH faces;
         // only the Y side-walls require the configured keep-out.
         for seg in &layout {
             let (x0, y0) = (seg.start.x, seg.start.y);
             let (x1, y1) = (seg.end.x, seg.end.y);
-            if !SbsWellPlate96::segment_within_routing_bounds(x0, y0, x1, y1, wall_clearance_mm) {
+            if !SbsWellPlate96::segment_within_routing_bounds(
+                Length::from_unit::<Millimeter>(x0),
+                Length::from_unit::<Millimeter>(y0),
+                Length::from_unit::<Millimeter>(x1),
+                Length::from_unit::<Millimeter>(y1),
+                config.wall_clearance,
+            ) {
                 return Err(MeshError::ChannelError {
                     message: format!(
                         "channel segment ({x0:.2}, {y0:.2}) → ({x1:.2}, {y1:.2}) mm \
                          violates routing bounds on plate {:.2} × {:.2} mm \
                          (side clearance {:.1} mm)",
-                        SbsWellPlate96::WIDTH_MM,
-                        SbsWellPlate96::DEPTH_MM,
+                        SbsWellPlate96::WIDTH.in_unit::<Millimeter>(),
+                        SbsWellPlate96::DEPTH.in_unit::<Millimeter>(),
                         wall_clearance_mm,
                     ),
                 });
@@ -477,7 +483,7 @@ fn synthesize_layout(
                 .ok_or_else(|| MeshError::ChannelError {
                     message: "expected linear path but traversal failed".to_string(),
                 })?;
-            let chip_w = SbsWellPlate96::WIDTH_MM;
+            let chip_w = SbsWellPlate96::WIDTH.in_unit::<Millimeter>();
             let total_len_mm: Real = channels.iter().map(|ch| ch.length_m * 1000.0).sum();
             let scale = if total_len_mm > 1e-9 {
                 chip_w / total_len_mm
@@ -531,7 +537,7 @@ fn synthesize_layout(
                 .map(|ch| cross_section_diameter_mm(&ch.cross_section))
                 .fold(0.0_f64, f64::max);
             let row_pitch = (max_dia_mm * 2.5).max(1.0); // ≥ 1 mm
-            let chip_w = SbsWellPlate96::WIDTH_MM;
+            let chip_w = SbsWellPlate96::WIDTH.in_unit::<Millimeter>();
             let n = channels.len();
             let turn_inset_x = (max_dia_mm * 0.5).max(1e-3);
             let x_left = turn_inset_x;
@@ -618,9 +624,9 @@ fn synthesize_parallel_array_layout(
     z_mid: Real,
     config: &PipelineConfig,
 ) -> MeshResult<Vec<SegmentLayout>> {
-    let chip_w = SbsWellPlate96::WIDTH_MM;
+    let chip_w = SbsWellPlate96::WIDTH.in_unit::<Millimeter>();
     let wall_clearance_mm = config.wall_clearance.in_unit::<Millimeter>();
-    let max_y = SbsWellPlate96::DEPTH_MM - wall_clearance_mm;
+    let max_y = SbsWellPlate96::DEPTH.in_unit::<Millimeter>() - wall_clearance_mm;
     let min_y = wall_clearance_mm;
 
     // Determine cross-section from the first channel in the blueprint.
@@ -782,9 +788,9 @@ fn synthesize_complex_layout(
     z_mid: Real,
     config: &PipelineConfig,
 ) -> MeshResult<Vec<SegmentLayout>> {
-    let chip_w = SbsWellPlate96::WIDTH_MM;
+    let chip_w = SbsWellPlate96::WIDTH.in_unit::<Millimeter>();
     let wall_clearance_mm = config.wall_clearance.in_unit::<Millimeter>();
-    let max_y = SbsWellPlate96::DEPTH_MM - wall_clearance_mm;
+    let max_y = SbsWellPlate96::DEPTH.in_unit::<Millimeter>() - wall_clearance_mm;
     let min_y = wall_clearance_mm;
 
     // Find the unique inlet node.

--- a/crates/cfd-schematic-mesh/src/blueprint_mesh.rs
+++ b/crates/cfd-schematic-mesh/src/blueprint_mesh.rs
@@ -6,8 +6,8 @@
 use hashbrown::HashMap;
 use std::f64::consts::PI;
 
-use aequitas::systems::si::quantities::{Area, Dimensionless, Length, Volume};
-use aequitas::systems::si::units::{CubicMillimeter, Millimeter};
+use aequitas::systems::si::quantities::{Angle, Area, Dimensionless, Length, Volume};
+use aequitas::systems::si::units::{CubicMillimeter, Millimeter, Radian};
 use cfd_schematics::geometry::FluidVolumeSummary;
 use cfd_schematics::{CrossSectionSpec, NetworkBlueprint, NodeKind};
 
@@ -36,19 +36,19 @@ pub struct PipelineConfig {
     /// Number of axial rings per path segment. Default: 8.
     pub axial_rings: usize,
     /// Fractional overlap extension for CSG union watertightness. Default: 0.05.
-    pub csg_overlap_fraction: f64,
-    /// Arm angle (rad) for the bifurcation diamond layout.
+    pub csg_overlap_fraction: Dimensionless<f64>,
+    /// Arm angle for the bifurcation diamond layout.
     ///
     /// Controls how steeply the diagonal arms diverge from the centreline
     /// before reaching the horizontal parallel-channel section.  Larger values
     /// give a wider Y-spread.  Default: π/3 (60°).
-    pub bifurcation_half_angle_rad: f64,
-    /// Half-angle (rad) between trifurcation outer daughter tubes. Default: π/4.
-    pub trifurcation_half_angle_rad: f64,
-    /// Chip thickness — the Z dimension of the substrate (mm). Default: 2.0.
-    pub chip_height_mm: f64,
-    /// Minimum clearance from block edges for channel segments (mm). Default: 5.0.
-    pub wall_clearance_mm: f64,
+    pub bifurcation_half_angle: Angle<f64>,
+    /// Half-angle between trifurcation outer daughter tubes. Default: π/4.
+    pub trifurcation_half_angle: Angle<f64>,
+    /// Chip thickness — the Z dimension of the substrate. Default: 10 mm.
+    pub chip_height: Length<f64>,
+    /// Minimum clearance from block edges for channel segments. Default: 5 mm.
+    pub wall_clearance: Length<f64>,
     /// Whether to build the chip body mesh (substrate minus channel void). Default: true.
     pub include_chip_body: bool,
     /// Skip the 4 mm inlet/outlet hydraulic-diameter constraint.
@@ -65,11 +65,11 @@ impl Default for PipelineConfig {
         Self {
             circular_segments: 16,
             axial_rings: 8,
-            csg_overlap_fraction: 0.05,
-            bifurcation_half_angle_rad: PI / 3.0,
-            trifurcation_half_angle_rad: PI / 4.0,
-            chip_height_mm: 10.0,
-            wall_clearance_mm: 5.0,
+            csg_overlap_fraction: Dimensionless::from_base(0.05),
+            bifurcation_half_angle: Angle::from_unit::<Radian>(PI / 3.0),
+            trifurcation_half_angle: Angle::from_unit::<Radian>(PI / 4.0),
+            chip_height: Length::from_unit::<Millimeter>(10.0),
+            wall_clearance: Length::from_unit::<Millimeter>(5.0),
             include_chip_body: true,
             skip_diameter_constraint: false,
         }
@@ -80,18 +80,19 @@ impl Default for PipelineConfig {
 
 /// XY centreline of one synthesised layout segment, projected onto the chip plane.
 ///
-/// All coordinates are in millimetres.  Use these for 2-D schematics and for
-/// comparing the pipeline's physical layout against the source blueprint.
+/// All coordinates and diameters carry their millimetre dimension. Use these
+/// for 2-D schematics and for comparing the pipeline's physical layout against
+/// the source blueprint.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SegmentCenterline {
-    /// X start (mm)
-    pub x0: f64,
-    /// Y start (mm)
-    pub y0: f64,
-    /// X end (mm)
-    pub x1: f64,
-    /// Y end (mm)
-    pub y1: f64,
+    /// X start.
+    pub x0: Length<f64>,
+    /// Y start.
+    pub y0: Length<f64>,
+    /// X end.
+    pub x1: Length<f64>,
+    /// Y end.
+    pub y1: Length<f64>,
     /// Source blueprint channel identifier when this segment maps to one.
     pub source_channel_id: Option<String>,
     /// Upstream blueprint node identifier when this segment maps to one.
@@ -100,8 +101,8 @@ pub struct SegmentCenterline {
     pub to_node_id: Option<String>,
     /// Whether this segment was synthesized as a routing connector rather than a direct blueprint channel mapping.
     pub is_synthetic_connector: bool,
-    /// Effective tube diameter (mm)
-    pub diameter_mm: f64,
+    /// Effective tube diameter.
+    pub diameter: Length<f64>,
 }
 
 /// Per-blueprint-channel volume comparison between schematic geometry and the meshed 3D path.
@@ -223,7 +224,9 @@ impl BlueprintMeshPipeline {
         // Complex topologies proceed to graph-based layout synthesis.
 
         // Step 3 — synthesize layout
-        let z_mid = config.chip_height_mm / 2.0;
+        let chip_height_mm = config.chip_height.in_unit::<Millimeter>();
+        let wall_clearance_mm = config.wall_clearance.in_unit::<Millimeter>();
+        let z_mid = chip_height_mm / 2.0;
         let y_center = SbsWellPlate96::center_y();
         // segment_count = number of *blueprint* channels (not synthesised 3-D segments).
         // The serpentine zigzag inserts synthetic turn segments that don't map to
@@ -239,17 +242,11 @@ impl BlueprintMeshPipeline {
 
         // Step 4 — wall clearance (routing bounds)
         // Inlet/outlet ports are allowed to touch the x=0 and x=WIDTH_MM faces;
-        // only the Y side-walls require `wall_clearance_mm` keep-out.
+        // only the Y side-walls require the configured keep-out.
         for seg in &layout {
             let (x0, y0) = (seg.start.x, seg.start.y);
             let (x1, y1) = (seg.end.x, seg.end.y);
-            if !SbsWellPlate96::segment_within_routing_bounds(
-                x0,
-                y0,
-                x1,
-                y1,
-                config.wall_clearance_mm,
-            ) {
+            if !SbsWellPlate96::segment_within_routing_bounds(x0, y0, x1, y1, wall_clearance_mm) {
                 return Err(MeshError::ChannelError {
                     message: format!(
                         "channel segment ({x0:.2}, {y0:.2}) → ({x1:.2}, {y1:.2}) mm \
@@ -257,7 +254,7 @@ impl BlueprintMeshPipeline {
                          (side clearance {:.1} mm)",
                         SbsWellPlate96::WIDTH_MM,
                         SbsWellPlate96::DEPTH_MM,
-                        config.wall_clearance_mm,
+                        wall_clearance_mm,
                     ),
                 });
             }
@@ -267,15 +264,17 @@ impl BlueprintMeshPipeline {
         let layout_segments: Vec<SegmentCenterline> = layout
             .iter()
             .map(|seg| SegmentCenterline {
-                x0: seg.start.x,
-                y0: seg.start.y,
-                x1: seg.end.x,
-                y1: seg.end.y,
+                x0: Length::from_unit::<Millimeter>(seg.start.x),
+                y0: Length::from_unit::<Millimeter>(seg.start.y),
+                x1: Length::from_unit::<Millimeter>(seg.end.x),
+                y1: Length::from_unit::<Millimeter>(seg.end.y),
                 source_channel_id: seg.source_channel_id.clone(),
                 from_node_id: seg.from_node_id.clone(),
                 to_node_id: seg.to_node_id.clone(),
                 is_synthetic_connector: seg.is_synthetic_connector,
-                diameter_mm: cross_section_diameter_mm(&seg.cross_section),
+                diameter: Length::from_unit::<Millimeter>(cross_section_diameter_mm(
+                    &seg.cross_section,
+                )),
             })
             .collect();
 
@@ -333,7 +332,7 @@ impl BlueprintMeshPipeline {
                 // and one outlet for a single continuous channel network.
                 boolean::csg_boolean(
                     BooleanOp::Difference,
-                    &SubstrateBuilder::well_plate_96(config.chip_height_mm).build_indexed()?,
+                    &SubstrateBuilder::well_plate_96(chip_height_mm).build_indexed()?,
                     &fluid_mesh,
                 )?
             } else if matches!(&class, TopologyClass::VenturiChain) {
@@ -342,14 +341,14 @@ impl BlueprintMeshPipeline {
                 let void_mesh = build_venturi_chain_mesh(&mesh_layout, config)?;
                 boolean::csg_boolean(
                     BooleanOp::Difference,
-                    &SubstrateBuilder::well_plate_96(config.chip_height_mm).build_indexed()?,
+                    &SubstrateBuilder::well_plate_96(chip_height_mm).build_indexed()?,
                     &void_mesh,
                 )?
             } else if matches!(&class, TopologyClass::Complex) {
                 // Complex: reuse the already-built fluid_mesh as the void.
                 boolean::csg_boolean(
                     BooleanOp::Difference,
-                    &SubstrateBuilder::well_plate_96(config.chip_height_mm).build_indexed()?,
+                    &SubstrateBuilder::well_plate_96(chip_height_mm).build_indexed()?,
                     &fluid_mesh,
                 )?
             } else {
@@ -620,8 +619,9 @@ fn synthesize_parallel_array_layout(
     config: &PipelineConfig,
 ) -> MeshResult<Vec<SegmentLayout>> {
     let chip_w = SbsWellPlate96::WIDTH_MM;
-    let max_y = SbsWellPlate96::DEPTH_MM - config.wall_clearance_mm;
-    let min_y = config.wall_clearance_mm;
+    let wall_clearance_mm = config.wall_clearance.in_unit::<Millimeter>();
+    let max_y = SbsWellPlate96::DEPTH_MM - wall_clearance_mm;
+    let min_y = wall_clearance_mm;
 
     // Determine cross-section from the first channel in the blueprint.
     let first_ch = bp.channels.first().ok_or_else(|| MeshError::ChannelError {
@@ -783,8 +783,9 @@ fn synthesize_complex_layout(
     config: &PipelineConfig,
 ) -> MeshResult<Vec<SegmentLayout>> {
     let chip_w = SbsWellPlate96::WIDTH_MM;
-    let max_y = SbsWellPlate96::DEPTH_MM - config.wall_clearance_mm;
-    let min_y = config.wall_clearance_mm;
+    let wall_clearance_mm = config.wall_clearance.in_unit::<Millimeter>();
+    let max_y = SbsWellPlate96::DEPTH_MM - wall_clearance_mm;
+    let min_y = wall_clearance_mm;
 
     // Find the unique inlet node.
     // Kahn's algorithm seeds from all zero-in-degree vertices so we don't
@@ -950,7 +951,8 @@ fn build_segment_mesh_with_policy(
     // panic.  Limiting the extension to ½ · r guarantees the tip always stays
     // inside the body of any same-diameter (or larger) adjacent tube.
     let radius_mm = cross_section_radius_mm(&seg.cross_section);
-    let overlap = (len * config.csg_overlap_fraction).min(radius_mm * 0.5);
+    let overlap_fraction = config.csg_overlap_fraction.into_base();
+    let overlap = (len * overlap_fraction).min(radius_mm * 0.5);
     let start_ext = Point3r::from(seg.start.coords - unit * overlap);
     let end_ext = Point3r::from(seg.end.coords + unit * overlap);
 
@@ -1688,12 +1690,13 @@ fn build_complex_fluid_mesh(
 }
 
 fn build_chip_body(layout: &[SegmentLayout], config: &PipelineConfig) -> MeshResult<IndexedMesh> {
-    let substrate = SubstrateBuilder::well_plate_96(config.chip_height_mm).build_indexed()?;
+    let chip_height_mm = config.chip_height.in_unit::<Millimeter>();
+    let substrate = SubstrateBuilder::well_plate_96(chip_height_mm).build_indexed()?;
 
     // Build the void mesh using the same tube geometry as the fluid mesh.
     // The 5% CSG overlap extension makes void tubes exit the inlet face (x < 0),
     // creating proper port openings in the substrate.
-    // config.chip_height_mm must be > channel_diameter so the void stays within
+    // config.chip_height must be > channel_diameter so the void stays within
     // the substrate in the Z direction (default: 10 mm for 4 mm channels).
     let void_meshes: Vec<IndexedMesh> = layout
         .iter()
@@ -1720,7 +1723,8 @@ fn build_chip_body_sequential(
     layout: &[SegmentLayout],
     config: &PipelineConfig,
 ) -> MeshResult<IndexedMesh> {
-    let mut result = SubstrateBuilder::well_plate_96(config.chip_height_mm).build_indexed()?;
+    let chip_height_mm = config.chip_height.in_unit::<Millimeter>();
+    let mut result = SubstrateBuilder::well_plate_96(chip_height_mm).build_indexed()?;
     for seg in layout {
         let void_mesh = build_segment_mesh(seg, config)?;
         result = boolean::csg_boolean(BooleanOp::Difference, &result, &void_mesh)?;
@@ -1981,6 +1985,10 @@ mod tests {
                 .iter()
                 .all(|trace| trace.schematic_volume.in_unit::<CubicMillimeter>() > 0.0)
         );
+        assert!(result
+            .layout_segments
+            .iter()
+            .all(|segment| segment.diameter.in_unit::<Millimeter>() > 0.0));
     }
 
     #[test]

--- a/crates/cfd-schematic-mesh/src/constraint.rs
+++ b/crates/cfd-schematic-mesh/src/constraint.rs
@@ -1,25 +1,26 @@
 //! Inlet/outlet diameter and wall-clearance constraints.
 
+use std::fmt;
+
+use aequitas::systems::si::{
+    quantities::Length,
+    units::{Meter, Millimeter},
+};
 use cfd_schematics::{NetworkBlueprint, NodeKind};
-use thiserror::Error;
 
 use super::well_plate::SbsWellPlate96;
 
-/// Required hydraulic diameter for inlet and outlet channels (m).
-pub const REQUIRED_HYD_DIAM_M: f64 = 4.0e-3;
-/// Allowed tolerance around the required diameter (m).
-pub const HYD_DIAM_TOLERANCE_M: f64 = 0.1e-3;
-/// Default wall clearance (mm).
-pub const DEFAULT_WALL_CLEARANCE: f64 = 5.0;
+/// Required hydraulic diameter for inlet and outlet channels.
+pub const REQUIRED_HYDRAULIC_DIAMETER: Length<f64> = Length::from_base(4.0e-3);
+/// Allowed tolerance around the required diameter.
+pub const HYDRAULIC_DIAMETER_TOLERANCE: Length<f64> = Length::from_base(0.1e-3);
+/// Default wall clearance.
+pub const DEFAULT_WALL_CLEARANCE: Length<f64> = Length::from_base(5.0e-3);
 
 /// Error returned when a channel's hydraulic diameter does not meet the 4 mm spec.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum DiameterConstraintError {
     /// Channel at an inlet/outlet node has the wrong hydraulic diameter.
-    #[error(
-        "channel '{channel_id}' at {node_kind} node '{node_id}' has hydraulic \
-         diameter {actual_m:.4e} m (expected {expected_m:.4e} ± {tolerance_m:.4e} m)"
-    )]
     WrongDiameter {
         /// Channel identifier.
         channel_id: String,
@@ -28,19 +29,47 @@ pub enum DiameterConstraintError {
         /// Node kind label ("inlet" or "outlet").
         node_kind: &'static str,
         /// Actual measured hydraulic diameter.
-        actual_m: f64,
+        actual: Length<f64>,
         /// Required hydraulic diameter.
-        expected_m: f64,
+        expected: Length<f64>,
         /// Allowed tolerance.
-        tolerance_m: f64,
+        tolerance: Length<f64>,
     },
     /// A node has no adjacent channels.
-    #[error("node '{node_id}' is isolated — no channels are adjacent")]
     IsolatedNode {
         /// Node identifier.
         node_id: String,
     },
 }
+
+impl fmt::Display for DiameterConstraintError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongDiameter {
+                channel_id,
+                node_id,
+                node_kind,
+                actual,
+                expected,
+                tolerance,
+            } => write!(
+                formatter,
+                "channel '{channel_id}' at {node_kind} node '{node_id}' has hydraulic diameter {:.4e} m (expected {:.4e} ± {:.4e} m)",
+                actual.in_unit::<Meter>(),
+                expected.in_unit::<Meter>(),
+                tolerance.in_unit::<Meter>(),
+            ),
+            Self::IsolatedNode { node_id } => {
+                write!(
+                    formatter,
+                    "node '{node_id}' is isolated — no channels are adjacent"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for DiameterConstraintError {}
 
 /// Validates that all inlet and outlet nodes have channels with hydraulic
 /// diameter `4.0 mm ± 0.1 mm`.
@@ -72,16 +101,19 @@ impl InletOutletConstraint {
             }
 
             for ch in adjacent {
-                let actual = ch.cross_section.hydraulic_diameter();
+                let actual = Length::from_unit::<Meter>(ch.cross_section.hydraulic_diameter());
                 // 1e-12 m slop guards against floating-point rounding at the tolerance boundary.
-                if (actual - REQUIRED_HYD_DIAM_M).abs() > HYD_DIAM_TOLERANCE_M + 1e-12 {
+                if (actual.in_unit::<Meter>() - REQUIRED_HYDRAULIC_DIAMETER.in_unit::<Meter>())
+                    .abs()
+                    > HYDRAULIC_DIAMETER_TOLERANCE.in_unit::<Meter>() + 1e-12
+                {
                     return Err(DiameterConstraintError::WrongDiameter {
                         channel_id: ch.id.as_str().to_string(),
                         node_id: node.id.to_string(),
                         node_kind,
-                        actual_m: actual,
-                        expected_m: REQUIRED_HYD_DIAM_M,
-                        tolerance_m: HYD_DIAM_TOLERANCE_M,
+                        actual,
+                        expected: REQUIRED_HYDRAULIC_DIAMETER,
+                        tolerance: HYDRAULIC_DIAMETER_TOLERANCE,
                     });
                 }
             }
@@ -91,49 +123,63 @@ impl InletOutletConstraint {
 }
 
 /// Wall clearance violation — a channel segment is too close to a plate edge.
-#[derive(Debug, Error)]
-#[error(
-    "channel segment ({x0:.2}, {y0:.2}) → ({x1:.2}, {y1:.2}) mm violates \
-     {clearance:.1} mm wall clearance on plate {plate_w:.2} × {plate_d:.2} mm"
-)]
+#[derive(Debug)]
 pub struct WallClearanceViolation {
-    /// Start X of the violating segment (mm).
-    pub x0: f64,
-    /// Start Y of the violating segment (mm).
-    pub y0: f64,
-    /// End X of the violating segment (mm).
-    pub x1: f64,
-    /// End Y of the violating segment (mm).
-    pub y1: f64,
-    /// Required clearance (mm).
-    pub clearance: f64,
-    /// Plate width (mm).
-    pub plate_w: f64,
-    /// Plate depth (mm).
-    pub plate_d: f64,
+    /// Start X of the violating segment.
+    pub x0: Length<f64>,
+    /// Start Y of the violating segment.
+    pub y0: Length<f64>,
+    /// End X of the violating segment.
+    pub x1: Length<f64>,
+    /// End Y of the violating segment.
+    pub y1: Length<f64>,
+    /// Required clearance.
+    pub clearance: Length<f64>,
+    /// Plate width.
+    pub plate_width: Length<f64>,
+    /// Plate depth.
+    pub plate_depth: Length<f64>,
 }
+
+impl fmt::Display for WallClearanceViolation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "channel segment ({:.2}, {:.2}) → ({:.2}, {:.2}) mm violates {:.1} mm wall clearance on plate {:.2} × {:.2} mm",
+            self.x0.in_unit::<Millimeter>(),
+            self.y0.in_unit::<Millimeter>(),
+            self.x1.in_unit::<Millimeter>(),
+            self.y1.in_unit::<Millimeter>(),
+            self.clearance.in_unit::<Millimeter>(),
+            self.plate_width.in_unit::<Millimeter>(),
+            self.plate_depth.in_unit::<Millimeter>(),
+        )
+    }
+}
+
+impl std::error::Error for WallClearanceViolation {}
 
 /// Validates that all channel segments remain within the SBS plate bounds.
 pub struct WallClearanceConstraint;
 
 impl WallClearanceConstraint {
     /// Check that all `(x0, y0) → (x1, y1)` segments stay inside the SBS plate
-    /// with the given clearance (in mm).
+    /// with the given clearance.
     #[allow(clippy::type_complexity)]
     pub fn check(
-        segments: &[((f64, f64), (f64, f64))],
-        clearance_mm: f64,
+        segments: &[((Length<f64>, Length<f64>), (Length<f64>, Length<f64>))],
+        clearance: Length<f64>,
     ) -> Result<(), WallClearanceViolation> {
         for &((x0, y0), (x1, y1)) in segments {
-            if !SbsWellPlate96::segment_within_bounds(x0, y0, x1, y1, clearance_mm) {
+            if !SbsWellPlate96::segment_within_bounds(x0, y0, x1, y1, clearance) {
                 return Err(WallClearanceViolation {
                     x0,
                     y0,
                     x1,
                     y1,
-                    clearance: clearance_mm,
-                    plate_w: SbsWellPlate96::WIDTH_MM,
-                    plate_d: SbsWellPlate96::DEPTH_MM,
+                    clearance,
+                    plate_width: SbsWellPlate96::WIDTH,
+                    plate_depth: SbsWellPlate96::DEPTH,
                 });
             }
         }
@@ -143,6 +189,7 @@ impl WallClearanceConstraint {
 
 #[cfg(test)]
 mod tests {
+    use aequitas::systems::si::units::Millimeter;
     use cfd_schematics::interface::presets::{serpentine_chain, venturi_chain};
     use cfd_schematics::NetworkBlueprint;
 
@@ -166,13 +213,30 @@ mod tests {
     #[test]
     fn four_mm_circular_passes() {
         let bp = venturi_chain("v", 0.030, 0.004, 0.002);
-        assert!(InletOutletConstraint::check(&bp).is_ok());
+        assert_eq!(
+            InletOutletConstraint::check(&bp).map_err(|error| error.to_string()),
+            Ok(())
+        );
     }
 
     #[test]
     fn two_mm_circular_fails() {
         let bp = serpentine_chain("s", 3, 0.010, 0.002);
-        assert!(InletOutletConstraint::check(&bp).is_err());
+        let error = InletOutletConstraint::check(&bp)
+            .expect_err("two millimetre inlet must violate the four millimetre contract");
+        match error {
+            DiameterConstraintError::WrongDiameter {
+                actual,
+                expected,
+                tolerance,
+                ..
+            } => {
+                assert_eq!(actual.in_unit::<Millimeter>(), 2.0);
+                assert_eq!(expected, REQUIRED_HYDRAULIC_DIAMETER);
+                assert_eq!(tolerance, HYDRAULIC_DIAMETER_TOLERANCE);
+            }
+            other => panic!("unexpected constraint error: {other}"),
+        }
     }
 
     #[test]
@@ -185,7 +249,10 @@ mod tests {
         bp.add_channel(ChannelSpec::new_pipe(
             "c", "inlet", "outlet", 0.01, 0.0041, 0.0, 0.0,
         ));
-        assert!(InletOutletConstraint::check(&bp).is_ok());
+        assert_eq!(
+            InletOutletConstraint::check(&bp).map_err(|error| error.to_string()),
+            Ok(())
+        );
     }
 
     #[test]
@@ -193,19 +260,50 @@ mod tests {
         use cfd_schematics::{NodeKind, NodeSpec};
         let mut bp = explicit_layout_blueprint("x");
         bp.add_node(NodeSpec::new_at("inlet", NodeKind::Inlet, (0.0, 0.0)));
-        assert!(InletOutletConstraint::check(&bp).is_err());
+        assert!(matches!(
+            InletOutletConstraint::check(&bp),
+            Err(DiameterConstraintError::IsolatedNode { node_id }) if node_id == "inlet"
+        ));
     }
 
     #[test]
     fn wall_clearance_passes_for_center_segment() {
-        let segments = vec![((10.0, 42.735), (117.76, 42.735))];
-        assert!(WallClearanceConstraint::check(&segments, 5.0).is_ok());
+        let segments = vec![(
+            (
+                Length::from_unit::<Millimeter>(10.0),
+                Length::from_unit::<Millimeter>(42.735),
+            ),
+            (
+                Length::from_unit::<Millimeter>(117.76),
+                Length::from_unit::<Millimeter>(42.735),
+            ),
+        )];
+        assert_eq!(
+            WallClearanceConstraint::check(&segments, Length::from_unit::<Millimeter>(5.0),)
+                .map_err(|error| error.to_string()),
+            Ok(())
+        );
     }
 
     #[test]
     fn wall_clearance_fails_for_out_of_bounds_segment() {
-        let segments = vec![((0.0, 42.735), (127.76, 42.735))];
-        assert!(WallClearanceConstraint::check(&segments, 5.0).is_err());
+        let segments = vec![(
+            (
+                Length::from_unit::<Millimeter>(0.0),
+                Length::from_unit::<Millimeter>(42.735),
+            ),
+            (
+                Length::from_unit::<Millimeter>(127.76),
+                Length::from_unit::<Millimeter>(42.735),
+            ),
+        )];
+        let error = WallClearanceConstraint::check(&segments, Length::from_unit::<Millimeter>(5.0))
+            .expect_err("a segment touching both plate faces must violate clearance");
+        assert_eq!(error.x0, Length::from_unit::<Millimeter>(0.0));
+        assert_eq!(error.x1, Length::from_unit::<Millimeter>(127.76));
+        assert_eq!(error.clearance, Length::from_unit::<Millimeter>(5.0));
+        assert_eq!(error.plate_width, SbsWellPlate96::WIDTH);
+        assert_eq!(error.plate_depth, SbsWellPlate96::DEPTH);
     }
 
     #[test]
@@ -220,6 +318,9 @@ mod tests {
             "c", "inlet", "outlet", 0.01, 0.0039, 0.0, 0.0,
         ));
         // 3.9 mm is exactly at the boundary (diff = 0.1e-3 = tolerance), should pass
-        assert!(InletOutletConstraint::check(&bp).is_ok());
+        assert_eq!(
+            InletOutletConstraint::check(&bp).map_err(|error| error.to_string()),
+            Ok(())
+        );
     }
 }

--- a/crates/cfd-schematic-mesh/src/shell_mesh.rs
+++ b/crates/cfd-schematic-mesh/src/shell_mesh.rs
@@ -21,6 +21,9 @@ use cfd_mesh::domain::geometry::tpms::{
 use cfd_mesh::domain::mesh::IndexedMesh;
 use hashbrown::HashMap;
 
+use aequitas::systems::si::quantities::Length;
+use aequitas::systems::si::units::Millimeter;
+
 use cfd_schematics::geometry::types::{InterchangeShellCuboid, TpmsSurfaceKind};
 
 // ── Pipeline configuration ────────────────────────────────────────────────────
@@ -28,20 +31,20 @@ use cfd_schematics::geometry::types::{InterchangeShellCuboid, TpmsSurfaceKind};
 /// Configuration for the `ShellMeshPipeline`.
 #[derive(Debug, Clone)]
 pub struct ShellPipelineConfig {
-    /// Desired 3-D height of the fluid cavity (Z-axis) (mm).  Typical: 1–2 mm.
-    pub cavity_height_mm: f64,
-    /// Desired 3-D height of the physical chip body (Z-axis) (mm).  Must be > cavity_height.
-    pub chip_height_mm: f64,
-    /// Z-coordinate for the mid-plane of the cavity (mm).
-    pub z_mid_mm: f64,
+    /// Desired 3-D height of the fluid cavity (Z-axis). Typical: 1–2 mm.
+    pub cavity_height: Length<f64>,
+    /// Desired 3-D height of the physical chip body (Z-axis). Must exceed the cavity height.
+    pub chip_height: Length<f64>,
+    /// Z-coordinate for the mid-plane of the cavity.
+    pub z_mid: Length<f64>,
 }
 
 impl Default for ShellPipelineConfig {
     fn default() -> Self {
         Self {
-            cavity_height_mm: 1.5,
-            chip_height_mm: 4.0,
-            z_mid_mm: 2.0,
+            cavity_height: Length::from_unit::<Millimeter>(1.5),
+            chip_height: Length::from_unit::<Millimeter>(4.0),
+            z_mid: Length::from_unit::<Millimeter>(2.0),
         }
     }
 }
@@ -78,11 +81,14 @@ impl ShellMeshPipeline {
     ) -> MeshResult<ShellPipelineOutput> {
         let (cw, ch) = shell.inner_dims_mm;
         let t = shell.shell_thickness_mm;
+        let cavity_height_mm = config.cavity_height.in_unit::<Millimeter>();
+        let chip_height_mm = config.chip_height.in_unit::<Millimeter>();
+        let z_mid_mm = config.z_mid.in_unit::<Millimeter>();
 
         // Origin of cavity is at (t, t) in schematic coords.
         let cvx = t;
         let cvy = t;
-        let cvz = config.z_mid_mm - config.cavity_height_mm / 2.0;
+        let cvz = z_mid_mm - cavity_height_mm / 2.0;
 
         let bounds = [
             cvx,
@@ -90,7 +96,7 @@ impl ShellMeshPipeline {
             cvz,
             cvx + cw,
             cvy + ch,
-            cvz + config.cavity_height_mm,
+            cvz + cavity_height_mm,
         ];
 
         // 1. Build the core cavity (either empty box or TPMS)
@@ -113,7 +119,7 @@ impl ShellMeshPipeline {
                 origin: cfd_mesh::domain::core::scalar::Point3r::new(cvx, cvy, cvz),
                 width: cw,
                 height: ch,
-                depth: config.cavity_height_mm,
+                depth: cavity_height_mm,
             }
             .build()
             .map_err(|e| MeshError::Other(e.to_string()))?
@@ -126,12 +132,12 @@ impl ShellMeshPipeline {
             let p1 = Vector3r::new(
                 port.outer_point_mm.0,
                 port.outer_point_mm.1,
-                config.z_mid_mm,
+                z_mid_mm,
             );
             let p2 = Vector3r::new(
                 port.inner_point_mm.0,
                 port.inner_point_mm.1,
-                config.z_mid_mm,
+                z_mid_mm,
             );
 
             // To ensure robust overlapping, we extend the inner point slightly into the cavity.
@@ -150,7 +156,7 @@ impl ShellMeshPipeline {
 
             // Port diameter defaults to 4mm to interface with 4mm tubing,
             // or 2mm if cavity is smaller.
-            let dia = config.cavity_height_mm.min(4.0);
+            let dia = cavity_height_mm.min(4.0);
 
             use cfd_mesh::application::channel::path::ChannelPath;
             use cfd_mesh::application::channel::profile::ChannelProfile;
@@ -208,7 +214,7 @@ impl ShellMeshPipeline {
             origin: cfd_mesh::domain::core::scalar::Point3r::origin(),
             width: shell.outer_dims_mm.0,
             height: shell.outer_dims_mm.1,
-            depth: config.chip_height_mm,
+            depth: chip_height_mm,
         }
         .build()
         .map_err(|e| MeshError::Other(e.to_string()))?;

--- a/crates/cfd-schematic-mesh/src/well_plate.rs
+++ b/crates/cfd-schematic-mesh/src/well_plate.rs
@@ -7,7 +7,9 @@
 //! Channel centerlines should be placed at:
 //! - `y = SbsWellPlate96::center_y()` — centered in the block width
 //! - `z = chip_height_mm / 2.0`        — centered in the block height
-//! - `x ∈ [0, WIDTH_MM]`               — inlet at left face, outlet at right
+//! - `x ∈ [0, WIDTH]`                  — inlet at left face, outlet at right
+
+use aequitas::systems::si::{quantities::Length, units::Meter};
 
 /// ANSI SBS 96-well plate outer dimensions used as the default substrate block size.
 ///
@@ -15,82 +17,113 @@
 pub struct SbsWellPlate96;
 
 impl SbsWellPlate96 {
-    /// Block length along X (mm).  Channels route from `x = 0` to `x = WIDTH_MM`.
-    pub const WIDTH_MM: f64 = 127.76;
+    /// Block length along X. Channels route from `x = 0` to `x = WIDTH`.
+    pub const WIDTH: Length<f64> = Length::from_base(0.12776);
 
-    /// Block width along Y (mm).  Channel centerline at `y = DEPTH_MM / 2`.
-    pub const DEPTH_MM: f64 = 85.47;
+    /// Block width along Y. Channel centerline is at `y = DEPTH / 2`.
+    pub const DEPTH: Length<f64> = Length::from_base(0.08547);
 
-    /// Standard center Y for all channels: `DEPTH_MM / 2 = 42.735 mm`.
-    pub fn center_y() -> f64 {
-        Self::DEPTH_MM / 2.0
+    /// Standard center Y for all channels: `DEPTH / 2 = 42.735 mm`.
+    pub fn center_y() -> Length<f64> {
+        Length::from_base(Self::DEPTH.as_base() / 2.0)
     }
 
-    /// `true` if a 2-D point `(x, y)` (in mm) lies strictly within the block
-    /// minus `clearance_mm` on all sides.
-    pub fn contains_point(x: f64, y: f64, clearance_mm: f64) -> bool {
-        x >= clearance_mm
-            && x <= Self::WIDTH_MM - clearance_mm
-            && y >= clearance_mm
-            && y <= Self::DEPTH_MM - clearance_mm
+    /// `true` if a 2-D point `(x, y)` lies within the block minus clearance
+    /// on all sides.
+    pub fn contains_point(x: Length<f64>, y: Length<f64>, clearance: Length<f64>) -> bool {
+        let x = x.in_unit::<Meter>();
+        let y = y.in_unit::<Meter>();
+        let clearance = clearance.in_unit::<Meter>();
+        x >= clearance
+            && x <= Self::WIDTH.in_unit::<Meter>() - clearance
+            && y >= clearance
+            && y <= Self::DEPTH.in_unit::<Meter>() - clearance
     }
 
-    /// `true` if the straight segment from `(x0, y0)` to `(x1, y1)` (mm) lies
-    /// within block bounds minus `clearance_mm` at **both** endpoints.
-    pub fn segment_within_bounds(x0: f64, y0: f64, x1: f64, y1: f64, clearance_mm: f64) -> bool {
-        Self::contains_point(x0, y0, clearance_mm) && Self::contains_point(x1, y1, clearance_mm)
+    /// `true` if the straight segment from `(x0, y0)` to `(x1, y1)` lies
+    /// within block bounds minus clearance at **both** endpoints.
+    pub fn segment_within_bounds(
+        x0: Length<f64>,
+        y0: Length<f64>,
+        x1: Length<f64>,
+        y1: Length<f64>,
+        clearance: Length<f64>,
+    ) -> bool {
+        Self::contains_point(x0, y0, clearance) && Self::contains_point(x1, y1, clearance)
     }
 
     /// `true` if the routing segment stays within the plate for channel layout.
     ///
-    /// Inlet/outlet faces lie at `x = 0` and `x = WIDTH_MM` — segments are
+    /// Inlet/outlet faces lie at `x = 0` and `x = WIDTH` — segments are
     /// allowed to reach those faces (`x_clearance = 0`).  Side walls (Y
-    /// direction) still require `side_clearance_mm` of keep-out margin.
-    /// Any X coordinate outside `[0, WIDTH_MM]` is rejected.
+    /// direction) still require `side_clearance` of keep-out margin.
+    /// Any X coordinate outside `[0, WIDTH]` is rejected.
     pub fn segment_within_routing_bounds(
-        x0: f64,
-        y0: f64,
-        x1: f64,
-        y1: f64,
-        side_clearance_mm: f64,
+        x0: Length<f64>,
+        y0: Length<f64>,
+        x1: Length<f64>,
+        y1: Length<f64>,
+        side_clearance: Length<f64>,
     ) -> bool {
-        let in_x = |x: f64| (0.0..=Self::WIDTH_MM).contains(&x);
-        let in_y = |y: f64| (side_clearance_mm..=Self::DEPTH_MM - side_clearance_mm).contains(&y);
+        let in_x = |x: Length<f64>| {
+            let x = x.in_unit::<Meter>();
+            (0.0..=Self::WIDTH.in_unit::<Meter>()).contains(&x)
+        };
+        let in_y = |y: Length<f64>| {
+            let y = y.in_unit::<Meter>();
+            let clearance = side_clearance.in_unit::<Meter>();
+            (clearance..=Self::DEPTH.in_unit::<Meter>() - clearance).contains(&y)
+        };
         in_x(x0) && in_y(y0) && in_x(x1) && in_y(y1)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use aequitas::systems::si::units::Millimeter;
+
     use super::*;
 
     #[test]
     fn center_y_is_half_depth() {
         let cy = SbsWellPlate96::center_y();
-        assert!((cy - 42.735).abs() < 1e-6, "center_y = {cy}");
+        let cy_mm = cy.in_unit::<Millimeter>();
+        assert!((cy_mm - 42.735).abs() < 1e-6, "center_y = {cy_mm}");
     }
 
     #[test]
     fn width_depth_constants() {
-        assert!((SbsWellPlate96::WIDTH_MM - 127.76).abs() < 1e-9);
-        assert!((SbsWellPlate96::DEPTH_MM - 85.47).abs() < 1e-9);
+        assert!((SbsWellPlate96::WIDTH.in_unit::<Millimeter>() - 127.76).abs() < 1e-9);
+        assert!((SbsWellPlate96::DEPTH.in_unit::<Millimeter>() - 85.47).abs() < 1e-9);
     }
 
     #[test]
     fn contains_point_inside() {
-        assert!(SbsWellPlate96::contains_point(63.88, 42.735, 5.0));
+        assert!(SbsWellPlate96::contains_point(
+            Length::from_unit::<Millimeter>(63.88),
+            Length::from_unit::<Millimeter>(42.735),
+            Length::from_unit::<Millimeter>(5.0),
+        ));
     }
 
     #[test]
     fn contains_point_outside_left() {
-        assert!(!SbsWellPlate96::contains_point(1.0, 42.7, 5.0));
+        assert!(!SbsWellPlate96::contains_point(
+            Length::from_unit::<Millimeter>(1.0),
+            Length::from_unit::<Millimeter>(42.7),
+            Length::from_unit::<Millimeter>(5.0),
+        ));
     }
 
     #[test]
     fn segment_within_bounds_rejects_out_of_range() {
         // segment starting at x=0 must fail with 5 mm clearance
         assert!(!SbsWellPlate96::segment_within_bounds(
-            0.0, 42.735, 127.76, 42.735, 5.0
+            Length::from_unit::<Millimeter>(0.0),
+            Length::from_unit::<Millimeter>(42.735),
+            Length::from_unit::<Millimeter>(127.76),
+            Length::from_unit::<Millimeter>(42.735),
+            Length::from_unit::<Millimeter>(5.0),
         ));
     }
 }

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -202,16 +202,18 @@ value assertions, targeted Rustfmt, and a clean diff check.
 
 ### 2026-08-02: Aequitas owns schematic mesh geometry metrics [major] [arch]
 
-Context: `cfd-schematic-mesh` runtime configuration and emitted
-`SegmentCenterline` values documented millimetres, radians, and dimensionless
-fractions but exposed raw scalars at the public boundary.
+Context: `cfd-schematic-mesh` runtime configuration, emitted
+`SegmentCenterline` values, and SBS plate/wall-clearance constraints documented
+millimetres, radians, and dimensionless fractions but exposed raw scalars at
+the public boundary.
 
-Decision: carry blueprint angles, chip/cavity dimensions, wall clearances, CSG
-overlap fractions, centerline coordinates, and centerline diameters through
-Aequitas `Angle`, `Length`, and `Dimensionless`. Extract base scalars only at
-mesh-provider, trigonometric, routing, and CSG formula boundaries. The
-serialized `cfd-schematics` interchange payload remains a separate
-unit-labelled format boundary.
+Decision: carry blueprint angles, chip/cavity dimensions, wall clearances, SBS
+plate bounds, constraint coordinates, CSG overlap fractions, centerline
+coordinates, and centerline diameters through Aequitas `Angle`, `Length`, and
+`Dimensionless`. Extract base scalars only at mesh-provider, trigonometric,
+routing, comparison, and CSG formula boundaries. The serialized
+`cfd-schematics` interchange payload remains a separate unit-labelled format
+boundary.
 
 Rejected alternative: retain scalar configuration fields or add typed
 accessors beside them. Both preserve an untyped construction path and create
@@ -223,10 +225,10 @@ physical unit applies, and complex values remain reserved for genuine
 phasor/Fourier data.
 
 Verification: `cargo metadata --offline --locked --no-deps`, the typed-field
-residue scan, and `git diff --check` pass. Focused package compilation is
-currently blocked before rustc because the locked Moirai revision requests a
-`mnemosyne` package unavailable in the local provider checkout; the exact
-provider residual is recorded in `gap_audit.md`.
+residue scan, and `git diff --check` pass. The standalone locked package check,
+Clippy with `-D warnings`, Nextest (29/29), doctests, and Rustdoc pass. The
+Atlas umbrella overlay remains a separate local-only resolver context because
+its working-tree package versions do not match the standalone lock.
 
 ### 2026-07-31: Aequitas owns analytical Stokes metrics [major] [arch]
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -29,6 +29,7 @@
 | **Aequitas-owned analytical non-Newtonian metrics** | 2026-07-31 | The cfd-validation non-Newtonian Poiseuille models erased fixed dimensions from geometry and derived metrics | Length, PressureGradient, Velocity, AreaPerTime, Pressure, ReciprocalTime, MassDensity, and Dimensionless remain typed through the validation boundary; the exponent-dependent `PowerLawConsistency` coefficient remains formula-bound; constitutive, integration, and mesh boundaries extract scalars | Breaking change for external analytical-validation constructors and callers |
 | **Canonical analytical benchmark ownership** | 2026-07-31 | `analytical_benchmarks` duplicated raw-scalar Couette, Poiseuille, and Taylor-Green models beside the canonical analytical modules | Remove duplicate model implementations and migrate the physics-validation consumer to canonical Aequitas-backed APIs; retain only normalized Ghia reference tables | Breaking removal of the legacy duplicate model names from `analytical_benchmarks` |
 | **Aequitas-owned schematic volume metrics** | 2026-07-31 | `cfd-schematics` volume summaries and `cfd-schematic-mesh` diagnostics exposed unit-suffixed length, area, volume, and percentage `f64` fields, including redundant mm³/uL pairs | `Length`, `Area`, `Volume`, and `Dimensionless` remain typed through public schematic and mesh volume contracts; mesh signed-volume and percentage calculations are explicit scalar boundaries | Breaking change for schematic and mesh diagnostic consumers |
+| **Aequitas-owned schematic mesh geometry metrics** | 2026-08-02 | `cfd-schematic-mesh` runtime configuration and emitted centerlines exposed angles, lengths, clearances, overlap fractions, and diameters as raw scalars | `Angle`, `Length`, and `Dimensionless` remain typed through blueprint/shell configuration and centerline output; mesh-provider, trigonometric, and CSG boundaries extract explicit scalars | Breaking change for runtime mesh configuration and centerline consumers |
 | **Canonical cfd-3d turbulence module** | 2026-07-31 | The crate-level turbulence module was a no-op placeholder beside the real Eunomia-backed models under `physics::turbulence` | One public module re-exports the canonical input-sensitive implementations; typed physical turbulence outputs are defined by the following Aequitas decision | Breaking removal of the placeholder model names; metric return types are covered by the following breaking decision |
 | **Aequitas-owned cfd-core turbulence metrics** | 2026-07-31 | `cfd-core::TurbulenceModel` exposed turbulent viscosity and kinetic energy as raw scalar vectors | `KinematicViscosity<T>` and `SpecificEnergy<T>` remain typed through the shared trait and every canonical cfd-3d closure; scalar extraction is confined to formulas and dense-field assertions | Breaking change for turbulence implementors and consumers; real Eunomia values only, with no imaginary-unit metric |
 | **Aequitas-owned cfd-3d multiphase mixture metrics** | 2026-07-31 | The phase-fraction exchange function accepted raw density and viscosity scalars despite being a public physical-property boundary | `Dimensionless`, `MassDensity`, and `DynamicViscosity` remain typed through the interpolation API; formula extraction is explicit and real-valued | Breaking change for multiphase exchange callers |
@@ -198,6 +199,34 @@ Verification: focused package check passes for `cfd-schematics` and
 `cfd-schematic-mesh`; Nextest run `0383cb4d-2e80-43e5-a0e0-683025defcbd`
 passes 207/207. The source migration includes summary and mesh-trace
 value assertions, targeted Rustfmt, and a clean diff check.
+
+### 2026-08-02: Aequitas owns schematic mesh geometry metrics [major] [arch]
+
+Context: `cfd-schematic-mesh` runtime configuration and emitted
+`SegmentCenterline` values documented millimetres, radians, and dimensionless
+fractions but exposed raw scalars at the public boundary.
+
+Decision: carry blueprint angles, chip/cavity dimensions, wall clearances, CSG
+overlap fractions, centerline coordinates, and centerline diameters through
+Aequitas `Angle`, `Length`, and `Dimensionless`. Extract base scalars only at
+mesh-provider, trigonometric, routing, and CSG formula boundaries. The
+serialized `cfd-schematics` interchange payload remains a separate
+unit-labelled format boundary.
+
+Rejected alternative: retain scalar configuration fields or add typed
+accessors beside them. Both preserve an untyped construction path and create
+two owners for the same geometry.
+
+Consequences: external mesh configuration and centerline consumers require the
+typed fields. The geometry remains real-valued under Eunomia; no imaginary
+physical unit applies, and complex values remain reserved for genuine
+phasor/Fourier data.
+
+Verification: `cargo metadata --offline --locked --no-deps`, the typed-field
+residue scan, and `git diff --check` pass. Focused package compilation is
+currently blocked before rustc because the locked Moirai revision requests a
+`mnemosyne` package unavailable in the local provider checkout; the exact
+provider residual is recorded in `gap_audit.md`.
 
 ### 2026-07-31: Aequitas owns analytical Stokes metrics [major] [arch]
 

--- a/docs/atlas-migration/schematic-mesh-geometry-metrics.md
+++ b/docs/atlas-migration/schematic-mesh-geometry-metrics.md
@@ -15,6 +15,8 @@ Use Aequitas quantities for the runtime mesh contract:
 - `ShellPipelineConfig` carries cavity height, chip height, and cavity mid-plane
   as `Length` values;
 - `SegmentCenterline` carries coordinates and diameter as `Length` values.
+- `SbsWellPlate96` bounds and wall-clearance constraints carry dimensions,
+  coordinates, and error metrics as `Length` values.
 
 The mesh provider still consumes millimetre/radian scalars at the explicit
 trigonometry, routing, primitive, and CSG formula boundaries. The serialized
@@ -33,9 +35,9 @@ untyped path. Both alternatives are rejected.
 
 ## Verification contract
 
-The focused `cfd-schematic-mesh` package check and value-semantic Nextest are
-required. The standalone provider graph is currently blocked before package
-compilation because the locked Moirai revision requests a `mnemosyne` package
-that is not available in the local git checkout; this external provider
-residual is recorded in `gap_audit.md` and does not change the geometry
-contract.
+The standalone locked `cfd-schematic-mesh` package check, Clippy with
+`-D warnings`, value-semantic Nextest (29/29), doctests, and Rustdoc pass. A
+typed-field residue scan and `git diff --check` also pass. The Atlas umbrella
+development overlay is not used for this standalone lock gate because its
+working-tree provider versions do not match the committed lock; this local
+resolver distinction does not change the geometry contract.

--- a/docs/atlas-migration/schematic-mesh-geometry-metrics.md
+++ b/docs/atlas-migration/schematic-mesh-geometry-metrics.md
@@ -1,0 +1,41 @@
+# Schematic mesh geometry metrics
+
+## Context
+
+`cfd-schematic-mesh` exposed runtime mesh configuration and emitted layout
+geometry as unit-suffixed scalars. Angles, chip and cavity dimensions, wall
+clearances, CSG overlap fractions, centerline coordinates, and diameters could
+therefore cross the public mesh boundary without a dimensional type check.
+
+## Decision
+
+Use Aequitas quantities for the runtime mesh contract:
+
+- `PipelineConfig` carries `Angle`, `Length`, and `Dimensionless` values;
+- `ShellPipelineConfig` carries cavity height, chip height, and cavity mid-plane
+  as `Length` values;
+- `SegmentCenterline` carries coordinates and diameter as `Length` values.
+
+The mesh provider still consumes millimetre/radian scalars at the explicit
+trigonometry, routing, primitive, and CSG formula boundaries. The serialized
+`cfd-schematics` interchange payload remains a separate unit-labelled format
+boundary and is not treated as a second runtime owner of these values.
+
+No complex or imaginary physical quantity applies: mesh geometry is real under
+Eunomia's real scalar contract. Eunomia complex values remain valid only for
+genuine phasor/Fourier data elsewhere in the stack.
+
+## Rejected alternative
+
+Keeping raw public fields would preserve dimensional ambiguity. Adding typed
+accessors beside the scalar fields would create two owners and retain the
+untyped path. Both alternatives are rejected.
+
+## Verification contract
+
+The focused `cfd-schematic-mesh` package check and value-semantic Nextest are
+required. The standalone provider graph is currently blocked before package
+compilation because the locked Moirai revision requests a `mnemosyne` package
+that is not available in the local git checkout; this external provider
+residual is recorded in `gap_audit.md` and does not change the geometry
+contract.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,32 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+## Schematic mesh geometry metrics (CFDRS-AEQ-MET-46, 2026-08-02)
+
+The audit found a remaining public Aequitas gap in `cfd-schematic-mesh`:
+`PipelineConfig` and `ShellPipelineConfig` exposed angles, lengths,
+clearances, CSG overlap fractions, and cavity dimensions as raw scalars, and
+`SegmentCenterline` exposed millimetre coordinates and diameter as raw
+scalars. These values are runtime mesh contracts rather than serialized
+interchange data.
+
+The gap is resolved. Runtime configuration now carries Aequitas `Angle`,
+`Length`, and `Dimensionless` values; emitted centerline coordinates and
+diameter carry `Length`. Scalar extraction occurs only when routing, primitive
+mesh, trigonometric, or CSG formulas require the provider scalar. The
+unit-labelled `cfd-schematics` interchange payload remains an explicit
+serialization boundary and is not duplicated as a second typed runtime owner.
+
+The geometry is real-valued under Eunomia. No complex or imaginary physical
+unit is introduced; Eunomia complex values remain reserved for genuine
+phasor/Fourier fields elsewhere in the stack.
+
+Verification: `cargo metadata --offline --locked --no-deps`, the typed-field
+residue scan, and `git diff --check` pass. The focused package check is blocked
+before rustc by the locked Moirai revision requesting a `mnemosyne` package
+that is unavailable in the local provider checkout. This is an external
+provider-resolution residual, not a geometry implementation failure.
+
 ## Standalone provider lock and hosted gate closure (2026-07-31)
 
 The Aequitas provider lock gap is closed. Aequitas commit `7f6afaf` restored

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -35,27 +35,39 @@
 
 The audit found a remaining public Aequitas gap in `cfd-schematic-mesh`:
 `PipelineConfig` and `ShellPipelineConfig` exposed angles, lengths,
-clearances, CSG overlap fractions, and cavity dimensions as raw scalars, and
+clearances, CSG overlap fractions, and cavity dimensions as raw scalars;
 `SegmentCenterline` exposed millimetre coordinates and diameter as raw
-scalars. These values are runtime mesh contracts rather than serialized
-interchange data.
+scalars; and the wall-clearance/plate constraint APIs exposed raw segment
+coordinates, dimensions, and error metrics. These values are runtime mesh
+contracts rather than serialized interchange data.
 
 The gap is resolved. Runtime configuration now carries Aequitas `Angle`,
 `Length`, and `Dimensionless` values; emitted centerline coordinates and
-diameter carry `Length`. Scalar extraction occurs only when routing, primitive
-mesh, trigonometric, or CSG formulas require the provider scalar. The
-unit-labelled `cfd-schematics` interchange payload remains an explicit
-serialization boundary and is not duplicated as a second typed runtime owner.
+diameter carry `Length`; and SBS plate bounds, wall-clearance inputs, and
+constraint error metrics carry `Length`. Scalar extraction occurs only when
+routing, primitive mesh, trigonometric, comparison, or CSG formulas require
+the provider scalar. The unit-labelled `cfd-schematics` interchange payload
+remains an explicit serialization boundary and is not duplicated as a second
+typed runtime owner.
 
 The geometry is real-valued under Eunomia. No complex or imaginary physical
 unit is introduced; Eunomia complex values remain reserved for genuine
 phasor/Fourier fields elsewhere in the stack.
 
 Verification: `cargo metadata --offline --locked --no-deps`, the typed-field
-residue scan, and `git diff --check` pass. The focused package check is blocked
-before rustc by the locked Moirai revision requesting a `mnemosyne` package
-that is unavailable in the local provider checkout. This is an external
-provider-resolution residual, not a geometry implementation failure.
+residue scan, and `git diff --check` pass. The standalone lock now resolves the
+current `moirai-runtime` and `mnemosyne-memory` package graph; the focused
+locked package all-target check, Clippy (`-D warnings`), Nextest run
+`a524f1a7-5676-4d8e-b9d9-d7f82aa6084e` (29/29), doctests, and Rustdoc pass
+through `cfd-schematic-mesh`. No provider-resolution residual remains for this
+geometry slice. The Atlas umbrella overlay remains
+a separate local-only resolver context because its current working-tree
+package versions do not match the standalone lock.
+
+The manifest and workflow now use the provider's `moirai-runtime` package and
+the immutable Atlas checkout action at `11581413ddd1da6fd849dd2c4ad11fdbb6ce673a`.
+The regenerated lock records current Aequitas, Apollo, Coeus, Hephaestus,
+Moirai, Mnemosyne, RITK, and related provider source identities.
 
 ## Standalone provider lock and hosted gate closure (2026-07-31)
 

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -58,7 +58,7 @@ Verification: `cargo metadata --offline --locked --no-deps`, the typed-field
 residue scan, and `git diff --check` pass. The standalone lock now resolves the
 current `moirai-runtime` and `mnemosyne-memory` package graph; the focused
 locked package all-target check, Clippy (`-D warnings`), Nextest run
-`a524f1a7-5676-4d8e-b9d9-d7f82aa6084e` (29/29), doctests, and Rustdoc pass
+`5091fabe-e3da-4e76-a6ed-8c0377b0b0ee` (29/29), doctests, and Rustdoc pass
 through `cfd-schematic-mesh`. No provider-resolution residual remains for this
 geometry slice. The Atlas umbrella overlay remains
 a separate local-only resolver context because its current working-tree
@@ -68,6 +68,13 @@ The manifest and workflow now use the provider's `moirai-runtime` package and
 the immutable Atlas checkout action at `11581413ddd1da6fd849dd2c4ad11fdbb6ce673a`.
 The regenerated lock records current Aequitas, Apollo, Coeus, Hephaestus,
 Moirai, Mnemosyne, RITK, and related provider source identities.
+
+The semver gate was attempted with `cargo semver-checks` using the historical
+`HEAD` baseline. The current crate built and parsed, but the baseline update
+stopped because that historical manifest still requests the retired `moirai`
+package; the registry baseline is unavailable because `cfd-schematic-mesh` is
+not published. This is a baseline/tooling limitation, not a regression in the
+current typed contract; the deliberate breaking change is recorded in the ADR.
 
 ## Standalone provider lock and hosted gate closure (2026-07-31)
 


### PR DESCRIPTION
## Outcome
Carry runtime cfd-schematic-mesh angles, lengths, clearances, overlap fractions, cavity dimensions, centerline coordinates, and diameters through Aequitas. Scalar extraction remains at mesh-provider, routing, trigonometric, and CSG boundaries. The serialized cfd-schematics interchange payload remains a separate unit-labelled boundary.

## Verification
- cargo metadata --offline --locked --no-deps: passed
- typed-field residue scan: passed
- git diff --check: passed
- value-semantic centerline diameter regression added
- Eunomia audit: real geometry only; no imaginary physical unit

## Local provider blocker
The focused package check cannot start because the standalone lock's pinned Moirai revision requests a mnemosyne package unavailable in the local provider checkout. This is recorded in gap_audit.md as an external provider-resolution residual, not a geometry implementation failure.

Refs: backlog.md#cfdrs-aequitas-metric-46
Refs: docs/atlas-migration/schematic-mesh-geometry-metrics.md
BREAKING CHANGE: cfd-schematic-mesh runtime geometry configuration and SegmentCenterline fields are now typed with Aequitas quantities.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces typed geometry configuration for the `cfd-schematic-mesh` module by replacing raw scalar angles, lengths, clearances, overlap fractions, cavity dimensions, centerline coordinates, and diameters with strongly-typed Aequitas quantities (`Angle`, `Length`, and `Dimensionless`). Scalar extraction is now confined to mesh-provider, routing, trigonometric, and CSG formula boundaries, while the serialized interchange payload remains a separate unit-labelled boundary. The geometry remains real-valued under Eunomia with no imaginary physical units introduced. This is a **breaking change** requiring external configuration and centerline consumers to use the typed fields.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/atlas-migration/schematic-mesh-geometry-metrics.md` |
| 2 | `docs/adr.md` |
| 3 | `gap_audit.md` |
| 4 | `CHECKLIST.md` |
| 5 | `backlog.md` |
| 6 | `CHANGELOG.md` |
| 7 | `crates/cfd-schematic-mesh/src/blueprint_mesh.rs` |
| 8 | `crates/cfd-schematic-mesh/src/shell_mesh.rs` |
| 9 | `crates/cfd-schematic-mesh/examples/schematic_to_openfoam.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Geometry configuration now uses explicit units for lengths, angles, areas, volumes, and dimensionless values.
  * Centerline coordinates and diameters are returned with length units.
  * Update integrations using renamed configuration fields, including chip, wall-clearance, cavity, and mid-plane dimensions.

* **Examples**
  * Updated the OpenFOAM schematic example to work with unit-aware chip-height configuration.

* **Documentation**
  * Added migration guidance, architecture notes, audit records, and verification details for the typed geometry contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->