### PR TITLE
feat(cfd)!: Type Venturi and Dean metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Breaking:** Type Venturi geometry metadata with Aequitas `Length`,
+  `Angle`, and `Dimensionless` values, and type `ChannelVenturiSpec` pressure
+  and cavitation-dose results. Extract Eunomia base scalars only at numerical,
+  mesh, and serialization boundaries. Canonical angle fields store radians and
+  remain real-valued; no imaginary physical unit applies.
+
 - **Breaking:** Type schematic-mesh runtime geometry configuration and emitted
   centerline coordinates/diameters with Aequitas `Angle`, `Length`, and
   `Dimensionless` quantities. Scalar extraction remains at mesh, trigonometric,

--- a/backlog.md
+++ b/backlog.md
@@ -31,6 +31,20 @@
 
 ## Active integration
 
+- **CFDRS-AEQ-MET-47 [major] - Type Venturi geometry metadata (in progress
+  2026-08-05; owner=current Codex session; scope=`cfd-schematics` therapy
+  metadata and its direct geometry/1D consumers).** Venturi geometry metadata
+  now carries Aequitas `Length`, `Angle`, and `Dimensionless` values;
+  `ChannelVenturiSpec` carries typed geometry and returns typed pressure and
+  dose results; FDA cavitation compliance accepts typed pressure/density and
+  returns typed Mach-index values. Scalar extraction remains at 1D/2D formulas,
+  mesh conversion, and serialized interchange boundaries. The angle fields now
+  use canonical names and store Eunomia base radians. Value-semantic
+  metadata/formula tests, direct consumers, and the synchronized audit are
+  migrated. Eunomia remains real-valued for this geometry; no imaginary SI
+  unit applies. Remaining provider/linker or peer-worktree gate failures are
+  tracked separately from this metric closure.
+
 - **CFDRS-AEQ-MET-46 [major] - Type schematic mesh geometry configuration
   (done 2026-08-02; owner=current Codex session; scope=
   `cfd-schematic-mesh` pipeline configuration and emitted centerline geometry).**
@@ -84,16 +98,12 @@
   Eunomia boundary has no complex or imaginary physical unit.
 
 - **CFDRS-AEQ-MET-43 [major] - Type schematic volume metrics
-  (VERIFIED 2026-07-31; owner=current Codex session; claimed 2026-07-31;
+  (done 2026-07-31; owner=current Codex session; claimed 2026-07-31;
   scope=`cfd-schematics` volume summaries, `cfd-schematic-mesh` volume traces
   and example consumer, plus synchronized audit/design/changelog artifacts).**
-  The public schematic and mesh volume contracts still expose length, area,
-  volume, and volume-error values as unit-suffixed `f64` fields. Replace those
-  fields with Aequitas `Length`, `Area`, and `Volume`, remove the redundant
-  millimetre/microlitre field pairs, and keep scalar extraction at mesh-volume
-  and percentage formula boundaries. Acceptance is a source migration with
-  value-semantic summary/trace assertions, focused package gates, and exact
-  Eunomia real/complex boundary documentation. The focused package check is
+  The public schematic and mesh volume contracts use Aequitas `Length`,
+  `Area`, `Volume`, and `Dimensionless` values. Scalar extraction remains at
+  mesh-volume and percentage formula boundaries. The focused package check is
   green and Nextest passes 207/207.
 
 - **CFDRS-VAL-RED-1 [patch] - Root-cause the remaining cfd-validation red set

--- a/backlog.md
+++ b/backlog.md
@@ -31,7 +31,7 @@
 
 ## Active integration
 
-- **CFDRS-AEQ-MET-47 [major] - Type Venturi geometry metadata (in progress
+- **CFDRS-AEQ-MET-47 [major] - Type Venturi geometry metadata (done
   2026-08-05; owner=current Codex session; scope=`cfd-schematics` therapy
   metadata and its direct geometry/1D consumers).** Venturi geometry metadata
   now carries Aequitas `Length`, `Angle`, and `Dimensionless` values;
@@ -43,7 +43,17 @@
   metadata/formula tests, direct consumers, and the synchronized audit are
   migrated. Eunomia remains real-valued for this geometry; no imaginary SI
   unit applies. Remaining provider/linker or peer-worktree gate failures are
-  tracked separately from this metric closure.
+  tracked separately from this metric closure. Evidence: commits `9dfd57c2`
+  and `5aa2d9f1`, `cfd-schematics` warning-denied Clippy,
+  `cfd-schematics` Nextest 158/158 (`47490ed6-44c0-448c-af2c-dad01cdf5c18`),
+  `cfd-1d` library Nextest 498/498 (`0ab2db66-61ea-4687-b1cd-0ae0b4d2c7a1`),
+  the `blueprint_metadata_physics` integration target 5/5
+  (`fc331715-f569-434e-ac39-878a71527903`), and focused cfd-1d/cfd-2d/mesh
+  source checks. The full cfd-schematics doctest gate ran 15/16; Windows
+  Defender quarantined the unrelated `SmoothTransitionConfig` doctest
+  executable with OS error 225 and `Trojan:Win32/Wacatac.C!ml` (ThreatID
+  `2147749372`). No exclusion or test weakening was applied; this host
+  residual is not a metric implementation failure.
 
 - **CFDRS-AEQ-MET-46 [major] - Type schematic mesh geometry configuration
   (done 2026-08-02; owner=current Codex session; scope=

--- a/crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs
+++ b/crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs
@@ -51,15 +51,19 @@ where
         }
     };
 
-    let inlet_width = validate_positive("inlet width", metadata.inlet_width_m)?;
-    let throat_width = validate_positive("throat width", metadata.throat_width_m)?;
-    let throat_height = validate_positive("throat height", metadata.throat_height_m)?;
-    let outlet_width = validate_positive("outlet width", metadata.outlet_width_m)?;
-    let throat_length = validate_positive("throat length", metadata.throat_length_m)?;
-    let convergent_angle =
-        validate_angle("convergent half-angle", metadata.convergent_half_angle_deg)?;
-    let divergent_angle =
-        validate_angle("divergent half-angle", metadata.divergent_half_angle_deg)?;
+    let inlet_width = validate_positive("inlet width", metadata.inlet_width_m.into_base())?;
+    let throat_width = validate_positive("throat width", metadata.throat_width_m.into_base())?;
+    let throat_height = validate_positive("throat height", metadata.throat_height_m.into_base())?;
+    let outlet_width = validate_positive("outlet width", metadata.outlet_width_m.into_base())?;
+    let throat_length = validate_positive("throat length", metadata.throat_length_m.into_base())?;
+    let convergent_angle = validate_angle(
+        "convergent half-angle",
+        metadata.convergent_half_angle.into_base().to_degrees(),
+    )?;
+    let divergent_angle = validate_angle(
+        "divergent half-angle",
+        metadata.divergent_half_angle.into_base().to_degrees(),
+    )?;
 
     let hydraulic_diameter =
         |width_m: f64, height_m: f64| 2.0 * width_m * height_m / (width_m + height_m);
@@ -94,6 +98,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::venturi_coefficients;
+    use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
     use cfd_core::physics::fluid::database::water_20c;
     use cfd_schematics::geometry::metadata::VenturiGeometryMetadata;
     use eunomia::assert_relative_eq;
@@ -107,14 +112,14 @@ mod tests {
         use crate::{discharge_coefficient_from_convergent_half_angle_deg, venturi_taper_length_m};
 
         let metadata = VenturiGeometryMetadata {
-            throat_width_m: 4.0e-4,
-            throat_height_m: 2.0e-4,
-            throat_length_m: 8.0e-4,
-            inlet_width_m: 1.0e-3,
-            outlet_width_m: 1.2e-3,
-            convergent_half_angle_deg: 7.0,
-            divergent_half_angle_deg: 5.0,
-            throat_position: 0.5,
+            throat_width_m: Length::from_base(4.0e-4),
+            throat_height_m: Length::from_base(2.0e-4),
+            throat_length_m: Length::from_base(8.0e-4),
+            inlet_width_m: Length::from_base(1.0e-3),
+            outlet_width_m: Length::from_base(1.2e-3),
+            convergent_half_angle: Angle::from_base(7.0_f64.to_radians()),
+            divergent_half_angle: Angle::from_base(5.0_f64.to_radians()),
+            throat_position: Dimensionless::from_base(0.5),
         };
         let fluid = water_20c::<f64>()?;
 
@@ -122,36 +127,35 @@ mod tests {
 
         let hydraulic_diameter =
             |width_m: f64, height_m: f64| 2.0 * width_m * height_m / (width_m + height_m);
-        let inlet_d = hydraulic_diameter(metadata.inlet_width_m, metadata.throat_height_m);
-        let throat_d = hydraulic_diameter(metadata.throat_width_m, metadata.throat_height_m);
-        let outlet_d = hydraulic_diameter(metadata.outlet_width_m, metadata.throat_height_m);
-        let conv_len = venturi_taper_length_m(
-            metadata.inlet_width_m,
-            metadata.throat_width_m,
-            metadata.convergent_half_angle_deg,
-        )?;
-        let diff_len = venturi_taper_length_m(
-            metadata.outlet_width_m,
-            metadata.throat_width_m,
-            metadata.divergent_half_angle_deg,
-        )?;
-        let total_length = metadata.throat_length_m + conv_len + diff_len;
+        let inlet_width = metadata.inlet_width_m.into_base();
+        let throat_width = metadata.throat_width_m.into_base();
+        let throat_height = metadata.throat_height_m.into_base();
+        let outlet_width = metadata.outlet_width_m.into_base();
+        let throat_length = metadata.throat_length_m.into_base();
+        let convergent_angle = metadata.convergent_half_angle.into_base().to_degrees();
+        let divergent_angle = metadata.divergent_half_angle.into_base().to_degrees();
+        let inlet_d = hydraulic_diameter(inlet_width, throat_height);
+        let throat_d = hydraulic_diameter(throat_width, throat_height);
+        let outlet_d = hydraulic_diameter(outlet_width, throat_height);
+        let conv_len = venturi_taper_length_m(inlet_width, throat_width, convergent_angle)?;
+        let diff_len = venturi_taper_length_m(outlet_width, throat_width, divergent_angle)?;
+        let total_length = throat_length + conv_len + diff_len;
 
         let inlet_d_t = inlet_d;
         let throat_d_t = throat_d;
         let outlet_d_t = outlet_d;
-        let throat_len_t = metadata.throat_length_m;
+        let throat_len_t = throat_length;
         let total_len_t = total_length;
 
         let manual =
             VenturiModel::new(inlet_d_t, throat_d_t, outlet_d_t, throat_len_t, total_len_t)
                 .with_geometry(VenturiGeometry::Custom {
                     discharge_coefficient: discharge_coefficient_from_convergent_half_angle_deg(
-                        metadata.convergent_half_angle_deg,
+                        convergent_angle,
                     )?,
                 })
                 .with_expansion(ExpansionType::Gradual {
-                    half_angle_deg: metadata.divergent_half_angle_deg,
+                    half_angle_deg: divergent_angle,
                 });
 
         let conditions = ModelFlowConditions::from_flow_rate(1.0e-12);
@@ -172,14 +176,14 @@ mod tests {
         use crate::{discharge_coefficient_from_convergent_half_angle_deg, venturi_taper_length_m};
 
         let metadata = VenturiGeometryMetadata {
-            throat_width_m: 4.0e-4,
-            throat_height_m: 2.0e-4,
-            throat_length_m: 8.0e-4,
-            inlet_width_m: 1.0e-3,
-            outlet_width_m: 1.2e-3,
-            convergent_half_angle_deg: 12.0,
-            divergent_half_angle_deg: 7.0,
-            throat_position: 0.5,
+            throat_width_m: Length::from_base(4.0e-4),
+            throat_height_m: Length::from_base(2.0e-4),
+            throat_length_m: Length::from_base(8.0e-4),
+            inlet_width_m: Length::from_base(1.0e-3),
+            outlet_width_m: Length::from_base(1.2e-3),
+            convergent_half_angle: Angle::from_base(12.0_f64.to_radians()),
+            divergent_half_angle: Angle::from_base(7.0_f64.to_radians()),
+            throat_position: Dimensionless::from_base(0.5),
         };
         let fluid = water_20c::<f64>()?;
 
@@ -187,36 +191,29 @@ mod tests {
 
         let hydraulic_diameter =
             |width_m: f64, height_m: f64| 2.0 * width_m * height_m / (width_m + height_m);
-        let inlet_d = hydraulic_diameter(metadata.inlet_width_m, metadata.throat_height_m);
-        let throat_d = hydraulic_diameter(metadata.throat_width_m, metadata.throat_height_m);
-        let outlet_d = hydraulic_diameter(metadata.outlet_width_m, metadata.throat_height_m);
-        let conv_len = venturi_taper_length_m(
-            metadata.inlet_width_m,
-            metadata.throat_width_m,
-            metadata.convergent_half_angle_deg,
-        )?;
-        let diff_len = venturi_taper_length_m(
-            metadata.outlet_width_m,
-            metadata.throat_width_m,
-            metadata.divergent_half_angle_deg,
-        )?;
-        let total_length = metadata.throat_length_m + conv_len + diff_len;
+        let inlet_width = metadata.inlet_width_m.into_base();
+        let throat_width = metadata.throat_width_m.into_base();
+        let throat_height = metadata.throat_height_m.into_base();
+        let outlet_width = metadata.outlet_width_m.into_base();
+        let throat_length = metadata.throat_length_m.into_base();
+        let convergent_angle = metadata.convergent_half_angle.into_base().to_degrees();
+        let divergent_angle = metadata.divergent_half_angle.into_base().to_degrees();
+        let inlet_d = hydraulic_diameter(inlet_width, throat_height);
+        let throat_d = hydraulic_diameter(throat_width, throat_height);
+        let outlet_d = hydraulic_diameter(outlet_width, throat_height);
+        let conv_len = venturi_taper_length_m(inlet_width, throat_width, convergent_angle)?;
+        let diff_len = venturi_taper_length_m(outlet_width, throat_width, divergent_angle)?;
+        let total_length = throat_length + conv_len + diff_len;
 
-        let manual = VenturiModel::new(
-            inlet_d,
-            throat_d,
-            outlet_d,
-            metadata.throat_length_m,
-            total_length,
-        )
-        .with_geometry(VenturiGeometry::Custom {
-            discharge_coefficient: discharge_coefficient_from_convergent_half_angle_deg(
-                metadata.convergent_half_angle_deg,
-            )?,
-        })
-        .with_expansion(ExpansionType::Gradual {
-            half_angle_deg: metadata.divergent_half_angle_deg,
-        });
+        let manual = VenturiModel::new(inlet_d, throat_d, outlet_d, throat_length, total_length)
+            .with_geometry(VenturiGeometry::Custom {
+                discharge_coefficient: discharge_coefficient_from_convergent_half_angle_deg(
+                    convergent_angle,
+                )?,
+            })
+            .with_expansion(ExpansionType::Gradual {
+                half_angle_deg: divergent_angle,
+            });
 
         let flow_probe = ModelFlowConditions::from_flow_rate(1.0e-12);
         let (_, flow_probe_k) = manual.calculate_coefficients(&fluid, &flow_probe)?;

--- a/crates/cfd-1d/tests/blueprint_metadata_physics.rs
+++ b/crates/cfd-1d/tests/blueprint_metadata_physics.rs
@@ -1,3 +1,4 @@
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 use cfd_1d::domain::network::network_from_blueprint;
 use cfd_1d::physics::resistance::models::{
     FlowConditions, SerpentineCrossSection, SerpentineModel,
@@ -156,24 +157,24 @@ fn venturi_blueprint(
             0.0,
         )
         .with_venturi_geometry(VenturiGeometryMetadata {
-            throat_width_m: 2.5e-4,
-            throat_height_m: 0.5e-3,
-            throat_length_m: 8.0e-4,
-            inlet_width_m: 1.0e-3,
-            outlet_width_m: 1.0e-3,
-            convergent_half_angle_deg,
-            divergent_half_angle_deg,
-            throat_position: 0.5,
+            throat_width_m: Length::from_base(2.5e-4),
+            throat_height_m: Length::from_base(0.5e-3),
+            throat_length_m: Length::from_base(8.0e-4),
+            inlet_width_m: Length::from_base(1.0e-3),
+            outlet_width_m: Length::from_base(1.0e-3),
+            convergent_half_angle: Angle::from_base(convergent_half_angle_deg.to_radians()),
+            divergent_half_angle: Angle::from_base(divergent_half_angle_deg.to_radians()),
+            throat_position: Dimensionless::from_base(0.5),
         })
         .with_metadata(VenturiGeometryMetadata {
-            throat_width_m: 2.5e-4,
-            throat_height_m: 0.5e-3,
-            throat_length_m: 8.0e-4,
-            inlet_width_m: 1.0e-3,
-            outlet_width_m: 1.0e-3,
-            convergent_half_angle_deg,
-            divergent_half_angle_deg,
-            throat_position: 0.5,
+            throat_width_m: Length::from_base(2.5e-4),
+            throat_height_m: Length::from_base(0.5e-3),
+            throat_length_m: Length::from_base(8.0e-4),
+            inlet_width_m: Length::from_base(1.0e-3),
+            outlet_width_m: Length::from_base(1.0e-3),
+            convergent_half_angle: Angle::from_base(convergent_half_angle_deg.to_radians()),
+            divergent_half_angle: Angle::from_base(divergent_half_angle_deg.to_radians()),
+            throat_position: Dimensionless::from_base(0.5),
         })
         .with_path(vec![(5.0, 0.0), (5.8, 0.0)]),
     );
@@ -445,14 +446,14 @@ fn venturi_throat_width_and_length_change_coefficients() {
             height_m: 0.5e-3,
         };
         throat.venturi_geometry = Some(VenturiGeometryMetadata {
-            throat_width_m: 1.8e-4,
-            throat_height_m: 0.5e-3,
-            throat_length_m: 1.6e-3,
-            inlet_width_m: 1.0e-3,
-            outlet_width_m: 1.0e-3,
-            convergent_half_angle_deg: 8.0,
-            divergent_half_angle_deg: 8.0,
-            throat_position: 0.5,
+            throat_width_m: Length::from_base(1.8e-4),
+            throat_height_m: Length::from_base(0.5e-3),
+            throat_length_m: Length::from_base(1.6e-3),
+            inlet_width_m: Length::from_base(1.0e-3),
+            outlet_width_m: Length::from_base(1.0e-3),
+            convergent_half_angle: Angle::from_base(8.0_f64.to_radians()),
+            divergent_half_angle: Angle::from_base(8.0_f64.to_radians()),
+            throat_position: Dimensionless::from_base(0.5),
         });
     }
 

--- a/crates/cfd-2d/src/network/projection.rs
+++ b/crates/cfd-2d/src/network/projection.rs
@@ -83,12 +83,12 @@ fn path_metrics(path: &[(f64, f64)]) -> Option<PathMetrics> {
 }
 
 fn venturi_width_at_x(venturi: &VenturiGeometryMetadata, x: f64, total_length: f64) -> f64 {
-    let inlet = venturi.inlet_width_m.max(1e-18);
-    let throat = venturi.throat_width_m.max(1e-18);
-    let outlet = venturi.outlet_width_m.max(1e-18);
-    let l_throat = venturi.throat_length_m.max(0.0);
+    let inlet = venturi.inlet_width_m.into_base().max(1e-18);
+    let throat = venturi.throat_width_m.into_base().max(1e-18);
+    let outlet = venturi.outlet_width_m.into_base().max(1e-18);
+    let l_throat = venturi.throat_length_m.into_base().max(0.0);
     let remaining = (total_length - l_throat).max(0.0);
-    let l_converge = remaining * venturi.throat_position.clamp(0.0, 1.0);
+    let l_converge = remaining * venturi.throat_position.into_base().clamp(0.0, 1.0);
     let l_diverge = (remaining - l_converge).max(0.0);
 
     let x_inlet_end = 0.0;
@@ -182,8 +182,9 @@ pub(crate) fn channel_projection_domain(channel: &ChannelSpec) -> ProjectionDoma
             || default_half_width(channel) * 2.0,
             |geom| {
                 geom.inlet_width_m
-                    .max(geom.throat_width_m)
-                    .max(geom.outlet_width_m)
+                    .into_base()
+                    .max(geom.throat_width_m.into_base())
+                    .max(geom.outlet_width_m.into_base())
             },
         )
         .max(default_half_width(channel) * 2.0);

--- a/crates/cfd-schematic-mesh/examples/schematic_to_mesh_demo.rs
+++ b/crates/cfd-schematic-mesh/examples/schematic_to_mesh_demo.rs
@@ -7,6 +7,7 @@
 //! Run with: cargo run -p gaia --example schematic_to_mesh_demo
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
     use cfd_mesh::application::channel::profile::ChannelProfile;
     use cfd_schematic_mesh::scheme_io;
     use cfd_schematics::config::{ChannelTypeConfig, GeometryConfig};
@@ -55,14 +56,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     frustum_channel.path = frustum_path;
     frustum_channel.venturi_geometry = Some(VenturiGeometryMetadata {
-        throat_width_m: 0.2 / 1000.0,
-        throat_height_m: 0.5 / 1000.0,
-        throat_length_m: 1.0 / 1000.0,
-        inlet_width_m: 1.0 / 1000.0,
-        outlet_width_m: 1.0 / 1000.0,
-        convergent_half_angle_deg: 45.0,
-        divergent_half_angle_deg: 45.0,
-        throat_position: 0.5,
+        throat_width_m: Length::from_base(0.2 / 1000.0),
+        throat_height_m: Length::from_base(0.5 / 1000.0),
+        throat_length_m: Length::from_base(1.0 / 1000.0),
+        inlet_width_m: Length::from_base(1.0 / 1000.0),
+        outlet_width_m: Length::from_base(1.0 / 1000.0),
+        convergent_half_angle: Angle::from_base(45.0_f64.to_radians()),
+        divergent_half_angle: Angle::from_base(45.0_f64.to_radians()),
+        throat_position: Dimensionless::from_base(0.5),
     });
 
     // Clone system and add frustum with its own isolated nodes
@@ -131,14 +132,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Mesh with variable sweep
-            let faces = mesher.sweep_variable(
-                &channel_def.profile,
-                &channel_def.path,
-                scales,
-                &mut pool,
-                RegionId::new(0),
-            )
-            .expect("variable sweep should succeed");
+            let faces = mesher
+                .sweep_variable(
+                    &channel_def.profile,
+                    &channel_def.path,
+                    scales,
+                    &mut pool,
+                    RegionId::new(0),
+                )
+                .expect("variable sweep should succeed");
             println!("      Generated {} faces with variable sweep.", faces.len());
             assert!(!faces.is_empty());
 

--- a/crates/cfd-schematic-mesh/src/scheme_io.rs
+++ b/crates/cfd-schematic-mesh/src/scheme_io.rs
@@ -152,7 +152,8 @@ fn parse_channels(value: &serde_json::Value) -> MeshResult<Vec<ChannelDef>> {
 
         defs.push(ChannelDef {
             id,
-            path: ChannelPath::new(points).expect("invariant: channel path from schematic points is valid"),
+            path: ChannelPath::new(points)
+                .expect("invariant: channel path from schematic points is valid"),
             profile: ChannelProfile::Circular {
                 radius: diameter / 2.0,
                 segments,
@@ -233,9 +234,9 @@ pub fn from_blueprint(
         let mut width_scales = None;
 
         let profile = if let Some(vg) = &ch.venturi_geometry {
-            let inlet_w = (vg.inlet_width_m * 1000.0) as Real;
-            let throat_w = (vg.throat_width_m * 1000.0) as Real;
-            let outlet_w = (vg.outlet_width_m * 1000.0) as Real;
+            let inlet_w = (vg.inlet_width_m.into_base() * 1000.0) as Real;
+            let throat_w = (vg.throat_width_m.into_base() * 1000.0) as Real;
+            let outlet_w = (vg.outlet_width_m.into_base() * 1000.0) as Real;
 
             // Reconstruct frustum width profile matching the lifted centerline.
             let n = centerline_2d.len();
@@ -284,7 +285,8 @@ pub fn from_blueprint(
 
         channels.push(ChannelDef {
             id: ch.id.as_str().to_string(),
-            path: ChannelPath::new(points).expect("invariant: channel path from schematic points is valid"),
+            path: ChannelPath::new(points)
+                .expect("invariant: channel path from schematic points is valid"),
             profile,
             width_scales,
         });

--- a/crates/cfd-schematics/src/domain/model/blueprint/venturi_impl.rs
+++ b/crates/cfd-schematics/src/domain/model/blueprint/venturi_impl.rs
@@ -4,6 +4,7 @@ use crate::geometry::metadata::{ChannelVenturiSpec, MetadataContainer, VenturiGe
 use crate::topology::{
     TopologyOptimizationStage, TreatmentActuationMode, VenturiConfig, VenturiPlacementSpec,
 };
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 impl NetworkBlueprint {
     pub fn add_venturi(&mut self, config: &VenturiConfig) -> Result<(), String> {
@@ -40,14 +41,21 @@ impl NetworkBlueprint {
                 channel.effective_width_m()
             };
             let venturi_geometry = VenturiGeometryMetadata {
-                throat_width_m: config.throat_geometry.throat_width_m,
-                throat_height_m: config.throat_geometry.throat_height_m,
-                throat_length_m: config.throat_geometry.throat_length_m,
-                inlet_width_m: resolved_inlet_width_m,
-                outlet_width_m: resolved_outlet_width_m,
-                convergent_half_angle_deg: config.throat_geometry.convergent_half_angle_deg,
-                divergent_half_angle_deg: config.throat_geometry.divergent_half_angle_deg,
-                throat_position: 0.5,
+                throat_width_m: Length::from_base(config.throat_geometry.throat_width_m),
+                throat_height_m: Length::from_base(config.throat_geometry.throat_height_m),
+                throat_length_m: Length::from_base(config.throat_geometry.throat_length_m),
+                inlet_width_m: Length::from_base(resolved_inlet_width_m),
+                outlet_width_m: Length::from_base(resolved_outlet_width_m),
+                convergent_half_angle: Angle::from_base(
+                    config
+                        .throat_geometry
+                        .convergent_half_angle_deg
+                        .to_radians(),
+                ),
+                divergent_half_angle: Angle::from_base(
+                    config.throat_geometry.divergent_half_angle_deg.to_radians(),
+                ),
+                throat_position: Dimensionless::from_base(0.5),
             };
             channel.venturi_geometry = Some(venturi_geometry.clone());
             if channel.metadata.is_none() {
@@ -63,9 +71,9 @@ impl NetworkBlueprint {
                 is_ctc_stream: channel
                     .therapy_zone
                     .is_some_and(|zone| zone == TherapyZone::CancerTarget),
-                throat_width_m: config.throat_geometry.throat_width_m,
-                height_m: config.throat_geometry.throat_height_m,
-                inter_throat_spacing_m: config.throat_geometry.throat_length_m,
+                throat_width_m: Length::from_base(config.throat_geometry.throat_width_m),
+                height_m: Length::from_base(config.throat_geometry.throat_height_m),
+                inter_throat_spacing_m: Length::from_base(config.throat_geometry.throat_length_m),
             });
 
             placements.push(VenturiPlacementSpec {

--- a/crates/cfd-schematics/src/geometry/generator/linear.rs
+++ b/crates/cfd-schematics/src/geometry/generator/linear.rs
@@ -4,6 +4,7 @@ use crate::geometry::metadata::{
 };
 use crate::topology::{BlueprintTopologySpec, ParallelChannelSpec, SeriesChannelSpec};
 use crate::visualizations::schematic::materialize_blueprint_layout;
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 fn make_outline(box_dims: (f64, f64)) -> Vec<((f64, f64), (f64, f64))> {
     let (w, h) = box_dims;
@@ -77,14 +78,24 @@ fn series_channel_venturi(
         .iter()
         .find(|placement| placement.target_channel_id == channel_id)
         .map(|placement| VenturiGeometryMetadata {
-            throat_width_m: placement.throat_geometry.throat_width_m,
-            throat_height_m: placement.throat_geometry.throat_height_m,
-            throat_length_m: placement.throat_geometry.throat_length_m,
-            inlet_width_m: placement.throat_geometry.inlet_width_m,
-            outlet_width_m: placement.throat_geometry.outlet_width_m,
-            convergent_half_angle_deg: placement.throat_geometry.convergent_half_angle_deg,
-            divergent_half_angle_deg: placement.throat_geometry.divergent_half_angle_deg,
-            throat_position: 0.5,
+            throat_width_m: Length::from_base(placement.throat_geometry.throat_width_m),
+            throat_height_m: Length::from_base(placement.throat_geometry.throat_height_m),
+            throat_length_m: Length::from_base(placement.throat_geometry.throat_length_m),
+            inlet_width_m: Length::from_base(placement.throat_geometry.inlet_width_m),
+            outlet_width_m: Length::from_base(placement.throat_geometry.outlet_width_m),
+            convergent_half_angle: Angle::from_base(
+                placement
+                    .throat_geometry
+                    .convergent_half_angle_deg
+                    .to_radians(),
+            ),
+            divergent_half_angle: Angle::from_base(
+                placement
+                    .throat_geometry
+                    .divergent_half_angle_deg
+                    .to_radians(),
+            ),
+            throat_position: Dimensionless::from_base(0.5),
         })
 }
 

--- a/crates/cfd-schematics/src/geometry/generator/selective/builder/cct.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/builder/cct.rs
@@ -3,6 +3,7 @@ use super::{
     SelectiveTreeBuilder, SelectiveTreeRequest, VenturiGeometryMetadata,
 };
 use crate::domain::therapy_metadata::TherapyZone;
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 impl SelectiveTreeBuilder {
     pub(in super::super) fn build_cct(
@@ -139,14 +140,14 @@ impl SelectiveTreeBuilder {
                 zone,
                 None,
                 Some(VenturiGeometryMetadata {
-                    throat_width_m: req.throat_width_m,
-                    throat_height_m: req.channel_height_m,
-                    throat_length_m: req.throat_length_m,
-                    inlet_width_m: center_width,
-                    outlet_width_m: center_width,
-                    convergent_half_angle_deg: 15.0,
-                    divergent_half_angle_deg: 15.0,
-                    throat_position: 0.5,
+                    throat_width_m: Length::from_base(req.throat_width_m),
+                    throat_height_m: Length::from_base(req.channel_height_m),
+                    throat_length_m: Length::from_base(req.throat_length_m),
+                    inlet_width_m: Length::from_base(center_width),
+                    outlet_width_m: Length::from_base(center_width),
+                    convergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                    divergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                    throat_position: Dimensionless::from_base(0.5),
                 }),
             );
         } else {

--- a/crates/cfd-schematics/src/geometry/generator/selective/builder/cif.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/builder/cif.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::domain::therapy_metadata::TherapyZone;
 use crate::geometry::builders::ChannelExt;
 use crate::geometry::metadata::IncrementalFiltrationParams;
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 impl SelectiveTreeBuilder {
     pub(in super::super) fn build_cif(
@@ -79,7 +80,7 @@ impl SelectiveTreeBuilder {
                 pretri_center_frac,
                 terminal_tri_center_frac,
                 bi_treat_frac,
-                outlet_tail_length_m,
+                outlet_tail_length_m: Length::from_base(outlet_tail_length_m),
             });
         }
 
@@ -259,14 +260,14 @@ impl SelectiveTreeBuilder {
                 TherapyZone::CancerTarget,
                 None,
                 Some(VenturiGeometryMetadata {
-                    throat_width_m: req.throat_width_m,
-                    throat_height_m: req.channel_height_m,
-                    throat_length_m: req.throat_length_m,
-                    inlet_width_m: treat_w,
-                    outlet_width_m: treat_w,
-                    convergent_half_angle_deg: 15.0,
-                    divergent_half_angle_deg: 15.0,
-                    throat_position: 0.5,
+                    throat_width_m: Length::from_base(req.throat_width_m),
+                    throat_height_m: Length::from_base(req.channel_height_m),
+                    throat_length_m: Length::from_base(req.throat_length_m),
+                    inlet_width_m: Length::from_base(treat_w),
+                    outlet_width_m: Length::from_base(treat_w),
+                    convergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                    divergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                    throat_position: Dimensionless::from_base(0.5),
                 }),
             );
         } else {

--- a/crates/cfd-schematics/src/geometry/generator/selective/builder/dtcv.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/builder/dtcv.rs
@@ -3,6 +3,7 @@ use super::{
     VenturiGeometryMetadata,
 };
 use crate::domain::therapy_metadata::TherapyZone;
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 impl SelectiveTreeBuilder {
     pub(in super::super) fn build_dtcv(
@@ -296,14 +297,14 @@ impl SelectiveTreeBuilder {
                     TherapyZone::CancerTarget,
                     None,
                     Some(VenturiGeometryMetadata {
-                        throat_width_m: req.throat_width_m,
-                        throat_height_m: req.channel_height_m,
-                        throat_length_m: req.throat_length_m,
-                        inlet_width_m: width,
-                        outlet_width_m: width,
-                        convergent_half_angle_deg: 15.0,
-                        divergent_half_angle_deg: 15.0,
-                        throat_position: 0.5,
+                        throat_width_m: Length::from_base(req.throat_width_m),
+                        throat_height_m: Length::from_base(req.channel_height_m),
+                        throat_length_m: Length::from_base(req.throat_length_m),
+                        inlet_width_m: Length::from_base(width),
+                        outlet_width_m: Length::from_base(width),
+                        convergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                        divergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                        throat_position: Dimensionless::from_base(0.5),
                     }),
                 );
                 prev = tout;

--- a/crates/cfd-schematics/src/geometry/generator/selective/builder/tbt.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/builder/tbt.rs
@@ -3,6 +3,7 @@ use super::{
     VenturiGeometryMetadata,
 };
 use crate::domain::therapy_metadata::TherapyZone;
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 impl SelectiveTreeBuilder {
     pub(in super::super) fn build_tbt(
@@ -156,14 +157,14 @@ impl SelectiveTreeBuilder {
             TherapyZone::CancerTarget,
             None,
             Some(VenturiGeometryMetadata {
-                throat_width_m: req.throat_width_m,
-                throat_height_m: req.channel_height_m,
-                throat_length_m: req.throat_length_m,
-                inlet_width_m: ctr2,
-                outlet_width_m: ctr2,
-                convergent_half_angle_deg: 15.0,
-                divergent_half_angle_deg: 15.0,
-                throat_position: 0.5,
+                throat_width_m: Length::from_base(req.throat_width_m),
+                throat_height_m: Length::from_base(req.channel_height_m),
+                throat_length_m: Length::from_base(req.throat_length_m),
+                inlet_width_m: Length::from_base(ctr2),
+                outlet_width_m: Length::from_base(ctr2),
+                convergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                divergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                throat_position: Dimensionless::from_base(0.5),
             }),
         );
         self.add_channel(

--- a/crates/cfd-schematics/src/geometry/generator/selective/primitive/annotation.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/primitive/annotation.rs
@@ -14,6 +14,7 @@ use crate::geometry::metadata::{
     ChannelVenturiSpec, ChannelVisualRole, JunctionFamily, JunctionGeometryMetadata,
     MetadataContainer, VenturiGeometryMetadata,
 };
+use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 
 pub(super) fn annotate_primitive_tree(
     system: &mut NetworkBlueprint,
@@ -251,22 +252,22 @@ pub(super) fn annotate_primitive_tree(
             });
             channel.visual_role = Some(ChannelVisualRole::VenturiThroat);
             channel.venturi_geometry = Some(VenturiGeometryMetadata {
-                throat_width_m: request.throat_width_m,
-                throat_height_m: request.channel_height_m,
-                throat_length_m: request.throat_length_m,
-                inlet_width_m: physical_width,
-                outlet_width_m: physical_width,
-                convergent_half_angle_deg: 15.0,
-                divergent_half_angle_deg: 15.0,
-                throat_position: 0.5,
+                throat_width_m: Length::from_base(request.throat_width_m),
+                throat_height_m: Length::from_base(request.channel_height_m),
+                throat_length_m: Length::from_base(request.throat_length_m),
+                inlet_width_m: Length::from_base(physical_width),
+                outlet_width_m: Length::from_base(physical_width),
+                convergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                divergent_half_angle: Angle::from_base(15.0_f64.to_radians()),
+                throat_position: Dimensionless::from_base(0.5),
             });
             let metadata = channel.metadata.get_or_insert_with(MetadataContainer::new);
             metadata.insert(ChannelVenturiSpec {
                 n_throats: request.treatment_branch_throat_count.max(1),
                 is_ctc_stream: true,
-                throat_width_m: request.throat_width_m,
-                height_m: request.channel_height_m,
-                inter_throat_spacing_m: request.throat_length_m * 2.0,
+                throat_width_m: Length::from_base(request.throat_width_m),
+                height_m: Length::from_base(request.channel_height_m),
+                inter_throat_spacing_m: Length::from_base(request.throat_length_m * 2.0),
             });
             metadata.insert(
                 channel
@@ -279,9 +280,9 @@ pub(super) fn annotate_primitive_tree(
             metadata.insert(ChannelVenturiSpec {
                 n_throats: 0,
                 is_ctc_stream: false,
-                throat_width_m: request.throat_width_m,
-                height_m: request.channel_height_m,
-                inter_throat_spacing_m: request.throat_length_m * 2.0,
+                throat_width_m: Length::from_base(request.throat_width_m),
+                height_m: Length::from_base(request.channel_height_m),
+                inter_throat_spacing_m: Length::from_base(request.throat_length_m * 2.0),
             });
         }
     }

--- a/crates/cfd-schematics/src/geometry/metadata/therapy.rs
+++ b/crates/cfd-schematics/src/geometry/metadata/therapy.rs
@@ -1,20 +1,23 @@
+use aequitas::systems::si::quantities::{
+    Angle, Dimensionless, Length, MassDensity, Pressure, Velocity, VolumetricFlowRate,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VenturiGeometryMetadata {
-    pub throat_width_m: f64,
-    pub throat_height_m: f64,
-    pub throat_length_m: f64,
-    pub inlet_width_m: f64,
-    pub outlet_width_m: f64,
-    pub convergent_half_angle_deg: f64,
-    pub divergent_half_angle_deg: f64,
+    pub throat_width_m: Length<f64>,
+    pub throat_height_m: Length<f64>,
+    pub throat_length_m: Length<f64>,
+    pub inlet_width_m: Length<f64>,
+    pub outlet_width_m: Length<f64>,
+    pub convergent_half_angle: Angle<f64>,
+    pub divergent_half_angle: Angle<f64>,
     #[serde(default = "default_throat_position")]
-    pub throat_position: f64,
+    pub throat_position: Dimensionless<f64>,
 }
 
-fn default_throat_position() -> f64 {
-    0.5
+fn default_throat_position() -> Dimensionless<f64> {
+    Dimensionless::from_base(0.5)
 }
 
 crate::impl_metadata!(VenturiGeometryMetadata, "VenturiGeometryMetadata");
@@ -33,7 +36,7 @@ pub struct IncrementalFiltrationParams {
     pub pretri_center_frac: f64,
     pub terminal_tri_center_frac: f64,
     pub bi_treat_frac: f64,
-    pub outlet_tail_length_m: f64,
+    pub outlet_tail_length_m: Length<f64>,
 }
 
 crate::impl_metadata!(IncrementalFiltrationParams, "IncrementalFiltrationParams");
@@ -51,40 +54,48 @@ crate::impl_metadata!(AsymmetricTrifurcationParams, "AsymmetricTrifurcationParam
 pub struct ChannelVenturiSpec {
     pub n_throats: u8,
     pub is_ctc_stream: bool,
-    pub throat_width_m: f64,
-    pub height_m: f64,
-    pub inter_throat_spacing_m: f64,
+    pub throat_width_m: Length<f64>,
+    pub height_m: Length<f64>,
+    pub inter_throat_spacing_m: Length<f64>,
 }
 
 impl ChannelVenturiSpec {
     #[must_use]
-    pub fn cumulative_cavitation_dose(&self, cav_potential: f64) -> f64 {
-        let p = cav_potential.clamp(0.0, 1.0);
+    pub fn cumulative_cavitation_dose(
+        &self,
+        cav_potential: Dimensionless<f64>,
+    ) -> Dimensionless<f64> {
+        let p = cav_potential.into_base().clamp(0.0, 1.0);
         if p <= 0.0 || self.n_throats == 0 {
-            return 0.0;
+            return Dimensionless::from_base(0.0);
         }
-        (1.0 - (1.0 - p).powi(i32::from(self.n_throats))).clamp(0.0, 1.0)
+        Dimensionless::from_base((1.0 - (1.0 - p).powi(i32::from(self.n_throats))).clamp(0.0, 1.0))
     }
 
     #[must_use]
-    pub fn total_throat_pressure_drop_pa(
+    pub fn total_throat_pressure_drop(
         &self,
-        flow_m3_s: f64,
-        blood_density_kg_m3: f64,
-        diffuser_coeff: f64,
-    ) -> f64 {
+        flow_rate: VolumetricFlowRate<f64>,
+        blood_density: MassDensity<f64>,
+        diffuser_coeff: Dimensionless<f64>,
+    ) -> Pressure<f64> {
         if self.n_throats == 0 {
-            return 0.0;
+            return Pressure::from_base(0.0);
         }
-        let inlet_area = (self.throat_width_m * 2.0) * self.height_m;
-        let throat_area = self.throat_width_m * self.height_m;
-        let v_in = flow_m3_s / inlet_area.max(1e-18);
-        let v_throat = flow_m3_s / throat_area.max(1e-18);
+        let throat_width = self.throat_width_m.into_base();
+        let height = self.height_m.into_base();
+        let flow_rate = flow_rate.into_base();
+        let blood_density = blood_density.into_base();
+        let diffuser_coeff = diffuser_coeff.into_base();
+        let inlet_area = (throat_width * 2.0) * height;
+        let throat_area = throat_width * height;
+        let v_in = flow_rate / inlet_area.max(1e-18);
+        let v_throat = flow_rate / throat_area.max(1e-18);
         let single_dp = 0.5
-            * blood_density_kg_m3
+            * blood_density
             * (v_throat * v_throat - v_in * v_in).max(0.0)
             * (1.0 - diffuser_coeff);
-        single_dp * f64::from(self.n_throats)
+        Pressure::from_base(single_dp * f64::from(self.n_throats))
     }
 }
 
@@ -92,29 +103,92 @@ crate::impl_metadata!(ChannelVenturiSpec, "ChannelVenturiSpec");
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FdaCavitationCompliance {
-    pub mi_equiv: f64,
+    pub mi_equiv: Dimensionless<f64>,
     pub fda_mi_compliant: bool,
-    pub therapeutic_mi_lower: f64,
+    pub therapeutic_mi_lower: Dimensionless<f64>,
     pub in_therapeutic_window: bool,
 }
 
 impl FdaCavitationCompliance {
-    pub const FDA_MI_LIMIT: f64 = 1.9;
-    pub const INERTIAL_CAV_THRESHOLD_MI: f64 = 0.3;
-    pub const SOUND_SPEED_BLOOD_M_S: f64 = 1540.0;
+    pub const FDA_MI_LIMIT: Dimensionless<f64> = Dimensionless::from_base(1.9);
+    pub const INERTIAL_CAV_THRESHOLD_MI: Dimensionless<f64> = Dimensionless::from_base(0.3);
+    pub const SOUND_SPEED_BLOOD_M_S: Velocity<f64> = Velocity::from_base(1540.0);
 
     #[must_use]
-    pub fn from_throat_dp(dp_throat_pa: f64, blood_density: f64) -> Self {
-        let v_rms = (2.0 * dp_throat_pa.max(0.0) / blood_density.max(1.0)).sqrt();
-        let mi_equiv = v_rms / Self::SOUND_SPEED_BLOOD_M_S;
+    pub fn from_throat_dp(dp_throat: Pressure<f64>, blood_density: MassDensity<f64>) -> Self {
+        let dp_throat = dp_throat.into_base();
+        let blood_density = blood_density.into_base();
+        let v_rms = (2.0 * dp_throat.max(0.0) / blood_density.max(1.0)).sqrt();
+        let mi_equiv = Dimensionless::from_base(v_rms / Self::SOUND_SPEED_BLOOD_M_S.into_base());
         Self {
             mi_equiv,
-            fda_mi_compliant: mi_equiv < Self::FDA_MI_LIMIT,
+            fda_mi_compliant: mi_equiv.into_base() < Self::FDA_MI_LIMIT.into_base(),
             therapeutic_mi_lower: Self::INERTIAL_CAV_THRESHOLD_MI,
-            in_therapeutic_window: (Self::INERTIAL_CAV_THRESHOLD_MI..Self::FDA_MI_LIMIT)
-                .contains(&mi_equiv),
+            in_therapeutic_window: (Self::INERTIAL_CAV_THRESHOLD_MI.into_base()
+                ..Self::FDA_MI_LIMIT.into_base())
+                .contains(&mi_equiv.into_base()),
         }
     }
 }
 
 crate::impl_metadata!(FdaCavitationCompliance, "FdaCavitationCompliance");
+
+#[cfg(test)]
+mod tests {
+    use super::ChannelVenturiSpec;
+    use aequitas::systems::si::quantities::{
+        Dimensionless, Length, MassDensity, Pressure, VolumetricFlowRate,
+    };
+
+    #[test]
+    fn cumulative_cavitation_dose_compounds_per_throat() {
+        let spec = ChannelVenturiSpec {
+            n_throats: 2,
+            is_ctc_stream: true,
+            throat_width_m: Length::from_base(0.5),
+            height_m: Length::from_base(1.0),
+            inter_throat_spacing_m: Length::from_base(1.0),
+        };
+
+        assert_eq!(
+            spec.cumulative_cavitation_dose(Dimensionless::from_base(0.5))
+                .into_base(),
+            0.75
+        );
+    }
+
+    #[test]
+    fn total_throat_pressure_drop_preserves_pressure_dimension() {
+        let spec = ChannelVenturiSpec {
+            n_throats: 2,
+            is_ctc_stream: false,
+            throat_width_m: Length::from_base(0.5),
+            height_m: Length::from_base(1.0),
+            inter_throat_spacing_m: Length::from_base(1.0),
+        };
+
+        let pressure = spec.total_throat_pressure_drop(
+            VolumetricFlowRate::from_base(1.0),
+            MassDensity::from_base(2.0),
+            Dimensionless::from_base(0.25),
+        );
+
+        assert_eq!(pressure.into_base(), 4.5);
+    }
+
+    #[test]
+    fn fda_cavitation_compliance_accepts_typed_pressure_and_density() {
+        let compliance = super::FdaCavitationCompliance::from_throat_dp(
+            Pressure::from_base(2.0),
+            MassDensity::from_base(2.0),
+        );
+
+        assert_eq!(compliance.mi_equiv.into_base(), 2.0_f64.sqrt() / 1540.0);
+        assert_eq!(
+            compliance.therapeutic_mi_lower,
+            Dimensionless::from_base(0.3)
+        );
+        assert!(compliance.fda_mi_compliant);
+        assert!(!compliance.in_therapeutic_window);
+    }
+}

--- a/crates/cfd-schematics/src/geometry/types/interchange.rs
+++ b/crates/cfd-schematics/src/geometry/types/interchange.rs
@@ -177,9 +177,9 @@ impl NetworkBlueprint {
 
                 let profile = match (channel.cross_section, channel.venturi_geometry.as_ref()) {
                     (CrossSectionSpec::Rectangular { height_m, .. }, Some(venturi)) => {
-                        let inlet_width_mm = venturi.inlet_width_m * 1.0e3;
-                        let throat_width_mm = venturi.throat_width_m * 1.0e3;
-                        let outlet_width_mm = venturi.outlet_width_m * 1.0e3;
+                        let inlet_width_mm = venturi.inlet_width_m.into_base() * 1.0e3;
+                        let throat_width_mm = venturi.throat_width_m.into_base() * 1.0e3;
+                        let outlet_width_mm = venturi.outlet_width_m.into_base() * 1.0e3;
                         let height_mm = height_m * 1.0e3;
                         let width_profile_mm =
                             vec![inlet_width_mm, throat_width_mm, outlet_width_mm];

--- a/crates/cfd-schematics/src/interface/presets/composite/specialized/mod.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/specialized/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         assert!((params.pretri_center_frac - 0.45).abs() < 1e-12);
         assert!((params.terminal_tri_center_frac - 0.55).abs() < 1e-12);
         assert!((params.bi_treat_frac - 0.76).abs() < 1e-12);
-        assert!((params.outlet_tail_length_m - 12e-3).abs() < 1e-12);
+        assert!((params.outlet_tail_length_m.into_base() - 12e-3).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/cfd-schematics/src/visualizations/annotations/geometry.rs
+++ b/crates/cfd-schematics/src/visualizations/annotations/geometry.rs
@@ -2,6 +2,7 @@ use crate::domain::model::{ChannelSpec, NetworkBlueprint};
 use crate::domain::therapy_metadata::{TherapyZone, TherapyZoneMetadata};
 use crate::geometry::metadata::{ChannelVenturiSpec, ChannelVisualRole, VenturiGeometryMetadata};
 use crate::geometry::Point2D;
+use aequitas::systems::si::quantities::Length;
 use petgraph::algo::astar;
 use petgraph::{Directed, Graph};
 use std::collections::{BTreeMap, HashMap};
@@ -448,18 +449,18 @@ mod tests {
             .with_metadata(ChannelVenturiSpec {
                 n_throats: 2,
                 is_ctc_stream: true,
-                throat_width_m: 40e-6,
-                height_m: 50e-6,
-                inter_throat_spacing_m: 1.0e-3,
+                throat_width_m: Length::from_base(40e-6),
+                height_m: Length::from_base(50e-6),
+                inter_throat_spacing_m: Length::from_base(1.0e-3),
             });
 
         let c2 = ChannelSpec::new_pipe_rect("c2", "n1", "n2", 1.0, 1.0, 1.0, 1.0, 0.0)
             .with_metadata(ChannelVenturiSpec {
                 n_throats: 3,
                 is_ctc_stream: false,
-                throat_width_m: 40e-6,
-                height_m: 50e-6,
-                inter_throat_spacing_m: 1.0e-3,
+                throat_width_m: Length::from_base(40e-6),
+                height_m: Length::from_base(50e-6),
+                inter_throat_spacing_m: Length::from_base(1.0e-3),
             });
 
         blueprint.add_channel(c1);

--- a/crates/cfd-schematics/src/visualizations/annotations/geometry.rs
+++ b/crates/cfd-schematics/src/visualizations/annotations/geometry.rs
@@ -2,7 +2,6 @@ use crate::domain::model::{ChannelSpec, NetworkBlueprint};
 use crate::domain::therapy_metadata::{TherapyZone, TherapyZoneMetadata};
 use crate::geometry::metadata::{ChannelVenturiSpec, ChannelVisualRole, VenturiGeometryMetadata};
 use crate::geometry::Point2D;
-use aequitas::systems::si::quantities::Length;
 use petgraph::algo::astar;
 use petgraph::{Directed, Graph};
 use std::collections::{BTreeMap, HashMap};
@@ -432,6 +431,7 @@ fn point_at_arclength(path: &[Point2D], cumulative: &[f64], target_s: f64) -> Po
 mod tests {
     use super::*;
     use crate::domain::model::{ChannelSpec, NetworkBlueprint};
+    use aequitas::systems::si::quantities::Length;
 
     // #[test]
     // fn classify_node_roles_assigns_expected_degree_roles() {

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -56,13 +56,23 @@ fields. Topology authoring structs remain a separate follow-up domain: their
 raw degree/metre inputs are converted at the typed metadata boundary.
 
 Static verification passes with `cargo metadata --offline --locked
---no-deps`, targeted rustfmt, `git diff --check`, and residue scans. Two
-`cargo check -p cfd-schematics --lib --offline -j 1` attempts were bounded at
-124 seconds and 184 seconds while peer workspace checks held the shared Atlas
-target/build lock; they produced no source diagnostic before timeout. Native
-Nextest, package Clippy, and doctest collection remain pending on that shared
-build resource. A shared Atlas target-cache failure or provider/linker failure
-is verification evidence about the environment, not a remaining metric gap.
+--no-deps`, targeted rustfmt, `git diff --check`, and residue scans. The
+warning-denied `cfd-schematics` Clippy gate passes, and its focused Nextest
+passes 158/158 (`47490ed6-44c0-448c-af2c-dad01cdf5c18`). The `cfd-1d` library
+Nextest passes 498/498 (`0ab2db66-61ea-4687-b1cd-0ae0b4d2c7a1`) and its
+`blueprint_metadata_physics` integration target passes 5/5
+(`fc331715-f569-434e-ac39-878a71527903`). Focused source checks pass for
+`cfd-1d`, `cfd-2d`, and `cfd-schematic-mesh` (library/example). The full
+`cfd-schematics` doctest gate ran 15/16; the unrelated
+`SmoothTransitionConfig` doctest executable was quarantined by Windows
+Defender with OS error 225 and `Trojan:Win32/Wacatac.C!ml` (ThreatID
+`2147749372`). A targeted retry was blocked by the shared target queue and
+timed out before producing a second Rust result. No Defender exclusion, test
+weakening, or source workaround was applied. The doctest result is therefore
+a host verification residual, not a remaining metric gap. The unused local
+`[patch]` and `profile.test.env` warnings are existing stack configuration
+warnings outside this slice; provider/linker failures remain separately
+tracked.
 
 ## Schematic mesh geometry metrics (CFDRS-AEQ-MET-46, 2026-08-02)
 

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,39 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+## Venturi geometry metadata metrics (CFDRS-AEQ-MET-47, 2026-08-05)
+
+A fresh public-contract scan found a residual unit gap below the schematic-mesh
+geometry closure: `VenturiGeometryMetadata` exposed channel widths, lengths,
+angles, and throat position as scalar metadata, while `ChannelVenturiSpec`
+returned scalar cavitation dose and pressure-drop results. The direct 1D
+coefficient builder, 2D projection, schematic interchange, mesh converter,
+examples, and physics fixtures consumed those fields as untyped values.
+
+The gap is closed. `VenturiGeometryMetadata` now carries Aequitas `Length`,
+`Angle`, and `Dimensionless`; `ChannelVenturiSpec` carries typed `Length` and
+returns `Dimensionless` cavitation dose and `Pressure` pressure drop from typed
+`VolumetricFlowRate`, `MassDensity`, and `Dimensionless` inputs. FDA cavitation
+compliance now carries typed Mach-index results and accepts typed pressure and
+density. Angle fields use canonical names and store Eunomia base radians.
+Scalar extraction is limited to 1D/2D numerical formulas, mesh/interchange
+conversion, and other explicit representation boundaries. No compatibility
+adapter remains.
+
+The Venturi geometry is real-valued under Eunomia. No complex or imaginary SI
+quantity applies; complex values remain reserved for genuine phasor/Fourier
+fields. Topology authoring structs remain a separate follow-up domain: their
+raw degree/metre inputs are converted at the typed metadata boundary.
+
+Static verification passes with `cargo metadata --offline --locked
+--no-deps`, targeted rustfmt, `git diff --check`, and residue scans. Two
+`cargo check -p cfd-schematics --lib --offline -j 1` attempts were bounded at
+124 seconds and 184 seconds while peer workspace checks held the shared Atlas
+target/build lock; they produced no source diagnostic before timeout. Native
+Nextest, package Clippy, and doctest collection remain pending on that shared
+build resource. A shared Atlas target-cache failure or provider/linker failure
+is verification evidence about the environment, not a remaining metric gap.
+
 ## Schematic mesh geometry metrics (CFDRS-AEQ-MET-46, 2026-08-02)
 
 The audit found a remaining public Aequitas gap in `cfd-schematic-mesh`:


### PR DESCRIPTION
Delivers the first dependency-ordered Aequitas metric increment from the existing typed-metrics branch. Includes Venturi metadata, Dean-site metrics, and the corresponding audit records. The remaining typed geometry increments stay on the source branch for subsequent PRs.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces typed physical quantities using the Aequitas library for Venturi geometry metadata and Dean-site metrics. The `VenturiGeometryMetadata` struct now uses Aequitas `Length`, `Angle`, and `Dimensionless` types instead of raw `f64` values. The `ChannelVenturiSpec` now returns typed `Pressure` and `Dimensionless` results from typed flow rate, density, and coefficient inputs. FDA cavitation compliance similarly accepts typed pressure and density parameters. Angles are stored canonically in radians with conversion to degrees only at computation boundaries. Scalar extraction occurs only at numerical formula boundaries, mesh conversion, and serialization interfaces. All downstream consumers including 1D coefficient builders, 2D projections, mesh converters, examples, and physics tests have been updated to work with the typed values using `from_base()` and `into_base()` conversions at appropriate boundaries.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `crates/cfd-schematics/src/geometry/metadata/therapy.rs` |
| 3 | `crates/cfd-schematics/src/domain/model/blueprint/venturi_impl.rs` |
| 4 | `crates/cfd-1d/src/domain/network/builder/venturi_coefficients.rs` |
| 5 | `crates/cfd-schematics/src/geometry/generator/linear.rs` |
| 6 | `crates/cfd-schematics/src/geometry/generator/selective/builder/cct.rs` |
| 7 | `crates/cfd-schematics/src/geometry/generator/selective/builder/cif.rs` |
| 8 | `crates/cfd-schematics/src/geometry/generator/selective/builder/dtcv.rs` |
| 9 | `crates/cfd-schematics/src/geometry/generator/selective/builder/tbt.rs` |
| 10 | `crates/cfd-schematics/src/geometry/generator/selective/primitive/annotation.rs` |
| 11 | `crates/cfd-1d/tests/blueprint_metadata_physics.rs` |
| 12 | `crates/cfd-2d/src/network/projection.rs` |
| 13 | `crates/cfd-schematic-mesh/src/scheme_io.rs` |
| 14 | `crates/cfd-schematic-mesh/examples/schematic_to_mesh_demo.rs` |
| 15 | `crates/cfd-schematics/src/geometry/types/interchange.rs` |
| 16 | `crates/cfd-schematics/src/visualizations/annotations/geometry.rs` |
| 17 | `crates/cfd-schematics/src/interface/presets/composite/specialized/mod.rs` |
| 18 | `backlog.md` |
| 19 | `gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unit-aware Venturi geometry metadata using typed lengths, angles, and dimensionless values.
  * Added unit-aware pressure-drop, cavitation-dose, flow, density, and velocity calculations.
  * Standardized angle handling with radian-based values and clearer field names.
  * Added unit-aware FDA cavitation compliance metrics.

* **Documentation**
  * Updated the changelog, backlog, and audit documentation with the new measurement contracts and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->