### PR TITLE
build(deps): Require aequitas 0.2.0 and leto 0.41.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Math and numerical
-aequitas = { version = "0.1.0", git = "https://github.com/ryancinsight/aequitas", default-features = false, features = ["std"] }
+aequitas = { version = "0.2.0", git = "https://github.com/ryancinsight/aequitas", default-features = false, features = ["std"] }
 proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
 hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
 tyche-core = { version = "0.1.0", git = "https://github.com/ryancinsight/tyche" }
@@ -78,8 +78,8 @@ cfd-io = { path = "crates/cfd-io" }
 cfd-mesh = { version = "0.3.0", git = "https://github.com/ryancinsight/gaia", package = "gaia" }
 apollo-fft = { version = "0.25.0", git = "https://github.com/ryancinsight/apollo" }
 apollo-nufft = { version = "0.7.0", git = "https://github.com/ryancinsight/apollo" }
-leto = { version = "0.40.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
-leto-ops = { version = "0.40.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
+leto = { version = "0.41.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
+leto-ops = { version = "0.41.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
 # consus: pure-Rust scientific storage formats (HDF5 etc.). Consumed by cfd-io
 # behind the `hdf5` feature for real HDF5 output.
 consus-core = { version = "0.1.0", git = "https://github.com/ryancinsight/consus.git", default-features = false }


### PR DESCRIPTION
Advances CFDrs first-party requirements to current published provider versions: aequitas 0.2.0 (MEMS quantities) and leto 0.41.0 (eunomia-0.8 API).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates two first-party dependency versions in the project: `aequitas` from 0.1.0 to 0.2.0 (which adds MEMS quantities support) and `leto`/`leto-ops` from 0.40.0 to 0.41.0 (which incorporates the eunomia-0.8 API). These are straightforward version bumps to keep the CFD project in sync with the latest published versions of its provider libraries.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal component versions to incorporate the latest compatible improvements.
  * Preserved existing source settings, feature options, and package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->