### PR TITLE
build(deps): Refresh lockfile onto aequitas 0.2.0 / leto 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aequitas"
-version = "0.1.0"
-source = "git+https://github.com/ryancinsight/aequitas#5e6f55ac87d199c6e7abc3d65d8ee400a183dd77"
+version = "0.2.0"
 dependencies = [
  "eunomia",
  "serde",
@@ -116,7 +115,6 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "apollo-fft"
 version = "0.25.0"
-source = "git+https://github.com/ryancinsight/apollo#bd349bfa78b7dfeb123a2d04d32a892e6297db24"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -138,7 +136,6 @@ dependencies = [
 [[package]]
 name = "apollo-fft-macros"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/apollo#bd349bfa78b7dfeb123a2d04d32a892e6297db24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,7 +145,6 @@ dependencies = [
 [[package]]
 name = "apollo-leto-interop"
 version = "0.17.0"
-source = "git+https://github.com/ryancinsight/apollo#bd349bfa78b7dfeb123a2d04d32a892e6297db24"
 dependencies = [
  "leto",
 ]
@@ -156,7 +152,6 @@ dependencies = [
 [[package]]
 name = "apollo-nufft"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/apollo#bd349bfa78b7dfeb123a2d04d32a892e6297db24"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -188,7 +183,6 @@ dependencies = [
 [[package]]
 name = "athena-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/athena#0b06b6636b0d6f91060ae3bcf7b8ff210b34b0c8"
 dependencies = [
  "eunomia",
 ]
@@ -196,7 +190,6 @@ dependencies = [
 [[package]]
 name = "athena-leto"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/athena#0b06b6636b0d6f91060ae3bcf7b8ff210b34b0c8"
 dependencies = [
  "athena-core",
  "eunomia",
@@ -483,12 +476,14 @@ dependencies = [
  "indexmap",
  "leto",
  "leto-ops",
+ "melinoe",
  "moirai-runtime",
  "num_cpus",
  "proptest",
  "proteus",
  "serde",
  "serde_json",
+ "themis-topology",
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
@@ -762,7 +757,6 @@ dependencies = [
 [[package]]
 name = "coeus-autograd"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -777,7 +771,6 @@ dependencies = [
 [[package]]
 name = "coeus-core"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -791,7 +784,6 @@ dependencies = [
 [[package]]
 name = "coeus-leto"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "coeus-core",
  "leto",
@@ -801,7 +793,6 @@ dependencies = [
 [[package]]
 name = "coeus-nn"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -815,7 +806,6 @@ dependencies = [
 [[package]]
 name = "coeus-ops"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -833,7 +823,6 @@ dependencies = [
 [[package]]
 name = "coeus-optim"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -847,7 +836,6 @@ dependencies = [
 [[package]]
 name = "coeus-sparse"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -858,7 +846,6 @@ dependencies = [
 [[package]]
 name = "coeus-tensor"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#7ea9170dd66a823fa011da69580d1cd10379a2ed"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -883,7 +870,6 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "consus-compression"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5c2e39340f24265b6b1023def7cb96775f3bb244"
 dependencies = [
  "byteorder",
  "consus-core",
@@ -892,7 +878,6 @@ dependencies = [
 [[package]]
 name = "consus-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5c2e39340f24265b6b1023def7cb96775f3bb244"
 dependencies = [
  "byteorder",
  "smallvec",
@@ -902,7 +887,6 @@ dependencies = [
 [[package]]
 name = "consus-hdf5"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5c2e39340f24265b6b1023def7cb96775f3bb244"
 dependencies = [
  "byteorder",
  "consus-compression",
@@ -913,7 +897,6 @@ dependencies = [
 [[package]]
 name = "consus-io"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5c2e39340f24265b6b1023def7cb96775f3bb244"
 dependencies = [
  "consus-core",
 ]
@@ -1191,7 +1174,6 @@ dependencies = [
 [[package]]
 name = "eunomia"
 version = "0.8.0"
-source = "git+https://github.com/ryancinsight/eunomia#c223fcf675d2fd6e84d723bfb707e47049e7a56a"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1414,7 +1396,6 @@ dependencies = [
 [[package]]
 name = "gaia"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/gaia#683565ec1e87e7d0e32e4dcf0810b597346a52c6"
 dependencies = [
  "anyhow",
  "eunomia",
@@ -1554,7 +1535,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hephaestus-core"
 version = "0.18.0"
-source = "git+https://github.com/ryancinsight/hephaestus#1e1f12ccb6a9aa9c39e9292947198715de0db480"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1567,7 +1547,6 @@ dependencies = [
 [[package]]
 name = "hephaestus-wgpu"
 version = "0.18.0"
-source = "git+https://github.com/ryancinsight/hephaestus#1e1f12ccb6a9aa9c39e9292947198715de0db480"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1587,7 +1566,6 @@ dependencies = [
 [[package]]
 name = "hermes-simd"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#612e02f840c5e8e59fb78c8e37fb70f268e6c33b"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1600,7 +1578,6 @@ dependencies = [
 [[package]]
 name = "hermes-simd-core"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#612e02f840c5e8e59fb78c8e37fb70f268e6c33b"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1612,7 +1589,6 @@ dependencies = [
 [[package]]
 name = "hermes-simd-intrinsics"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#612e02f840c5e8e59fb78c8e37fb70f268e6c33b"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1621,7 +1597,6 @@ dependencies = [
 [[package]]
 name = "hermes-simd-macros"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#612e02f840c5e8e59fb78c8e37fb70f268e6c33b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1631,7 +1606,6 @@ dependencies = [
 [[package]]
 name = "hermes-simd-types"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/hermes.git#612e02f840c5e8e59fb78c8e37fb70f268e6c33b"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1646,7 +1620,6 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "hyperion"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/hyperion#ab5bc521ad707b9a263a4fe072de9206660a5626"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1704,7 +1677,6 @@ dependencies = [
 [[package]]
 name = "iris"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/iris#2382c3289cda99e1773676f3fa43b8462e80de55"
 
 [[package]]
 name = "is-terminal"
@@ -1773,8 +1745,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leto"
-version = "0.40.0"
-source = "git+https://github.com/ryancinsight/leto.git#912b9918db2e44c6a43cc0b337e71ffdbf9f82da"
+version = "0.41.0"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1786,8 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "leto-ops"
-version = "0.40.0"
-source = "git+https://github.com/ryancinsight/leto.git#912b9918db2e44c6a43cc0b337e71ffdbf9f82da"
+version = "0.41.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1879,7 +1849,6 @@ dependencies = [
 [[package]]
 name = "melinoe"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/melinoe.git#9988daa956edc23bee7dcb4b1955b2871a68c31e"
 
 [[package]]
 name = "memchr"
@@ -1900,7 +1869,6 @@ dependencies = [
 [[package]]
 name = "mnemosyne-arena"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
@@ -1911,7 +1879,6 @@ dependencies = [
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "mnemosyne-memory-core",
 ]
@@ -1919,12 +1886,10 @@ dependencies = [
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1932,17 +1897,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "mnemosyne-hardened"
-version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
-dependencies = [
- "mnemosyne-memory-core",
-]
-
-[[package]]
 name = "mnemosyne-heap"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1956,7 +1912,6 @@ dependencies = [
 [[package]]
 name = "mnemosyne-local"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1971,13 +1926,11 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory"
 version = "0.6.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
  "mnemosyne-backend",
  "mnemosyne-decay",
- "mnemosyne-hardened",
  "mnemosyne-heap",
  "mnemosyne-local",
  "mnemosyne-memory-core",
@@ -1987,12 +1940,10 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory-core"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 
 [[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#e1c43802b2c865fdd0910a8c835b4e553ecb864b"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -2002,7 +1953,6 @@ dependencies = [
 [[package]]
 name = "moirai-async"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "futures",
  "libc",
@@ -2018,7 +1968,6 @@ dependencies = [
 [[package]]
 name = "moirai-async-macros"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2028,7 +1977,6 @@ dependencies = [
 [[package]]
 name = "moirai-core"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "bytemuck",
  "libc",
@@ -2039,7 +1987,6 @@ dependencies = [
 [[package]]
 name = "moirai-executor"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2052,7 +1999,6 @@ dependencies = [
 [[package]]
 name = "moirai-gpu"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "mnemosyne-memory-core",
  "moirai-core",
@@ -2063,7 +2009,6 @@ dependencies = [
 [[package]]
 name = "moirai-iter"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "futures",
  "libc",
@@ -2079,7 +2024,6 @@ dependencies = [
 [[package]]
 name = "moirai-pal"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "js-sys",
  "libc",
@@ -2094,7 +2038,6 @@ dependencies = [
 [[package]]
 name = "moirai-parallel"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "melinoe",
  "moirai-core",
@@ -2104,7 +2047,6 @@ dependencies = [
 [[package]]
 name = "moirai-runtime"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2122,7 +2064,6 @@ dependencies = [
 [[package]]
 name = "moirai-scheduler"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "mnemosyne-memory",
  "moirai-core",
@@ -2134,7 +2075,6 @@ dependencies = [
 [[package]]
 name = "moirai-sync"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "libc",
  "moirai-core",
@@ -2144,7 +2084,6 @@ dependencies = [
 [[package]]
 name = "moirai-transport"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 dependencies = [
  "bytemuck",
  "moirai-core",
@@ -2155,7 +2094,6 @@ dependencies = [
 [[package]]
 name = "moirai-utils"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Moirai#963879ede19cf25efa65beeb183734628614d584"
 
 [[package]]
 name = "munge"
@@ -2608,7 +2546,6 @@ dependencies = [
 [[package]]
 name = "proteus"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/proteus#add61e5bd71a652317ea5349e4021e79eaac2e06"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -2923,7 +2860,6 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "ritk-image"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#cabc7115e360db52bfc700973ca1767786c48373"
 dependencies = [
  "anyhow",
  "coeus-autograd",
@@ -2940,7 +2876,6 @@ dependencies = [
 [[package]]
 name = "ritk-spatial"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/ritk#cabc7115e360db52bfc700973ca1767786c48373"
 dependencies = [
  "leto",
  "serde",
@@ -2950,7 +2885,6 @@ dependencies = [
 [[package]]
 name = "ritk-vtk"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/ritk#cabc7115e360db52bfc700973ca1767786c48373"
 dependencies = [
  "anyhow",
  "coeus-core",
@@ -2966,7 +2900,6 @@ dependencies = [
 [[package]]
 name = "ritk-wgpu-compat"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/ritk#cabc7115e360db52bfc700973ca1767786c48373"
 
 [[package]]
 name = "rkyv"
@@ -3269,7 +3202,6 @@ dependencies = [
 [[package]]
 name = "themis-topology"
 version = "0.10.1"
-source = "git+https://github.com/ryancinsight/themis#54b89f97430bee96c0573f4dfc21995a723537f2"
 dependencies = [
  "melinoe",
 ]
@@ -3459,7 +3391,6 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 [[package]]
 name = "tyche-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/tyche#7e76bbb26edaee67415fd6f5caef155217115d0c"
 dependencies = [
  "eunomia",
 ]
@@ -4178,3 +4109,63 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "ritk-core"
+version = "0.9.0"
+
+[[patch.unused]]
+name = "ritk-dicom"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "ritk-io"
+version = "0.2.0"
+
+[[patch.unused]]
+name = "ritk-registration"
+version = "0.53.0"
+
+[[patch.unused]]
+name = "asclepius"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "asclepius-coeus"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "hephaestus-cuda"
+version = "0.18.0"
+
+[[patch.unused]]
+name = "hephaestus-metal"
+version = "0.18.0"
+
+[[patch.unused]]
+name = "hephaestus-rocm"
+version = "0.18.0"
+
+[[patch.unused]]
+name = "apollo-sht"
+version = "0.7.0"
+
+[[patch.unused]]
+name = "horae"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "consus-npy"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "consus-onnx"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "consus-zarr"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "moirai-http"
+version = "0.4.0"


### PR DESCRIPTION
Re-resolves the lockfile so first-party providers are pinned at the current published versions (aequitas 0.2.0, leto 0.41.0).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the Cargo lockfile to pin first-party dependencies to their latest published versions, specifically upgrading `aequitas` from 0.1.0 to 0.2.0 and `leto` (along with `leto-ops`) from 0.40.0 to 0.41.0. The changes remove git source references for numerous dependencies, indicating they are now being pulled from a registry instead. Additionally, two new dependencies (`melinoe` and `themis-topology`) have been added to the `cronus-runtime` package, and the `mnemosyne-hardened` package has been removed from the dependency tree.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.lock` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `Cargo.lock` | Addition of new dependencies `melinoe` and `themis-topology` to `cronus-runtime` seems unrelated to simply refreshing the lockfile for version bumps |
| `Cargo.lock` | Removal of `mnemosyne-hardened` package from the dependency tree appears to be a structural change beyond just version updates |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->