### PR TITLE
chore(lints): Wire CFDrs workspace lint floor and reach zero cfd-schematics doc debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   public API documentation.
 - cfd-schematics series and parallel geometry generators now carry public API
   documentation.
+- cfd-schematics selective-tree path, topology, request, and generator
+  contracts now carry public API documentation.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.
+- cfd-math performance and DG progress reporting now use invariant-checked
+  mutex access and structured tracing output.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   xtask CLI output pass through a checked writer.
 - cfd-math performance and DG progress reporting now use invariant-checked
   mutex access and structured tracing output.
+- cfd-schematics topology specification types and lookup methods now carry
+  public API documentation; the package documentation ratchet remains open.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Changelog
 
+- Workspace packages now inherit the canonical Atlas lint floor; the initial
+  ratchet increment also removes a cfd-core plugin resolver unwrap and makes
+  xtask CLI output pass through a checked writer.
+
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
   mutex access and structured tracing output.
 - cfd-schematics topology specification types and lookup methods now carry
   public API documentation; the package documentation ratchet remains open.
+- cfd-schematics configuration constants and public config manifests now carry
+  public API documentation; the documentation ratchet remains open.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   documentation.
 - cfd-schematics geometry-generator entry points and metadata builder now carry
   public API documentation.
+- cfd-schematics series and parallel geometry generators now carry public API
+  documentation.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   public API documentation; the package documentation ratchet remains open.
 - cfd-schematics configuration constants and public config manifests now carry
   public API documentation; the documentation ratchet remains open.
+- cfd-schematics node and channel builder setters now carry public API
+  documentation.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
   public API documentation; the documentation ratchet remains open.
 - cfd-schematics node and channel builder setters now carry public API
   documentation.
+- cfd-schematics geometry-generator entry points and metadata builder now carry
+  public API documentation.
 
 - Removed stale legacy-migration audit exemptions for the fully Eunomia/Leto
   `cfd-1d` and `cfd-3d` scalar seams.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -13,6 +13,9 @@
 - [ ] Continue the workspace ratchet: cfd-math unwrap/output sites,
       cfd-schematics missing-docs debt, cfd-core test/bench lint debt, and the
       pre-existing all-target formatting baseline remain open.
+- [x] Replace the cfd-math multigrid coarsening `partial_cmp().unwrap()` calls
+      with deterministic NaN-safe ordering and add its value-semantic test;
+      cfd-math Nextest passes 198/198.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -27,8 +27,10 @@
 - [x] Document the `ConstantsRegistry` contract, adaptive primitive constants,
       and public config module manifests; package Clippy residue decreases from
       611 to 534.
+- [x] Document the ten public node/channel builder setters in
+      `geometry/builders.rs`; package Clippy residue decreases from 534 to 524.
 - [ ] Continue the cfd-schematics documentation ratchet from the remaining
-      534 diagnostics, then address cfd-core test/bench lint debt and format
+      524 diagnostics, then address cfd-core test/bench lint debt and format
       baseline debt.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -36,8 +36,13 @@
       `geometry/generator/linear.rs`; package Clippy residue decreases from
       508 to 506. Current working-tree Clippy reports 492 with peer-owned
       `analysis_impl.rs` documentation changes present but uncommitted.
+- [x] Document the public selective-tree path specification, topology
+      variants, request fields, and generator entrypoint in
+      `geometry/generator/selective/mod.rs`; package Clippy residue decreases
+      from 506 to 468. Current working-tree Clippy reports 454 with the same
+      peer-owned documentation changes present.
 - [ ] Continue the cfd-schematics documentation ratchet from the remaining
-      506 diagnostics, then address cfd-core test/bench lint debt and format
+      468 diagnostics, then address cfd-core test/bench lint debt and format
       baseline debt.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -19,6 +19,8 @@
 - [x] Replace remaining cfd-math multigrid/interpolation unwraps with
       invariant-checked expectations and centralize C-contiguous JFNK/spectral
       storage access; cfd-math Nextest remains 198/198.
+- [x] Replace cfd-math performance-monitor lock/output violations and DG
+      solver println output; focused cfd-math library Clippy and Nextest pass.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -21,6 +21,12 @@
       storage access; cfd-math Nextest remains 198/198.
 - [x] Replace cfd-math performance-monitor lock/output violations and DG
       solver println output; focused cfd-math library Clippy and Nextest pass.
+- [x] Document the exported `cfd-schematics::topology::model` contract,
+      including fields, variants, aliases, and lookup methods; package Clippy
+      missing-documentation residue decreases from 712 to 611.
+- [ ] Continue the cfd-schematics documentation ratchet from the remaining
+      611 diagnostics, then address cfd-core test/bench lint debt and format
+      baseline debt.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,19 @@
 # CFDrs Work Checklist
 
+## Owner: current Codex session — CFDRS-LINT-FLOOR-001 — in progress 2026-08-06
+
+- [x] Declare the Atlas `[workspace.lints]` floor and inherit it from all
+      workspace packages plus `xtask`.
+- [x] Remove the input-dependent `cfd-core` plugin dependency-map unwrap and
+      route `xtask` CLI lines through a checked writer so the deny floor remains
+      active.
+- [x] Verify `cargo clippy -p xtask --all-targets`,
+      `cargo clippy -p cfd-core --lib`, cfd-core Nextest (246/246), cfd-core
+      doctests (3/3), and the explicit legacy-migration audit.
+- [ ] Continue the workspace ratchet: cfd-math unwrap/output sites,
+      cfd-schematics missing-docs debt, cfd-core test/bench lint debt, and the
+      pre-existing all-target formatting baseline remain open.
+
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31
 
 - [x] Regenerate `Cargo.lock` outside the Atlas development overlay after the

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -24,8 +24,11 @@
 - [x] Document the exported `cfd-schematics::topology::model` contract,
       including fields, variants, aliases, and lookup methods; package Clippy
       missing-documentation residue decreases from 712 to 611.
+- [x] Document the `ConstantsRegistry` contract, adaptive primitive constants,
+      and public config module manifests; package Clippy residue decreases from
+      611 to 534.
 - [ ] Continue the cfd-schematics documentation ratchet from the remaining
-      611 diagnostics, then address cfd-core test/bench lint debt and format
+      534 diagnostics, then address cfd-core test/bench lint debt and format
       baseline debt.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -32,8 +32,12 @@
 - [x] Document the metadata configuration, generation functions, and builder
       contract in `geometry/generator/entrypoints.rs`; package Clippy residue
       decreases from 524 to 508.
+- [x] Document the series and parallel geometry builders in
+      `geometry/generator/linear.rs`; package Clippy residue decreases from
+      508 to 506. Current working-tree Clippy reports 492 with peer-owned
+      `analysis_impl.rs` documentation changes present but uncommitted.
 - [ ] Continue the cfd-schematics documentation ratchet from the remaining
-      508 diagnostics, then address cfd-core test/bench lint debt and format
+      506 diagnostics, then address cfd-core test/bench lint debt and format
       baseline debt.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -16,6 +16,9 @@
 - [x] Replace the cfd-math multigrid coarsening `partial_cmp().unwrap()` calls
       with deterministic NaN-safe ordering and add its value-semantic test;
       cfd-math Nextest passes 198/198.
+- [x] Replace remaining cfd-math multigrid/interpolation unwraps with
+      invariant-checked expectations and centralize C-contiguous JFNK/spectral
+      storage access; cfd-math Nextest remains 198/198.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -29,8 +29,11 @@
       611 to 534.
 - [x] Document the ten public node/channel builder setters in
       `geometry/builders.rs`; package Clippy residue decreases from 534 to 524.
+- [x] Document the metadata configuration, generation functions, and builder
+      contract in `geometry/generator/entrypoints.rs`; package Clippy residue
+      decreases from 524 to 508.
 - [ ] Continue the cfd-schematics documentation ratchet from the remaining
-      524 diagnostics, then address cfd-core test/bench lint debt and format
+      508 diagnostics, then address cfd-core test/bench lint debt and format
       baseline debt.
 
 ## Owner: current Codex session — CFDRS-CI-LOCK-1 standalone provider lock and hosted gates — done 2026-07-31

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,46 @@ cfd-2d = { path = "crates/cfd-2d" }
 cfd-3d = { path = "crates/cfd-3d" }
 cfd-optim = { path = "crates/cfd-optim" }
 cfd-validation = { path = "crates/cfd-validation" }
+
+[workspace.lints.rust]
+# Floor: warn. Per-crate `#![deny(missing_docs)]` is the strict escalation
+# surface (each crate decides its own missing-docs tier; the workspace floor
+# stays at warn so existing crates without missing-docs discipline remain
+# warning-only and promotion is incremental).
+missing_docs = "warn"
+
+[workspace.lints.clippy]
+# Canonical Atlas floor (template SSOT: repos/apollo/Cargo.toml L88-L107).
+# `all` + `pedantic` at warn, priority = -1 so they evaluate before
+# crate-level allows. The `allow` set below mirrors apollo's template
+# verbatim so atlas-wide existing-debt stays non-regressive.
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# Canonical Atlas library hygiene: deny the four output/panic-erasure
+# patterns at workspace level. Pre-existing violations carry per-site
+# `#[expect(lint, reason="ratchet cfd-<id>")]`; the floor itself never
+# `allow`s them — that would erase the ratchet signal.
+unwrap_used = "deny"
+print_stderr = "deny"
+print_stdout = "deny"
+dbg_macro = "deny"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+similar_names = "allow"
+too_many_lines = "allow"
+default_constructed_unit_structs = "allow"
+doc_lazy_continuation = "allow"
+needless_range_loop = "allow"
+too_many_arguments = "allow"
+manual_is_multiple_of = "allow"
+manual_div_ceil = "allow"
+manual_slice_size_calculation = "allow"
+len_zero = "allow"
+cast_possible_truncation = "allow"
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+items_after_statements = "allow"
+range_minus_one = "allow"
+default_trait_access = "allow"
+useless_conversion = "allow"

--- a/backlog.md
+++ b/backlog.md
@@ -45,6 +45,10 @@
   add a regression test. cfd-math Nextest is 198/198; its library Clippy
   residue is reduced from 51 to 48 diagnostics, with the remaining debt
   recorded for subsequent slices.
+- Follow-up cfd-math storage/invariant slice: replace multigrid hierarchy and
+  interpolation unwraps with invariant-checked `expect` calls, and centralize
+  C-contiguous JFNK slices plus spectral connectivity checks. cfd-math Nextest
+  remains 198/198; its library Clippy residue is now 22 diagnostics.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -57,6 +57,10 @@
   topology specification types, fields, enum variants, aliases, and lookup
   methods in `topology/model.rs`. Package Clippy diagnostics decrease from 712
   to 611; the remaining missing-documentation debt is outside this model.
+- cfd-schematics constants/config-manifest documentation slice: document the
+  `ConstantsRegistry` contract, adaptive primitive constants, and public config
+  module manifests. Package Clippy diagnostics decrease from 611 to 534; the
+  remaining missing-documentation debt is outside this configuration scope.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -29,6 +29,18 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # CFDrs Backlog
 
+## Active lint-floor increment
+
+- **CFDRS-LINT-FLOOR-001 [patch] — in progress (2026-08-06; current Codex
+  session):** wire every workspace package and `xtask` to the canonical Atlas
+  `[workspace.lints]` floor, remove the `cfd-core` plugin resolver unwrap, and
+  centralize `xtask` CLI output through its checked writer. `cfd-core` library
+  Clippy, 246 cfd-core unit tests through Nextest, three doctests, and the
+  explicit legacy-migration audit pass. Full closure remains open: workspace
+  all-target Clippy still reports pre-existing cfd-math unwrap/output debt,
+  cfd-schematics missing documentation, and test/bench lint debt; the existing
+  all-target format baseline is also red outside this increment.
+
 ## Active integration
 
 - **CFDRS-AEQ-MET-63 [major] - Type ChannelSpec hydraulic metrics

--- a/backlog.md
+++ b/backlog.md
@@ -64,6 +64,10 @@
 - cfd-schematics geometry-builder documentation slice: document the ten public
   node/channel builder setters in `geometry/builders.rs`; the package Clippy
   residual decreases from 534 to 524.
+- cfd-schematics geometry-generator entrypoint documentation slice: document
+  the metadata configuration, generation functions, and builder contract in
+  `geometry/generator/entrypoints.rs`; the package Clippy residual decreases
+  from 524 to 508.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -68,6 +68,11 @@
   the metadata configuration, generation functions, and builder contract in
   `geometry/generator/entrypoints.rs`; the package Clippy residual decreases
   from 524 to 508.
+- cfd-schematics linear-generator documentation slice: document the series and
+  parallel geometry builders in `geometry/generator/linear.rs`; the package
+  Clippy residual decreases from 508 to 506. The current working tree reports
+  492 because peer-owned documentation changes are also present in
+  `domain/model/blueprint/analysis_impl.rs` and remain uncommitted.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -40,6 +40,11 @@
   all-target Clippy still reports pre-existing cfd-math unwrap/output debt,
   cfd-schematics missing documentation, and test/bench lint debt; the existing
   all-target format baseline is also red outside this increment.
+- Follow-up cfd-math slice: replace floating-point `partial_cmp().unwrap()`
+  ordering in multigrid coarsening with deterministic NaN-safe ordering and
+  add a regression test. cfd-math Nextest is 198/198; its library Clippy
+  residue is reduced from 51 to 48 diagnostics, with the remaining debt
+  recorded for subsequent slices.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -49,6 +49,10 @@
   interpolation unwraps with invariant-checked `expect` calls, and centralize
   C-contiguous JFNK slices plus spectral connectivity checks. cfd-math Nextest
   remains 198/198; its library Clippy residue is now 22 diagnostics.
+- cfd-math closure slice: replace performance-monitor lock unwraps with
+  invariant diagnostics and route calibration output through tracing; replace
+  DG solver println output with structured tracing events. cfd-math library
+  Clippy now passes and Nextest remains 198/198.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -73,6 +73,11 @@
   Clippy residual decreases from 508 to 506. The current working tree reports
   492 because peer-owned documentation changes are also present in
   `domain/model/blueprint/analysis_impl.rs` and remain uncommitted.
+- cfd-schematics selective-tree documentation slice: document the public path
+  specification, topology variants, request fields, and generator entrypoint
+  in `geometry/generator/selective/mod.rs`; the package Clippy residual
+  decreases from 506 to 468. The current working tree reports 454 with the
+  peer-owned blueprint-analysis documentation still present.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -53,6 +53,10 @@
   invariant diagnostics and route calibration output through tracing; replace
   DG solver println output with structured tracing events. cfd-math library
   Clippy now passes and Nextest remains 198/198.
+- cfd-schematics topology-model documentation slice: document the exported
+  topology specification types, fields, enum variants, aliases, and lookup
+  methods in `topology/model.rs`. Package Clippy diagnostics decrease from 712
+  to 611; the remaining missing-documentation debt is outside this model.
 
 ## Active integration
 

--- a/backlog.md
+++ b/backlog.md
@@ -61,6 +61,9 @@
   `ConstantsRegistry` contract, adaptive primitive constants, and public config
   module manifests. Package Clippy diagnostics decrease from 611 to 534; the
   remaining missing-documentation debt is outside this configuration scope.
+- cfd-schematics geometry-builder documentation slice: document the ten public
+  node/channel builder setters in `geometry/builders.rs`; the package Clippy
+  residual decreases from 534 to 524.
 
 ## Active integration
 

--- a/crates/cfd-1d/Cargo.toml
+++ b/crates/cfd-1d/Cargo.toml
@@ -42,3 +42,6 @@ harness = false
 [[bench]]
 name = "direct_solver_cutoff"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cfd-2d/Cargo.toml
+++ b/crates/cfd-2d/Cargo.toml
@@ -43,3 +43,6 @@ rand.workspace = true
 [[bench]]
 name = "solver_benchmarks"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cfd-3d/Cargo.toml
+++ b/crates/cfd-3d/Cargo.toml
@@ -43,3 +43,6 @@ cfd-schematics.workspace = true
 [[bench]]
 name = "smagorinsky_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cfd-core/Cargo.toml
+++ b/crates/cfd-core/Cargo.toml
@@ -44,3 +44,6 @@ leto-ops.workspace = true
 name = "turbulence_benchmark"
 harness = false
 required-features = ["gpu"]
+
+[lints]
+workspace = true

--- a/crates/cfd-core/src/management/plugin/dependency.rs
+++ b/crates/cfd-core/src/management/plugin/dependency.rs
@@ -129,7 +129,7 @@ impl DependencyResolver {
                     .entry(dep.clone())
                     .or_default()
                     .push(plugin.clone());
-                *in_degree.get_mut(plugin).unwrap() += 1;
+                *in_degree.entry(plugin.clone()).or_insert(0) += 1;
             }
         }
 

--- a/crates/cfd-io/Cargo.toml
+++ b/crates/cfd-io/Cargo.toml
@@ -37,3 +37,6 @@ tempfile = "3.8"
 proptest.workspace = true
 # Memory-backed reader used to validate written HDF5 images in round-trip tests.
 consus-io = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cfd-math/Cargo.toml
+++ b/crates/cfd-math/Cargo.toml
@@ -68,3 +68,6 @@ harness = false
 [[bench]]
 name = "cg_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/cfd-math/src/diagnostics/performance_monitor.rs
+++ b/crates/cfd-math/src/diagnostics/performance_monitor.rs
@@ -57,7 +57,10 @@ impl AdaptivePerformanceMonitor {
 
     /// Record performance measurement for an operation
     pub fn record_measurement(&self, operation: &str, array_size: usize, execution_time_ns: u64) {
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self
+            .metrics
+            .lock()
+            .expect("invariant: performance monitor metrics mutex is not poisoned");
         let op_metrics = metrics.entry(operation.to_string()).or_default();
         let (old_avg, old_std, old_count) = {
             let size_metrics = op_metrics.entry(array_size).or_default();
@@ -111,7 +114,10 @@ impl AdaptivePerformanceMonitor {
 
     /// Get optimal threshold for switching between algorithms
     pub fn get_optimal_threshold(&self, operation: &str) -> Option<usize> {
-        let metrics = self.metrics.lock().unwrap();
+        let metrics = self
+            .metrics
+            .lock()
+            .expect("invariant: performance monitor metrics mutex is not poisoned");
         let op_metrics = metrics.get(operation)?;
 
         // Find crossover point where SIMD becomes beneficial
@@ -159,13 +165,16 @@ impl AdaptivePerformanceMonitor {
 
     /// Check if calibration is needed
     pub fn needs_calibration(&self) -> bool {
-        let last_calibration = *self.last_calibration.lock().unwrap();
+        let last_calibration = *self
+            .last_calibration
+            .lock()
+            .expect("invariant: calibration mutex is not poisoned");
         last_calibration.elapsed() > self.calibration_interval
     }
 
     /// Run performance calibration suite
     pub fn run_calibration(&self) -> Result<(), Box<dyn std::error::Error>> {
-        println!("Running performance calibration...");
+        tracing::info!("Running performance calibration");
         let sizes = [64usize, 128, 256, 512, 1024, 2048, 4096, 8192];
 
         for size in sizes {
@@ -256,9 +265,12 @@ impl AdaptivePerformanceMonitor {
             self.record_measurement("spmv", size, avg);
         }
 
-        *self.last_calibration.lock().unwrap() = Instant::now();
+        *self
+            .last_calibration
+            .lock()
+            .expect("invariant: calibration mutex is not poisoned") = Instant::now();
 
-        println!("Performance calibration completed");
+        tracing::info!("Performance calibration completed");
         Ok(())
     }
 
@@ -289,7 +301,10 @@ impl AdaptivePerformanceMonitor {
 
     /// Get performance report
     pub fn get_performance_report(&self) -> HashMap<String, HashMap<usize, PerformanceMetrics>> {
-        self.metrics.lock().unwrap().clone()
+        self.metrics
+            .lock()
+            .expect("invariant: performance monitor metrics mutex is not poisoned")
+            .clone()
     }
 }
 

--- a/crates/cfd-math/src/high_order/dg/solver/mod.rs
+++ b/crates/cfd-math/src/high_order/dg/solver/mod.rs
@@ -214,12 +214,12 @@ impl DGSolver {
             && (self.step_count.is_multiple_of(self.params.output_interval)
                 || self.t >= self.params.t_final)
         {
-            println!(
-                "Step {}: t = {:.6}, dt = {:.2e}, |u| = {:.6e}",
-                self.step_count,
-                self.t,
+            tracing::info!(
+                step = self.step_count,
+                time = self.t,
                 dt,
-                matrix_norm(&self.u)
+                solution_norm = matrix_norm(&self.u),
+                "DG step"
             );
         }
 
@@ -251,11 +251,13 @@ impl DGSolver {
         let start_time = Instant::now();
 
         if self.params.verbose {
-            println!("Starting time integration...");
-            println!("  Method: {:?}", self.params.method);
-            println!("  t_final: {}", self.params.t_final);
-            println!("  Initial dt: {}", self.dt);
-            println!("  Max steps: {}", self.params.max_steps);
+            tracing::info!(
+                method = ?self.params.method,
+                final_time = self.params.t_final,
+                initial_dt = self.dt,
+                max_steps = self.params.max_steps,
+                "Starting DG time integration"
+            );
         }
 
         // Main time-stepping loop
@@ -266,7 +268,7 @@ impl DGSolver {
 
             if !result.converged {
                 if self.params.verbose {
-                    println!("Warning: Time step failed at t = {}", self.t);
+                    tracing::warn!(time = self.t, "DG time step failed");
                 }
 
                 if self.dt <= self.params.dt_min {
@@ -281,7 +283,7 @@ impl DGSolver {
                 self.nrejected += 1;
 
                 if self.params.verbose {
-                    println!("  Reducing time step to dt = {}", self.dt);
+                    tracing::warn!(new_dt = self.dt, "Reducing DG time step");
                 }
 
                 continue;
@@ -293,16 +295,16 @@ impl DGSolver {
         let elapsed = start_time.elapsed();
 
         if self.params.verbose {
-            println!(
-                "Time integration completed in {:.3} seconds",
-                elapsed.as_secs_f64()
+            tracing::info!(
+                elapsed_seconds = elapsed.as_secs_f64(),
+                final_time = self.t,
+                time_steps = self.step_count,
+                rejected_steps = self.nrejected,
+                function_evaluations = self.nfev,
+                jacobian_evaluations = self.njev,
+                linear_solves = self.nlinsolve,
+                "DG time integration completed"
             );
-            println!("  Final time: {}", self.t);
-            println!("  Time steps: {}", self.step_count);
-            println!("  Rejected steps: {}", self.nrejected);
-            println!("  Function evaluations: {}", self.nfev);
-            println!("  Jacobian evaluations: {}", self.njev);
-            println!("  Linear solves: {}", self.nlinsolve);
         }
 
         if self.t < self.params.t_final && self.step_count >= self.params.max_steps {

--- a/crates/cfd-math/src/high_order/spectral/element.rs
+++ b/crates/cfd-math/src/high_order/spectral/element.rs
@@ -228,7 +228,11 @@ impl SpectralMesh1D {
     pub fn find_element(&self, x: f64) -> Option<usize> {
         for (e, _element) in self.elements.iter().enumerate() {
             let x0 = self.node_coord(self.element_connectivity[e][0]);
-            let x1 = self.node_coord(*self.element_connectivity[e].last().unwrap());
+            let x1 = self.node_coord(
+                *self.element_connectivity[e]
+                    .last()
+                    .expect("invariant: spectral element connectivity is non-empty"),
+            );
 
             // Use [x0, x1) for all but the last element, which is [x0, x1]
             let is_last = e == self.num_elements - 1;
@@ -278,7 +282,11 @@ impl SpectralMesh1D {
 
             // Compute element contribution to error
             let x0 = self.node_coord(conn[0]);
-            let x1 = self.node_coord(*conn.last().unwrap());
+            let x1 = self.node_coord(
+                *conn
+                    .last()
+                    .expect("invariant: spectral element connectivity is non-empty"),
+            );
 
             // Use Gauss quadrature for more accurate error computation
             let quad_points = 10; // Number of quadrature points per element

--- a/crates/cfd-math/src/high_order/spectral/mod.rs
+++ b/crates/cfd-math/src/high_order/spectral/mod.rs
@@ -91,7 +91,12 @@ fn dot(lhs: &Array1<f64>, rhs: &Array1<f64>) -> f64 {
         rhs.shape(),
         "invariant: dot operands must have equal length"
     );
-    leto_ops::Scalar::dot_slice(lhs.as_slice().unwrap(), rhs.as_slice().unwrap())
+    leto_ops::Scalar::dot_slice(
+        lhs.as_slice()
+            .expect("invariant: spectral vectors are C-contiguous"),
+        rhs.as_slice()
+            .expect("invariant: spectral vectors are C-contiguous"),
+    )
 }
 
 fn stiffness_matrix(derivative: &Array2<f64>, mass: &Array2<f64>) -> Array2<f64> {

--- a/crates/cfd-math/src/linear_solver/preconditioners/multigrid/amg.rs
+++ b/crates/cfd-math/src/linear_solver/preconditioners/multigrid/amg.rs
@@ -238,7 +238,10 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicMultigrid<T> {
             // Use cached operators to build coarse matrices
             for (restriction, interpolation) in &hierarchy.operators {
                 let coarse_matrix = {
-                    let current_level = self.levels.last_mut().unwrap();
+                    let current_level = self
+                        .levels
+                        .last_mut()
+                        .expect("invariant: cached hierarchy starts from the finest level");
                     let temp_matrix = sparse_product(restriction, &current_level.matrix)?;
                     let coarse_matrix = sparse_product(&temp_matrix, interpolation)?;
 
@@ -256,14 +259,24 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicMultigrid<T> {
                     interpolation: None,
                     smoother,
                 });
-                self.statistics
-                    .level_sizes
-                    .push(self.levels.last().unwrap().matrix.nrows());
+                self.statistics.level_sizes.push(
+                    self.levels
+                        .last()
+                        .expect("invariant: cached hierarchy level was just inserted")
+                        .matrix
+                        .nrows(),
+                );
             }
         } else {
             // Standard build
             while self.levels.len() < self.config.max_levels
-                && self.levels.last().unwrap().matrix.nrows() > self.config.min_coarse_size
+                && self
+                    .levels
+                    .last()
+                    .expect("invariant: AMG setup created the finest level")
+                    .matrix
+                    .nrows()
+                    > self.config.min_coarse_size
             {
                 self.build_next_level()?;
             }
@@ -281,7 +294,10 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicMultigrid<T> {
     /// Build the next coarser level in the hierarchy
     fn build_next_level(&mut self) -> Result<()> {
         let (restriction, interpolation, coarse_matrix) = {
-            let current_level = self.levels.last().unwrap();
+            let current_level = self
+                .levels
+                .last()
+                .expect("invariant: AMG hierarchy has a current level");
 
             // Perform coarsening using the configured strategy
             let coarsening_result = match self.config.coarsening_strategy {
@@ -440,7 +456,10 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicMultigrid<T> {
 
             // 3. Restriction: r_coarse = R * r
             sparse_apply_into(
-                current_level.restriction.as_ref().unwrap(),
+                current_level
+                    .restriction
+                    .as_ref()
+                    .expect("invariant: non-coarsest AMG level has restriction"),
                 r,
                 &mut current_workspace.coarse_residual,
             )
@@ -459,7 +478,10 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicMultigrid<T> {
 
             // 5. Interpolation: e = P * e_coarse
             sparse_apply_into(
-                current_level.interpolation.as_ref().unwrap(),
+                current_level
+                    .interpolation
+                    .as_ref()
+                    .expect("invariant: non-coarsest AMG level has interpolation"),
                 &current_workspace.coarse_solution,
                 &mut current_workspace.correction,
             )

--- a/crates/cfd-math/src/linear_solver/preconditioners/multigrid/coarsening/algorithms.rs
+++ b/crates/cfd-math/src/linear_solver/preconditioners/multigrid/coarsening/algorithms.rs
@@ -255,7 +255,7 @@ pub fn falgout_coarsening<T: RealField + Copy + FloatElement + LetoScalar>(
     }
 
     let mut sorted_indices: Vec<usize> = (0..n).collect();
-    sorted_indices.sort_by(|&a, &b| measures[b].partial_cmp(&measures[a]).unwrap());
+    sorted_indices.sort_by(|&a, &b| measures[b].total_cmp(&measures[a]));
 
     let lambda = 4.0 / 3.0;
     let mut status = vec![0; n];
@@ -330,7 +330,7 @@ pub fn pmis_coarsening<T: RealField + Copy + FloatElement + LetoScalar>(
     let priorities: Vec<f64> = (0..n).map(|_| rng.gen()).collect();
 
     let mut sorted_indices: Vec<usize> = (0..n).collect();
-    sorted_indices.sort_by(|&a, &b| priorities[b].partial_cmp(&priorities[a]).unwrap());
+    sorted_indices.sort_by(|&a, &b| priorities[b].total_cmp(&priorities[a]));
 
     for &i in &sorted_indices {
         if status[i] != 0 {

--- a/crates/cfd-math/src/linear_solver/preconditioners/multigrid/coarsening/quality.rs
+++ b/crates/cfd-math/src/linear_solver/preconditioners/multigrid/coarsening/quality.rs
@@ -2,6 +2,8 @@
 //!
 //! Reference: Cleary, A. J., Falgout, R. D., Henson, V. E., & Jones, J. E. (2001)
 
+use core::cmp::Ordering;
+
 use super::super::SparseMatrix;
 use super::CoarseningResult;
 use eunomia::{FloatElement, NumericElement, RealField};
@@ -107,7 +109,7 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicDistances<T> {
             <T as NumericElement>::ZERO
         };
 
-        high_distance_points.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        high_distance_points.sort_by(|a, b| descending_total_order(&a.1, &b.1));
 
         Self {
             distances,
@@ -176,6 +178,21 @@ impl<T: RealField + Copy + FloatElement + LetoScalar> AlgebraicDistances<T> {
         }
 
         quality
+    }
+}
+
+/// Orders finite values by descending magnitude and places unordered values
+/// after finite values. The coarsening report remains deterministic when a
+/// numerical input produces NaN instead of panicking while sorting diagnostics.
+fn descending_total_order<T: PartialOrd>(left: &T, right: &T) -> Ordering {
+    let left_unordered = left.partial_cmp(left).is_none();
+    let right_unordered = right.partial_cmp(right).is_none();
+
+    match (left_unordered, right_unordered) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Greater,
+        (false, true) => Ordering::Less,
+        (false, false) => right.partial_cmp(left).unwrap_or(Ordering::Equal),
     }
 }
 
@@ -331,5 +348,21 @@ impl CoarseningQuality {
             && self.coarsening_ratio > 0.1
             && self.coarsening_ratio < 0.8
             && self.max_interpolation_points <= 10
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::descending_total_order;
+    use core::cmp::Ordering;
+
+    #[test]
+    fn descending_total_order_places_unordered_values_after_finite_values() {
+        assert_eq!(descending_total_order(&f64::NAN, &1.0), Ordering::Greater);
+        assert_eq!(descending_total_order(&1.0, &f64::NAN), Ordering::Less);
+        assert_eq!(
+            descending_total_order(&f64::NAN, &f64::NAN),
+            Ordering::Equal
+        );
     }
 }

--- a/crates/cfd-math/src/linear_solver/preconditioners/multigrid/interpolation.rs
+++ b/crates/cfd-math/src/linear_solver/preconditioners/multigrid/interpolation.rs
@@ -132,7 +132,8 @@ pub fn create_classical_interpolation<T: RealField + Copy + FloatElement + LetoS
                     let neg_diag_inv = <T as NumericElement>::ONE / -diagonal;
 
                     for &j in &c_i {
-                        let coarse_local_idx = coarse_map[j].unwrap();
+                        let coarse_local_idx = coarse_map[j]
+                            .expect("invariant: every classical interpolation C-point is mapped");
 
                         // A_ij (direct connection)
                         let mut a_ij = <T as NumericElement>::ZERO;
@@ -236,7 +237,10 @@ pub fn create_standard_interpolation<T: RealField + Copy + FloatElement + LetoSc
     for fine_i in 0..fine_n {
         if coarse_points.contains(&fine_i) {
             // Direct injection for coarse points
-            let coarse_idx = coarse_points.iter().position(|&x| x == fine_i).unwrap();
+            let coarse_idx = coarse_points
+                .iter()
+                .position(|&x| x == fine_i)
+                .expect("invariant: a listed coarse point has a local index");
             col_indices.push(coarse_idx);
             values.push(<T as NumericElement>::ONE);
         } else {

--- a/crates/cfd-math/src/nonlinear_solver/linalg.rs
+++ b/crates/cfd-math/src/nonlinear_solver/linalg.rs
@@ -3,6 +3,20 @@ use leto::Array1;
 use leto_ops::Scalar;
 
 #[inline]
+fn contiguous_slice<T>(vector: &Array1<T>) -> &[T] {
+    vector
+        .as_slice()
+        .expect("invariant: JFNK Array1 storage is C-contiguous")
+}
+
+#[inline]
+fn contiguous_slice_mut<T>(vector: &mut Array1<T>) -> &mut [T] {
+    vector
+        .as_slice_mut()
+        .expect("invariant: JFNK Array1 storage is C-contiguous")
+}
+
+#[inline]
 pub(super) fn vector_zeros<T: Scalar>(len: usize) -> Array1<T> {
     Array1::from_elem([len], T::ZERO)
 }
@@ -19,7 +33,7 @@ pub(super) fn dot<T: Scalar>(lhs: &Array1<T>, rhs: &Array1<T>) -> T {
         vector_len(rhs),
         "invariant: vector dot requires equal lengths"
     );
-    T::dot_slice(lhs.as_slice().unwrap(), rhs.as_slice().unwrap())
+    T::dot_slice(contiguous_slice(lhs), contiguous_slice(rhs))
 }
 
 #[inline]
@@ -37,9 +51,9 @@ pub(super) fn add<T: Scalar>(lhs: &Array1<T>, rhs: &Array1<T>) -> Array1<T> {
     let n = vector_len(lhs);
     let mut out = Array1::from_elem([n], T::ZERO);
     T::add_slice(
-        lhs.as_slice().unwrap(),
-        rhs.as_slice().unwrap(),
-        out.as_slice_mut().unwrap(),
+        contiguous_slice(lhs),
+        contiguous_slice(rhs),
+        contiguous_slice_mut(&mut out),
     );
     out
 }
@@ -54,9 +68,9 @@ pub(super) fn sub<T: Scalar>(lhs: &Array1<T>, rhs: &Array1<T>) -> Array1<T> {
     let n = vector_len(lhs);
     let mut out = Array1::from_elem([n], T::ZERO);
     T::sub_slice(
-        lhs.as_slice().unwrap(),
-        rhs.as_slice().unwrap(),
-        out.as_slice_mut().unwrap(),
+        contiguous_slice(lhs),
+        contiguous_slice(rhs),
+        contiguous_slice_mut(&mut out),
     );
     out
 }
@@ -69,7 +83,7 @@ pub(super) fn add_scaled<T: Scalar>(lhs: &Array1<T>, rhs: &Array1<T>, scale: T) 
         "invariant: scaled vector addition requires equal lengths"
     );
     let mut out = lhs.clone();
-    T::axpy_slice(scale, rhs.as_slice().unwrap(), out.as_slice_mut().unwrap());
+    T::axpy_slice(scale, contiguous_slice(rhs), contiguous_slice_mut(&mut out));
     out
 }
 
@@ -80,7 +94,7 @@ pub(super) fn add_scaled_in_place<T: Scalar>(lhs: &mut Array1<T>, rhs: &Array1<T
         vector_len(rhs),
         "invariant: scaled vector update requires equal lengths"
     );
-    T::axpy_slice(scale, rhs.as_slice().unwrap(), lhs.as_slice_mut().unwrap());
+    T::axpy_slice(scale, contiguous_slice(rhs), contiguous_slice_mut(lhs));
 }
 
 #[inline]
@@ -94,8 +108,8 @@ pub(super) fn scale<T: Scalar>(vector: &Array1<T>, factor: T) -> Array1<T> {
     let mut out = Array1::from_elem([n], T::ZERO);
     T::axpy_slice(
         factor,
-        vector.as_slice().unwrap(),
-        out.as_slice_mut().unwrap(),
+        contiguous_slice(vector),
+        contiguous_slice_mut(&mut out),
     );
     out
 }

--- a/crates/cfd-optim/Cargo.toml
+++ b/crates/cfd-optim/Cargo.toml
@@ -60,3 +60,6 @@ path = "examples/milestone12_option2.rs"
 [[example]]
 name = "milestone12_ga"
 path = "examples/milestone12_ga.rs"
+
+[lints]
+workspace = true

--- a/crates/cfd-python/Cargo.toml
+++ b/crates/cfd-python/Cargo.toml
@@ -28,3 +28,6 @@ cfd-validation = { path = "../cfd-validation" }
 # Common dependencies
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/crates/cfd-schematic-mesh/Cargo.toml
+++ b/crates/cfd-schematic-mesh/Cargo.toml
@@ -43,3 +43,6 @@ path = "examples/schematic_to_openfoam.rs"
 [[example]]
 name = "millifluidic_shell_tpms"
 path = "examples/millifluidic_shell_tpms.rs"
+
+[lints]
+workspace = true

--- a/crates/cfd-schematics/Cargo.toml
+++ b/crates/cfd-schematics/Cargo.toml
@@ -69,3 +69,6 @@ path = "examples/topology/unified_generator_demo.rs"
 [[example]]
 name = "shell_cuboid_demo"
 path = "examples/advanced/shell_cuboid_demo.rs"
+
+[lints]
+workspace = true

--- a/crates/cfd-schematics/examples/split_tree/asymmetric_demo.rs
+++ b/crates/cfd-schematics/examples/split_tree/asymmetric_demo.rs
@@ -43,8 +43,7 @@ fn main() {
         min_width = min_width.min(ch.effective_width_m().into_base() * 1000.0);
         max_width = max_width.max(ch.effective_width_m().into_base() * 1000.0);
 
-        if ((ch.effective_width_m().into_base() * 1000.0) - config.channel_width_mm()).abs()
-            < 0.05
+        if ((ch.effective_width_m().into_base() * 1000.0) - config.channel_width_mm()).abs() < 0.05
         {
             base_width_found = true;
             println!("  -> Found base-width trunk or merge channel");

--- a/crates/cfd-schematics/src/application/mod.rs
+++ b/crates/cfd-schematics/src/application/mod.rs
@@ -1,2 +1,6 @@
+//! Application ports and use cases for blueprint graph materialization.
+
+/// Port trait definitions for external infrastructure adapters.
 pub mod ports;
+/// Application services orchestrating validation and graph generation.
 pub mod use_cases;

--- a/crates/cfd-schematics/src/application/ports/graph_sink.rs
+++ b/crates/cfd-schematics/src/application/ports/graph_sink.rs
@@ -1,8 +1,11 @@
 use crate::domain::model::NetworkBlueprint;
 use cfd_core::error::Result;
 
+/// Port for materializing a network blueprint into an output graph form.
 pub trait GraphSink {
+    /// Output graph representation.
     type Output;
 
+    /// Build the output graph from a validated blueprint.
     fn build(&self, blueprint: &NetworkBlueprint) -> Result<Self::Output>;
 }

--- a/crates/cfd-schematics/src/application/use_cases/generate_network.rs
+++ b/crates/cfd-schematics/src/application/use_cases/generate_network.rs
@@ -3,16 +3,19 @@ use crate::domain::model::NetworkBlueprint;
 use crate::domain::rules::BlueprintValidator;
 use cfd_core::error::Result;
 
+/// Use case that validates a blueprint and materializes it through a sink.
 pub struct NetworkGenerationService<S: GraphSink> {
     sink: S,
 }
 
 impl<S: GraphSink> NetworkGenerationService<S> {
+    /// Create a service bound to the given graph sink.
     #[must_use]
     pub fn new(sink: S) -> Self {
         Self { sink }
     }
 
+    /// Validate the blueprint, then build its output graph.
     pub fn generate(&self, blueprint: &NetworkBlueprint) -> Result<S::Output> {
         BlueprintValidator::validate(blueprint)?;
         self.sink.build(blueprint)

--- a/crates/cfd-schematics/src/config/channel/mod.rs
+++ b/crates/cfd-schematics/src/config/channel/mod.rs
@@ -1,6 +1,10 @@
+/// Circular-arc channel configuration.
 pub mod arc;
+/// Frustum channel configuration.
 pub mod frustum;
+/// Serpentine channel configuration.
 pub mod serpentine;
+/// Shared channel configuration types.
 pub mod types;
 
 pub use arc::*;

--- a/crates/cfd-schematics/src/config/constants/mod.rs
+++ b/crates/cfd-schematics/src/config/constants/mod.rs
@@ -185,31 +185,49 @@ pub mod primitives {
         pub const DEFAULT_MIDDLE_ZONE_FRACTION: f64 = 0.4;
     }
 
-    // Adaptive collision constants (Added during refactor recovery)
+    // Adaptive collision constants.
+    /// Default maximum collision adjustment factor.
     pub const DEFAULT_MAX_ADJUSTMENT_FACTOR: f64 = 0.5;
+    /// Default minimum distance between channels.
     pub const DEFAULT_MIN_CHANNEL_DISTANCE: f64 = 0.5;
+    /// Default safety margin applied to collision checks.
     pub const DEFAULT_SAFETY_MARGIN_FACTOR: f64 = 1.1;
+    /// Default maximum reduction factor for collision recovery.
     pub const DEFAULT_MAX_REDUCTION_FACTOR: f64 = 0.8;
+    /// Default sensitivity used by collision detection.
     pub const DEFAULT_DETECTION_SENSITIVITY: f64 = 0.1;
+    /// Default divisor for proximity normalization.
     pub const DEFAULT_PROXIMITY_DIVISOR: f64 = 10.0;
+    /// Default minimum proximity factor.
     pub const DEFAULT_MIN_PROXIMITY_FACTOR: f64 = 0.2;
+    /// Default maximum proximity factor.
     pub const DEFAULT_MAX_PROXIMITY_FACTOR: f64 = 2.0;
+    /// Default divisor for branch adjustment scaling.
     pub const DEFAULT_BRANCH_ADJUSTMENT_DIVISOR: f64 = 5.0;
+    /// Default maximum sensitivity multiplier.
     pub const DEFAULT_MAX_SENSITIVITY_MULTIPLIER: f64 = 3.0;
+    /// Default multiplier for long-channel reduction.
     pub const DEFAULT_LONG_CHANNEL_REDUCTION_MULTIPLIER: f64 = 0.9;
+    /// Default upper bound for collision reduction.
     pub const DEFAULT_MAX_REDUCTION_LIMIT: f64 = 0.5;
 }
 
-/// Registry for all configuration constants
+/// Registry for all validated configuration constant groups.
 pub struct ConstantsRegistry {
+    /// Thresholds used to select channel strategies.
     pub strategies: StrategyThresholds,
+    /// Constants used by serpentine wave generation.
     pub waves: WaveGenerationConstants,
+    /// Constants used by geometry generation.
     pub geometry: GeometryGenerationConstants,
+    /// Constants used by geometry optimization.
     pub optimization: OptimizationConstants,
+    /// Constants used by visualization rendering.
     pub visualization: VisualizationConstants,
 }
 
 impl ConstantsRegistry {
+    /// Constructs a registry populated with the canonical defaults.
     pub fn new() -> Self {
         Self {
             strategies: StrategyThresholds::default(),
@@ -221,160 +239,204 @@ impl ConstantsRegistry {
     }
 
     // --- Adaptive Collision ---
+    /// Returns the default maximum collision-adjustment factor.
     pub fn get_max_adjustment_factor(&self) -> f64 {
         primitives::DEFAULT_MAX_ADJUSTMENT_FACTOR
     }
+    /// Returns the default minimum channel separation distance.
     pub fn get_min_channel_distance(&self) -> f64 {
         primitives::DEFAULT_MIN_CHANNEL_DISTANCE
     }
+    /// Returns the configured minimum wall clearance.
     pub fn get_min_wall_distance(&self) -> f64 {
         *self.geometry.default_wall_clearance.get_raw_value()
     }
+    /// Returns the default collision safety-margin factor.
     pub fn get_safety_margin_factor(&self) -> f64 {
         primitives::DEFAULT_SAFETY_MARGIN_FACTOR
     }
+    /// Returns the default maximum curvature-reduction factor.
     pub fn get_max_reduction_factor(&self) -> f64 {
         primitives::DEFAULT_MAX_REDUCTION_FACTOR
     }
+    /// Returns the default collision-detection sensitivity.
     pub fn get_detection_sensitivity(&self) -> f64 {
         primitives::DEFAULT_DETECTION_SENSITIVITY
     }
+    /// Returns the distance normalization divisor used by proximity checks.
     pub fn get_proximity_divisor(&self) -> f64 {
         primitives::DEFAULT_PROXIMITY_DIVISOR
     }
+    /// Returns the minimum proximity adjustment factor.
     pub fn get_min_proximity_factor(&self) -> f64 {
         primitives::DEFAULT_MIN_PROXIMITY_FACTOR
     }
+    /// Returns the maximum proximity adjustment factor.
     pub fn get_max_proximity_factor(&self) -> f64 {
         primitives::DEFAULT_MAX_PROXIMITY_FACTOR
     }
+    /// Returns the configured branch-factor exponent.
     pub fn get_branch_factor_exponent(&self) -> f64 {
         *self.optimization.branch_factor_exponent.get_raw_value()
     }
+    /// Returns the divisor used to scale branch adjustments.
     pub fn get_branch_adjustment_divisor(&self) -> f64 {
         primitives::DEFAULT_BRANCH_ADJUSTMENT_DIVISOR
     }
+    /// Returns the maximum sensitivity multiplier.
     pub fn get_max_sensitivity_multiplier(&self) -> f64 {
         primitives::DEFAULT_MAX_SENSITIVITY_MULTIPLIER
     }
+    /// Returns the threshold for classifying a route as long.
     pub fn get_long_channel_threshold(&self) -> f64 {
         *self.geometry.long_horizontal_threshold.get_raw_value()
     }
+    /// Returns the default multiplier for long-channel reduction.
     pub fn get_long_channel_reduction_multiplier(&self) -> f64 {
         primitives::DEFAULT_LONG_CHANNEL_REDUCTION_MULTIPLIER
     }
+    /// Returns the configured maximum reduction limit.
     pub fn get_max_reduction_limit(&self) -> f64 {
         primitives::DEFAULT_MAX_REDUCTION_LIMIT
     }
 
     // --- Optimization ---
+    /// Returns the maximum number of optimization iterations.
     pub fn get_max_optimization_iterations(&self) -> usize {
         *self
             .optimization
             .max_optimization_iterations
             .get_raw_value()
     }
+    /// Returns the convergence tolerance used by optimization.
     pub fn get_optimization_tolerance(&self) -> f64 {
         *self.optimization.convergence_tolerance.get_raw_value()
     }
+    /// Returns the configured fast-path wavelength factors.
     pub fn get_fast_wavelength_factors(&self) -> Vec<f64> {
         self.optimization
             .fast_wavelength_factors
             .get_raw_value()
             .clone()
     }
+    /// Returns the configured fast-path wave-density factors.
     pub fn get_fast_wave_density_factors(&self) -> Vec<f64> {
         self.optimization
             .fast_wave_density_factors
             .get_raw_value()
             .clone()
     }
+    /// Returns the configured fast-path fill factors.
     pub fn get_fast_fill_factors(&self) -> Vec<f64> {
         self.optimization.fast_fill_factors.get_raw_value().clone()
     }
 
     // --- Wave Generation ---
+    /// Returns the lower threshold for smoothing a wave endpoint.
     pub fn get_smooth_endpoint_start_threshold(&self) -> f64 {
         *self.waves.smooth_endpoint_start_threshold.get_raw_value()
     }
+    /// Returns the upper threshold for smoothing a wave endpoint.
     pub fn get_smooth_endpoint_end_threshold(&self) -> f64 {
         *self.waves.smooth_endpoint_end_threshold.get_raw_value()
     }
+    /// Returns the default transition-length factor.
     pub fn get_default_transition_length_factor(&self) -> f64 {
         *self.waves.default_transition_length_factor.get_raw_value()
     }
+    /// Returns the default transition-amplitude factor.
     pub fn get_default_transition_amplitude_factor(&self) -> f64 {
         *self
             .waves
             .default_transition_amplitude_factor
             .get_raw_value()
     }
+    /// Returns the default transition smoothness.
     pub fn get_default_transition_smoothness(&self) -> usize {
         *self.waves.default_transition_smoothness.get_raw_value()
     }
+    /// Returns the default wave multiplier.
     pub fn get_default_wave_multiplier(&self) -> f64 {
         *self.waves.default_wave_multiplier.get_raw_value()
     }
+    /// Returns the sharpness used for square-wave generation.
     pub fn get_square_wave_sharpness(&self) -> f64 {
         *self.waves.square_wave_sharpness.get_raw_value()
     }
+    /// Returns the neighboring-channel avoidance scale factor.
     pub fn get_neighbor_scale_factor(&self) -> f64 {
         *self.waves.neighbor_avoidance_scaling_factor.get_raw_value()
     }
+    /// Returns the transition-zone scale factor.
     pub fn get_transition_zone_factor(&self) -> f64 {
         *self.waves.transition_zone_factor.get_raw_value()
     }
 
     // --- Geometry ---
+    /// Returns the multiplier for short-channel widths.
     pub fn get_short_channel_width_multiplier(&self) -> f64 {
         *self.geometry.short_channel_width_multiplier.get_raw_value()
     }
+    /// Returns the configured geometric tolerance.
     pub fn get_geometric_tolerance(&self) -> f64 {
         *self.waves.geometric_tolerance.get_raw_value()
     }
+    /// Returns the maximum curvature-reduction factor.
     pub fn get_max_curvature_reduction_factor(&self) -> f64 {
         *self.geometry.max_curvature_reduction_factor.get_raw_value()
     }
+    /// Returns the minimum curvature factor.
     pub fn get_min_curvature_factor(&self) -> f64 {
         *self.geometry.min_curvature_factor.get_raw_value()
     }
+    /// Returns the minimum-distance threshold used by geometry checks.
     pub fn get_min_distance_threshold(&self) -> f64 {
         *self.waves.geometric_tolerance.get_raw_value()
     }
 
     // --- Strategies ---
+    /// Returns the horizontal-route length threshold.
     pub fn get_long_horizontal_threshold(&self) -> f64 {
         *self.geometry.long_horizontal_threshold.get_raw_value()
     }
+    /// Returns the horizontal-angle threshold.
     pub fn get_horizontal_angle_threshold(&self) -> f64 {
         *self.geometry.horizontal_angle_threshold.get_raw_value()
     }
+    /// Returns the minimum frustum length threshold.
     pub fn get_frustum_min_length_threshold(&self) -> f64 {
         *self.strategies.frustum_min_length_threshold.get_raw_value()
     }
+    /// Returns the maximum frustum length threshold.
     pub fn get_frustum_max_length_threshold(&self) -> f64 {
         *self.strategies.frustum_max_length_threshold.get_raw_value()
     }
+    /// Returns the frustum angle threshold.
     pub fn get_frustum_angle_threshold(&self) -> f64 {
         *self.strategies.frustum_angle_threshold.get_raw_value()
     }
+    /// Returns the minimum arc-length threshold.
     pub fn get_min_arc_length_threshold(&self) -> f64 {
         *self.geometry.min_arc_length_threshold.get_raw_value()
     }
 
     // --- Visualization ---
+    /// Returns the default chart margin.
     pub fn get_default_chart_margin(&self) -> u32 {
         *self.visualization.default_chart_margin.get_raw_value()
     }
+    /// Returns the default chart right margin.
     pub fn get_default_chart_right_margin(&self) -> u32 {
         *self
             .visualization
             .default_chart_right_margin
             .get_raw_value()
     }
+    /// Returns the default x-axis label area size.
     pub fn get_default_x_label_area_size(&self) -> u32 {
         *self.visualization.default_x_label_area_size.get_raw_value()
     }
+    /// Returns the default y-axis label area size.
     pub fn get_default_y_label_area_size(&self) -> u32 {
         *self.visualization.default_y_label_area_size.get_raw_value()
     }

--- a/crates/cfd-schematics/src/config/geometry/mod.rs
+++ b/crates/cfd-schematics/src/config/geometry/mod.rs
@@ -1,4 +1,6 @@
+/// Core geometry configuration and validation.
 pub mod core;
+/// Geometry generation parameters.
 pub mod generation;
 
 pub use core::*;

--- a/crates/cfd-schematics/src/config/mod.rs
+++ b/crates/cfd-schematics/src/config/mod.rs
@@ -13,10 +13,14 @@
 //! - **Composability**: Complex configurations are built from simpler ones
 //! - **Discoverability**: Presets and builders make common configurations easy
 
+/// Adaptive geometry configuration.
 pub mod adaptive;
+/// Channel geometry configuration and strategies.
 pub mod channel;
 pub mod constants;
+/// Geometry generation configuration.
 pub mod geometry;
+/// Reusable configuration presets.
 pub mod presets;
 
 // Re-export constants module content

--- a/crates/cfd-schematics/src/domain/mod.rs
+++ b/crates/cfd-schematics/src/domain/mod.rs
@@ -1,3 +1,8 @@
+//! Domain model, rules, and therapy metadata for network blueprints.
+
+/// Core blueprint domain model (nodes, channels, blueprint).
 pub mod model;
+/// Structural validation rules over the domain model.
 pub mod rules;
+/// Therapy routing zone metadata.
 pub mod therapy_metadata;

--- a/crates/cfd-schematics/src/domain/model/blueprint/analysis_impl.rs
+++ b/crates/cfd-schematics/src/domain/model/blueprint/analysis_impl.rs
@@ -4,6 +4,7 @@ use super::{ChannelOverlapAnalysis, NetworkBlueprint};
 use crate::topology::BlueprintTopologyFactory;
 
 impl NetworkBlueprint {
+    /// Number of nodes marked `NodeKind::Inlet` in the network.
     #[must_use]
     pub fn inlet_count(&self) -> usize {
         self.nodes
@@ -12,6 +13,7 @@ impl NetworkBlueprint {
             .count()
     }
 
+    /// Number of nodes marked `NodeKind::Outlet` in the network.
     #[must_use]
     pub fn outlet_count(&self) -> usize {
         self.nodes
@@ -20,6 +22,7 @@ impl NetworkBlueprint {
             .count()
     }
 
+    /// Number of nodes marked `NodeKind::Junction` between connected channels.
     #[must_use]
     pub fn junction_count(&self) -> usize {
         self.nodes
@@ -28,6 +31,7 @@ impl NetworkBlueprint {
             .count()
     }
 
+    /// Number of channels carrying the `EdgeKind::Pipe` flow segment.
     #[must_use]
     pub fn pipe_count(&self) -> usize {
         self.channels
@@ -36,6 +40,7 @@ impl NetworkBlueprint {
             .count()
     }
 
+    /// Aggregate length of every channel in the network.
     #[must_use]
     pub fn total_length_m(&self) -> Length<f64> {
         self.channels
@@ -44,6 +49,9 @@ impl NetworkBlueprint {
             .fold(Length::default(), |total, length| total + length)
     }
 
+    /// Aggregate length of channels that carry the requested therapy-zone
+    /// metadata, summed over channels whose `MetadataContainer` exposes a
+    /// matching `TherapyZoneMetadata`.
     #[must_use]
     pub fn length_in_zone(
         &self,
@@ -63,6 +71,8 @@ impl NetworkBlueprint {
             .fold(Length::default(), |total, length| total + length)
     }
 
+    /// Channels that carry an authored Venturi geometry or its derived
+    /// `VenturiGeometryMetadata`.
     #[must_use]
     pub fn venturi_channels(&self) -> Vec<&super::super::ChannelSpec> {
         self.channels
@@ -78,20 +88,28 @@ impl NetworkBlueprint {
             .collect()
     }
 
+    /// Insert intersection nodes for any channel crossings in place and report
+    /// the resulting geometry intersection outcome.
     pub fn resolve_channel_overlaps(&mut self) -> crate::geometry::IntersectionResult {
         crate::geometry::insert_intersection_nodes(self)
     }
 
+    /// Number of channel crossings not yet represented by an intersection node.
     #[must_use]
     pub fn unresolved_channel_overlap_count(&self) -> usize {
         crate::geometry::unresolved_intersection_count(self)
     }
 
+    /// Whether any channel crossing remains unrepresented by an intersection
+    /// node.
     #[must_use]
     pub fn has_unresolved_channel_overlaps(&self) -> bool {
         self.unresolved_channel_overlap_count() > 0
     }
 
+    /// Worst-case channel-pair crossing analysis across the authored paths,
+    /// reporting the maximum overlap fraction, width ratio at that worst pair,
+    /// and the count of overlapping pairs found.
     #[must_use]
     pub fn channel_overlap_analysis(&self) -> ChannelOverlapAnalysis {
         let channels_with_paths: Vec<(usize, f64)> = self
@@ -134,11 +152,21 @@ impl NetworkBlueprint {
         worst
     }
 
+    /// Maximum overlap fraction reported between any channel pair,
+    /// normalized by the narrower channel width.
     #[must_use]
     pub fn max_channel_overlap_fraction(&self) -> f64 {
         self.channel_overlap_analysis().max_overlap_fraction
     }
 
+    /// Fail when the network is empty, references dangling endpoint nodes,
+    /// contains unresolved interior channel crossings, or carries a
+    /// selective-routing topology without authored geometry.  Returns a
+    /// human-readable description of the first failure encountered.
+    ///
+    /// # Errors
+    /// Returns a non-empty `String` describing the first structural defect
+    /// found, in the order above.
     pub fn validate(&self) -> Result<(), String> {
         if self.nodes.is_empty() {
             return Err("NetworkBlueprint has no nodes".to_string());
@@ -184,6 +212,8 @@ impl NetworkBlueprint {
         Ok(())
     }
 
+    /// Render a compact human-readable summary of node and channel counts
+    /// and the total channel length, suitable for diagnostic CLI output.
     #[must_use]
     pub fn describe(&self) -> String {
         let mut inlets = 0usize;

--- a/crates/cfd-schematics/src/domain/model/blueprint/metadata_impl.rs
+++ b/crates/cfd-schematics/src/domain/model/blueprint/metadata_impl.rs
@@ -12,6 +12,14 @@ impl NetworkBlueprint {
                 trees. Use `create_geometry()` (cfd_schematics::geometry::generator) for \
                 split-tree layouts, or ensure every NodeSpec is created with NodeSpec::new_at()."
     )]
+    /// Construct an empty `NetworkBlueprint` with auto-laid-out nodes.
+    ///
+    /// # Deprecated
+    /// Nodes created via this constructor have no layout positions
+    /// and fall back to the generic auto-layout, producing incorrect
+    /// geometry for bifurcation trees. Use `create_geometry()` from
+    /// `cfd_schematics::geometry::generator` for split-tree layouts,
+    /// or ensure every `NodeSpec` is built with `NodeSpec::new_at()`.
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self {
@@ -28,6 +36,9 @@ impl NetworkBlueprint {
         }
     }
 
+    /// Construct an empty `NetworkBlueprint` that will not run
+    /// auto-layout, leaving it the caller's responsibility to position
+    /// every node explicitly through `NodeSpec::new_at()`.
     #[must_use]
     pub fn new_with_explicit_positions(name: impl Into<String>) -> Self {
         Self {
@@ -44,12 +55,17 @@ impl NetworkBlueprint {
         }
     }
 
+    /// Attach render hints that visualization passes use to control
+    /// annotation density, line styling, and schematic polish.
+    /// Returns `self` for chaining.
     #[must_use]
     pub fn with_render_hints(mut self, hints: BlueprintRenderHints) -> Self {
         self.render_hints = Some(hints);
         self
     }
 
+    /// Resolve the blueprint's render hints, preferring the inline
+    /// field and falling back to the metadata container when absent.
     #[must_use]
     pub fn render_hints(&self) -> Option<&BlueprintRenderHints> {
         self.render_hints
@@ -57,6 +73,7 @@ impl NetworkBlueprint {
             .or_else(|| self.metadata.as_ref()?.get::<BlueprintRenderHints>())
     }
 
+    /// Attach a metadata entry of type `T` and return `self` for chaining.
     #[must_use]
     pub fn with_metadata<T: crate::geometry::metadata::Metadata + Clone + 'static>(
         mut self,
@@ -66,6 +83,8 @@ impl NetworkBlueprint {
         self
     }
 
+    /// Insert a metadata entry of type `T` into the blueprint's metadata
+    /// container, lazy-creating the container on first use.
     pub fn insert_metadata<T: crate::geometry::metadata::Metadata + Clone + 'static>(
         &mut self,
         metadata: T,
@@ -79,43 +98,58 @@ impl NetworkBlueprint {
             .insert(metadata);
     }
 
+    /// Borrow a metadata entry of type `T` previously inserted into the
+    /// blueprint, if present.
     #[must_use]
     pub fn metadata<T: crate::geometry::metadata::Metadata + 'static>(&self) -> Option<&T> {
         self.metadata.as_ref()?.get::<T>()
     }
 
+    /// Borrow the geometry-authoring provenance metadata, if present.
     #[must_use]
     pub fn geometry_authoring_provenance(&self) -> Option<&GeometryAuthoringProvenance> {
         self.metadata::<GeometryAuthoringProvenance>()
     }
 
+    /// Whether geometry has been authored for this blueprint, either by
+    /// setting the explicit flag or by carrying an authoring-provenance
+    /// record in the metadata.
     #[must_use]
     pub fn is_geometry_authored(&self) -> bool {
         self.geometry_authored || self.geometry_authoring_provenance().is_some()
     }
 
+    /// Attach an authored topology specification and return `self` for
+    /// chaining.
     #[must_use]
     pub fn with_topology_spec(mut self, topology: BlueprintTopologySpec) -> Self {
         self.topology = Some(topology);
         self
     }
 
+    /// Attach a topology-lineage metadata block and return `self` for
+    /// chaining.
     #[must_use]
     pub fn with_lineage(mut self, lineage: TopologyLineageMetadata) -> Self {
         self.lineage = Some(lineage);
         self
     }
 
+    /// Borrow the topology specification, if one is attached.
     #[must_use]
     pub fn topology_spec(&self) -> Option<&BlueprintTopologySpec> {
         self.topology.as_ref()
     }
 
+    /// Borrow the topology-lineage metadata, if one is attached.
     #[must_use]
     pub fn lineage(&self) -> Option<&TopologyLineageMetadata> {
         self.lineage.as_ref()
     }
 
+    /// Resolve the channel identifiers that lie on the treatment path,
+    /// delegating to the attached `BlueprintTopologySpec` when present
+    /// and returning an empty vector otherwise.
     #[must_use]
     pub fn treatment_channel_ids(&self) -> Vec<String> {
         self.topology
@@ -123,22 +157,27 @@ impl NetworkBlueprint {
             .map_or_else(Vec::new, BlueprintTopologySpec::treatment_channel_ids)
     }
 
+    /// Serialize the blueprint to a pretty-printed JSON string.
     pub fn to_json_pretty(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string_pretty(self)
     }
 
+    /// Serialize the blueprint to a JSON string, equivalent to `to_json_pretty`.
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         self.to_json_pretty()
     }
 
+    /// Parse a `NetworkBlueprint` from a JSON string.
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
 
+    /// Append a node to the blueprint's node list.
     pub fn add_node(&mut self, node: NodeSpec) {
         self.nodes.push(node);
     }
 
+    /// Append a channel to the blueprint's channel list.
     pub fn add_channel(&mut self, channel: ChannelSpec) {
         self.channels.push(channel);
     }

--- a/crates/cfd-schematics/src/domain/model/blueprint/mod.rs
+++ b/crates/cfd-schematics/src/domain/model/blueprint/mod.rs
@@ -8,21 +8,32 @@ mod analysis_impl;
 mod metadata_impl;
 mod venturi_impl;
 
+/// A network blueprint graph of nodes and channels.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkBlueprint {
+    /// Blueprint name.
     pub name: String,
+    /// Authored plate envelope in millimeters.
     pub box_dims: (f64, f64),
+    /// Plate outline segments in schematic coordinates.
     pub box_outline: Vec<((f64, f64), (f64, f64))>,
+    /// Graph nodes.
     pub nodes: Vec<NodeSpec>,
+    /// Graph channels.
     pub channels: Vec<ChannelSpec>,
+    /// Render hints for visualizers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub render_hints: Option<BlueprintRenderHints>,
+    /// Materialized topology specification, when geometry was authored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub topology: Option<BlueprintTopologySpec>,
+    /// Lineage metadata tracking the blueprint source.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lineage: Option<TopologyLineageMetadata>,
+    /// Extension metadata container.
     #[serde(skip)]
     pub metadata: Option<MetadataContainer>,
+    /// Whether the geometry was produced by the canonical authoring pipeline.
     #[serde(default)]
     pub geometry_authored: bool,
 }

--- a/crates/cfd-schematics/src/domain/model/blueprint/venturi_impl.rs
+++ b/crates/cfd-schematics/src/domain/model/blueprint/venturi_impl.rs
@@ -7,6 +7,12 @@ use crate::topology::{
 use aequitas::systems::si::quantities::Dimensionless;
 
 impl NetworkBlueprint {
+    /// Augment the blueprint with venturi placements on the target channels.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no target channel is given, a target channel does
+    /// not exist, or a throat geometry cannot be resolved.
     pub fn add_venturi(&mut self, config: &VenturiConfig) -> Result<(), String> {
         let target_channel_ids = if config.target_channel_ids.is_empty() {
             self.treatment_channel_ids()

--- a/crates/cfd-schematics/src/domain/model/ids.rs
+++ b/crates/cfd-schematics/src/domain/model/ids.rs
@@ -1,13 +1,17 @@
 use serde::{Deserialize, Serialize};
 
+/// Stable identifier of a node.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub String);
 
 impl NodeId {
+    /// Create a node identifier from its string form.
+    #[must_use]
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
+    /// Borrow the string form of this identifier.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -20,14 +24,18 @@ impl std::fmt::Display for NodeId {
     }
 }
 
+/// Stable identifier of an edge.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EdgeId(pub String);
 
 impl EdgeId {
+    /// Create an edge identifier from its string form.
+    #[must_use]
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
+    /// Borrow the string form of this identifier.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/crates/cfd-schematics/src/domain/model/specs.rs
+++ b/crates/cfd-schematics/src/domain/model/specs.rs
@@ -93,33 +93,47 @@ impl CrossSectionSpec {
     }
 }
 
+/// Role of a node in the network topology.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeKind {
+    /// Fluid entry point into the network.
     Inlet,
+    /// Fluid exit point from the network.
     Outlet,
+    /// Pressure reservoir boundary.
     Reservoir,
+    /// Internal branch point connecting multiple edges.
     Junction,
 }
 
+/// Node placement and role specification for a network blueprint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeSpec {
+    /// Stable identifier of the node.
     pub id: NodeId,
+    /// Role of the node in the topology.
     pub kind: NodeKind,
+    /// Placement `(x, y)` in schematic coordinates.
     pub point: (f64, f64),
+    /// Optional layout metadata for the node.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub layout: Option<NodeLayoutMetadata>,
+    /// Optional junction geometry metadata for the node.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub junction_geometry: Option<JunctionGeometryMetadata>,
+    /// Extension metadata attached to the node.
     #[serde(skip)]
     pub metadata: Option<crate::geometry::metadata::MetadataContainer>,
 }
 
 impl NodeSpec {
+    /// Construct a node at the origin with the given id and kind.
     #[must_use]
     pub fn new(id: impl Into<String>, kind: NodeKind) -> Self {
         Self::new_at(id, kind, (0.0, 0.0))
     }
 
+    /// Construct a node at the given point with the given id and kind.
     #[must_use]
     pub fn new_at(id: impl Into<String>, kind: NodeKind, point: (f64, f64)) -> Self {
         Self {
@@ -132,12 +146,14 @@ impl NodeSpec {
         }
     }
 
+    /// Set the placement point.
     #[must_use]
     pub fn with_point(mut self, point: (f64, f64)) -> Self {
         self.point = point;
         self
     }
 
+    /// Set the layout metadata and align the placement point to it.
     #[must_use]
     pub fn with_layout(mut self, layout: NodeLayoutMetadata) -> Self {
         self.point = (layout.x_mm, layout.y_mm);
@@ -145,12 +161,14 @@ impl NodeSpec {
         self
     }
 
+    /// Attach junction geometry metadata.
     #[must_use]
     pub fn with_junction_geometry(mut self, geometry: JunctionGeometryMetadata) -> Self {
         self.junction_geometry = Some(geometry);
         self
     }
 
+    /// Attach a typed metadata entry to the node.
     #[must_use]
     pub fn with_metadata<T: crate::geometry::metadata::Metadata + Clone + 'static>(
         mut self,
@@ -167,10 +185,14 @@ impl NodeSpec {
     }
 }
 
+/// Role of an edge in the network topology.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EdgeKind {
+    /// Passive channel with hydraulic resistance.
     Pipe,
+    /// Flow-control valve.
     Valve,
+    /// Active pump with flow and pressure limits.
     Pump,
 }
 
@@ -208,11 +230,16 @@ pub enum ChannelShape {
     },
 }
 
+/// Edge specification connecting two nodes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelSpec {
+    /// Stable identifier of the edge.
     pub id: EdgeId,
+    /// Role of the edge.
     pub kind: EdgeKind,
+    /// Origin node identifier.
     pub from: NodeId,
+    /// Destination node identifier.
     pub to: NodeId,
     /// Authored centerline length as an Eunomia-backed SI length.
     pub length_m: Length<f64>,
@@ -238,18 +265,24 @@ pub struct ChannelSpec {
     pub pump_max_flow: Option<VolumetricFlowRate<f64>>,
     /// Stall-point pump pressure limit.
     pub pump_max_pressure: Option<Pressure<f64>>,
+    /// Visual role used when rendering the edge.
     pub visual_role: Option<crate::geometry::metadata::ChannelVisualRole>,
+    /// Authored centerline waypoints in schematic coordinates.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub path: Vec<(f64, f64)>,
+    /// Therapy zone the edge belongs to, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub therapy_zone: Option<TherapyZone>,
+    /// Venturi geometry metadata for therapy channels.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub venturi_geometry: Option<VenturiGeometryMetadata>,
+    /// Extension metadata attached to the edge.
     #[serde(skip)]
     pub metadata: Option<crate::geometry::metadata::MetadataContainer>,
 }
 
 impl ChannelSpec {
+    /// Attach a typed metadata entry to the channel.
     pub fn with_metadata<T: crate::geometry::metadata::Metadata + Clone + 'static>(
         mut self,
         meta: T,
@@ -334,6 +367,7 @@ impl ChannelSpec {
         }
     }
 
+    /// Create a valve channel spec from a conventional `Cv` loss coefficient.
     #[must_use]
     pub fn new_valve(
         id: impl Into<String>,
@@ -365,6 +399,8 @@ impl ChannelSpec {
         }
     }
 
+    /// Create a pump channel spec with free-delivery flow and stall pressure
+    /// limits.
     #[must_use]
     pub fn new_pump(
         id: impl Into<String>,
@@ -396,18 +432,21 @@ impl ChannelSpec {
         }
     }
 
+    /// Set the authored centerline waypoints.
     #[must_use]
     pub fn with_path(mut self, path: Vec<(f64, f64)>) -> Self {
         self.path = path;
         self
     }
 
+    /// Set the visual role used when rendering the edge.
     #[must_use]
     pub fn with_visual_role(mut self, role: crate::geometry::metadata::ChannelVisualRole) -> Self {
         self.visual_role = Some(role);
         self
     }
 
+    /// Attach venturi geometry metadata for therapy channels.
     #[must_use]
     pub fn with_venturi_geometry(mut self, geometry: VenturiGeometryMetadata) -> Self {
         self.venturi_geometry = Some(geometry);

--- a/crates/cfd-schematics/src/domain/rules/validator.rs
+++ b/crates/cfd-schematics/src/domain/rules/validator.rs
@@ -2,9 +2,17 @@ use crate::domain::model::{NetworkBlueprint, NodeKind};
 use cfd_core::error::{Error, Result};
 use std::collections::HashSet;
 
+/// Stateless validator enforcing structural integrity of a network blueprint.
 pub struct BlueprintValidator;
 
 impl BlueprintValidator {
+    /// Validate blueprint structure: non-empty node/channel sets, at least one
+    /// inlet and outlet, unique identifiers, and resolvable, physically
+    /// positive channel geometry.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidConfiguration` on the first violated rule.
     pub fn validate(blueprint: &NetworkBlueprint) -> Result<()> {
         if blueprint.nodes.is_empty() {
             return Err(Error::InvalidConfiguration(

--- a/crates/cfd-schematics/src/domain/therapy_metadata.rs
+++ b/crates/cfd-schematics/src/domain/therapy_metadata.rs
@@ -17,10 +17,13 @@ pub enum TherapyZone {
 /// Implements `cfd_schematics::geometry::metadata::Metadata`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TherapyZoneMetadata {
+    /// Therapy routing zone for the tagged channel or node.
     pub zone: TherapyZone,
 }
 
 impl TherapyZoneMetadata {
+    /// Create metadata tagging a zone.
+    #[must_use]
     pub fn new(zone: TherapyZone) -> Self {
         Self { zone }
     }

--- a/crates/cfd-schematics/src/geometry/builders.rs
+++ b/crates/cfd-schematics/src/geometry/builders.rs
@@ -37,18 +37,21 @@ impl NodeBuilder {
         }
     }
 
+    /// Sets the optional human-readable node name.
     #[must_use]
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
+    /// Sets the node's domain kind.
     #[must_use]
     pub const fn with_kind(mut self, kind: NodeKind) -> Self {
         self.kind = Some(kind);
         self
     }
 
+    /// Sets geometric metadata for a junction node.
     #[must_use]
     pub fn with_junction_geometry(mut self, geometry: JunctionGeometryMetadata) -> Self {
         self.junction_geometry = Some(geometry);
@@ -143,24 +146,28 @@ impl ChannelBuilder {
         }
     }
 
+    /// Sets the optional human-readable channel name.
     #[must_use]
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
+    /// Sets the visual role used when rendering the channel.
     #[must_use]
     pub const fn with_visual_role(mut self, role: ChannelVisualRole) -> Self {
         self.visual_role = Some(role);
         self
     }
 
+    /// Sets the physical channel length in metres.
     #[must_use]
     pub const fn with_physical_length_m(mut self, length_m: f64) -> Self {
         self.physical_length_m = Some(length_m);
         self
     }
 
+    /// Sets the physical channel width and height in metres.
     #[must_use]
     pub const fn with_physical_dims_m(mut self, width_m: f64, height_m: f64) -> Self {
         self.physical_width_m = Some(width_m);
@@ -168,18 +175,21 @@ impl ChannelBuilder {
         self
     }
 
+    /// Sets the physical cross-sectional shape.
     #[must_use]
     pub const fn with_physical_shape(mut self, shape: ChannelShape) -> Self {
         self.physical_shape = Some(shape);
         self
     }
 
+    /// Sets the therapy zone served by the channel.
     #[must_use]
     pub const fn with_therapy_zone(mut self, zone: TherapyZone) -> Self {
         self.therapy_zone = Some(zone);
         self
     }
 
+    /// Sets Venturi geometry metadata for the channel.
     #[must_use]
     pub fn with_venturi_geometry(mut self, geometry: VenturiGeometryMetadata) -> Self {
         self.venturi_geometry = Some(geometry);

--- a/crates/cfd-schematics/src/geometry/generator/entrypoints.rs
+++ b/crates/cfd-schematics/src/geometry/generator/entrypoints.rs
@@ -9,12 +9,16 @@ use aequitas::systems::si::quantities::Length;
 /// Configuration for metadata generation.
 #[derive(Debug, Clone, Default)]
 pub struct MetadataConfig {
+    /// Records per-stage performance measurements when metadata is generated.
     pub track_performance: bool,
+    /// Records optimization decisions when metadata is generated.
     pub track_optimization: bool,
+    /// Supplies an optional channel diameter for generated metadata.
     pub channel_diameter_m: Option<Length<f64>>,
 }
 
 impl MetadataConfig {
+    /// Sets the channel diameter used by generated metadata.
     #[must_use]
     pub const fn with_channel_diameter_m(mut self, channel_diameter_m: Length<f64>) -> Self {
         self.channel_diameter_m = Some(channel_diameter_m);
@@ -22,6 +26,7 @@ impl MetadataConfig {
     }
 }
 
+/// Generates a network blueprint from geometric dimensions and split stages.
 #[must_use]
 pub fn create_geometry(
     box_dims: (f64, f64),
@@ -37,6 +42,7 @@ pub fn create_geometry(
     GeometryGenerator::new(box_dims, *config, *channel_type_config, total_branches).generate(splits)
 }
 
+/// Generates a network blueprint through the blueprint-named entry point.
 #[must_use]
 pub fn create_blueprint_geometry(
     box_dims: (f64, f64),
@@ -47,6 +53,7 @@ pub fn create_blueprint_geometry(
     create_geometry(box_dims, splits, config, channel_type_config)
 }
 
+/// Generates a network blueprint and attaches configured generation metadata.
 #[must_use]
 pub fn create_geometry_with_metadata(
     box_dims: (f64, f64),
@@ -70,6 +77,7 @@ pub fn create_geometry_with_metadata(
     .generate(splits)
 }
 
+/// Generates a metadata-bearing network blueprint through the blueprint-named entry point.
 #[must_use]
 pub fn create_blueprint_geometry_with_metadata(
     box_dims: (f64, f64),
@@ -87,6 +95,7 @@ pub fn create_blueprint_geometry_with_metadata(
     )
 }
 
+/// Configures geometry generation and optional blueprint metadata before building.
 pub struct GeometryGeneratorBuilder<'s> {
     box_dims: (f64, f64),
     splits: &'s [SplitType],
@@ -100,6 +109,7 @@ pub struct GeometryGeneratorBuilder<'s> {
 }
 
 impl<'s> GeometryGeneratorBuilder<'s> {
+    /// Creates a builder borrowing the split sequence and copying generation configuration.
     #[must_use]
     pub fn new(
         box_dims: (f64, f64),
@@ -120,36 +130,42 @@ impl<'s> GeometryGeneratorBuilder<'s> {
         }
     }
 
+    /// Adds performance and optimization metadata configuration.
     #[must_use]
     pub fn with_metadata_config(mut self, cfg: MetadataConfig) -> Self {
         self.metadata_config = Some(cfg);
         self
     }
 
+    /// Adds rendering hints to the generated blueprint.
     #[must_use]
     pub fn with_render_hints(mut self, hints: BlueprintRenderHints) -> Self {
         self.render_hints = Some(hints);
         self
     }
 
+    /// Adds the topology specification used to describe the generated blueprint.
     #[must_use]
     pub fn with_topology_spec(mut self, spec: BlueprintTopologySpec) -> Self {
         self.topology = Some(spec);
         self
     }
 
+    /// Adds lineage metadata describing the source topology.
     #[must_use]
     pub fn with_lineage(mut self, lineage: TopologyLineageMetadata) -> Self {
         self.lineage = Some(lineage);
         self
     }
 
+    /// Adds the metadata container attached to the generated blueprint.
     #[must_use]
     pub fn with_blueprint_metadata(mut self, metadata: MetadataContainer) -> Self {
         self.blueprint_metadata = Some(metadata);
         self
     }
 
+    /// Builds the configured network blueprint.
     #[must_use]
     pub fn build(self) -> NetworkBlueprint {
         let total_branches = self

--- a/crates/cfd-schematics/src/geometry/generator/linear.rs
+++ b/crates/cfd-schematics/src/geometry/generator/linear.rs
@@ -125,6 +125,7 @@ fn build_series_channel(
     )
 }
 
+/// Builds a geometry-authored blueprint for the specification's series channels.
 pub fn create_series_geometry_from_spec(spec: &BlueprintTopologySpec) -> NetworkBlueprint {
     let channel_count = spec.series_channels.len();
     let box_dims_mm = spec.box_dims_mm();
@@ -230,6 +231,7 @@ fn build_parallel_channel(
     apply_series_channel_metadata(built, &channel.route, None)
 }
 
+/// Builds a geometry-authored blueprint for the specification's parallel channels.
 pub fn create_parallel_geometry_from_spec(spec: &BlueprintTopologySpec) -> NetworkBlueprint {
     let box_dims_mm = spec.box_dims_mm();
     let inlet = layout_node("inlet", NodeKind::Inlet, (0.0, box_dims_mm.1 * 0.5));

--- a/crates/cfd-schematics/src/geometry/generator/selective/mod.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/mod.rs
@@ -14,8 +14,11 @@ use crate::domain::model::NetworkBlueprint;
 use aequitas::systems::si::quantities::Length;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Describes the center serpentine overlay used by a selective tree.
 pub struct CenterSerpentinePathSpec {
+    /// Number of segments in the serpentine path.
     pub segments: usize,
+    /// Bend radius of the path in metres.
     pub bend_radius_m: Length<f64>,
     /// Waveform type for the serpentine path.  Defaults to Sine when
     /// constructed from legacy topology specs that omit this field.
@@ -32,46 +35,80 @@ struct PendingVenturiPath {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Selects the topology-specific construction parameters for a selective tree.
 pub enum SelectiveTreeTopology {
+    /// Builds a cascade of center trifurcations.
     CascadeCenterTrifurcation {
+        /// Number of trifurcation levels in the cascade.
         n_levels: usize,
+        /// Fraction of each split assigned to the center branch.
         center_frac: f64,
+        /// Enables Venturi treatment geometry on treatment branches.
         venturi_treatment_enabled: bool,
+        /// Optional center serpentine overlay.
         center_serpentine: Option<CenterSerpentinePathSpec>,
     },
+    /// Builds incremental filtration stages with terminal tri-bifurcation.
     IncrementalFiltrationTriBi {
+        /// Number of preliminary trifurcation stages.
         n_pretri: usize,
+        /// Center fraction used by preliminary trifurcations.
         pretri_center_frac: f64,
+        /// Center fraction used by the terminal trifurcation.
         terminal_tri_center_frac: f64,
+        /// Fraction assigned to the treatment branch at the bifurcation.
         bi_treat_frac: f64,
+        /// Enables Venturi treatment geometry on treatment branches.
         venturi_treatment_enabled: bool,
+        /// Optional center serpentine overlay.
         center_serpentine: Option<CenterSerpentinePathSpec>,
+        /// Length of the outlet tail in metres.
         outlet_tail_length_m: Length<f64>,
     },
+    /// Builds a tri-bifurcation-bifurcation-trifurcation selective topology.
     TriBiTriSelective {
+        /// Center fraction at the first trifurcation.
         first_center_frac: f64,
+        /// Fraction assigned to the treatment branch at the bifurcation.
         bi_treat_frac: f64,
+        /// Center fraction at the second trifurcation.
         second_center_frac: f64,
     },
+    /// Builds a double-trifurcation CIF topology with a center Venturi train.
     DoubleTrifurcationCif {
+        /// Center fraction at the first trifurcation.
         split1_center_frac: f64,
+        /// Center fraction at the second trifurcation.
         split2_center_frac: f64,
+        /// Number of serial center throats.
         center_throat_count: u8,
+        /// Spacing between center throats in metres.
         inter_throat_spacing_m: Length<f64>,
     },
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Defines the physical dimensions and topology of a selective-tree blueprint.
 pub struct SelectiveTreeRequest {
+    /// Human-readable name assigned to the generated blueprint.
     pub name: String,
+    /// Overall rectangular envelope dimensions in metres.
     pub box_dims_m: (Length<f64>, Length<f64>),
+    /// Length of the inlet trunk in metres.
     pub trunk_length_m: Length<f64>,
+    /// Length of ordinary branches in metres.
     pub branch_length_m: Length<f64>,
+    /// Length of hybrid branches in metres.
     pub hybrid_branch_length_m: Length<f64>,
+    /// Width of the main channels in metres.
     pub main_width_m: Length<f64>,
+    /// Width of Venturi throats in metres.
     pub throat_width_m: Length<f64>,
+    /// Length of Venturi throats in metres.
     pub throat_length_m: Length<f64>,
+    /// Channel height in metres.
     pub channel_height_m: Length<f64>,
+    /// Topology-specific construction parameters.
     pub topology: SelectiveTreeTopology,
 }
 
@@ -109,6 +146,7 @@ struct SelectiveTreeGeometry {
     channel_height_m: f64,
 }
 
+/// Generates a selective-tree blueprint from its physical request and topology.
 pub fn create_selective_tree_geometry(request: &SelectiveTreeRequest) -> NetworkBlueprint {
     let geometry = request.geometry();
     let mut builder = SelectiveTreeBuilder::new(request.name.clone(), geometry.box_dims_mm);

--- a/crates/cfd-schematics/src/geometry/generator/selective/primitive/mod.rs
+++ b/crates/cfd-schematics/src/geometry/generator/selective/primitive/mod.rs
@@ -15,28 +15,47 @@ mod annotation;
 
 use annotation::annotate_primitive_tree;
 
+/// Split kind of a primitive selective tree stage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrimitiveSelectiveSplitKind {
+    /// Two-way split.
     Bi,
+    /// Three-way split.
     Tri,
+    /// Four-way split.
     Quad,
+    /// Five-way split.
     Penta,
 }
 
+/// Request describing a primitive selective tree geometry.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveSelectiveTreeRequest {
+    /// Blueprint name.
     pub name: String,
+    /// Authored plate envelope in meters.
     pub box_dims_m: (Length<f64>, Length<f64>),
+    /// Ordered split kinds per stage.
     pub split_sequence: Vec<PrimitiveSelectiveSplitKind>,
+    /// Inlet trunk width.
     pub main_width_m: Length<f64>,
+    /// Venturi throat width.
     pub throat_width_m: Length<f64>,
+    /// Venturi throat length.
     pub throat_length_m: Length<f64>,
+    /// Uniform channel height.
     pub channel_height_m: Length<f64>,
+    /// Center-line fraction for the first trifurcation stage.
     pub first_trifurcation_center_frac: f64,
+    /// Center-line fraction for later trifurcation stages.
     pub later_trifurcation_center_frac: f64,
+    /// Fraction of the bifurcation consumed by the treatment path.
     pub bifurcation_treatment_frac: f64,
+    /// Whether the treatment branch carries venturi throats.
     pub treatment_branch_venturi_enabled: bool,
+    /// Number of serial venturi throats on the treatment branch.
     pub treatment_branch_throat_count: u8,
+    /// Serpentine applied to the center branch, if any.
     pub center_serpentine: Option<super::super::CenterSerpentinePathSpec>,
 }
 
@@ -49,6 +68,10 @@ impl PrimitiveSelectiveTreeRequest {
     }
 }
 
+/// Build a primitive selective tree geometry from a request.
+///
+/// Generation expands the authored plate envelope to resolve channel overlap,
+/// then scales the resulting geometry back to the target dimensions.
 pub fn create_primitive_selective_tree_geometry(
     request: &PrimitiveSelectiveTreeRequest,
 ) -> NetworkBlueprint {

--- a/crates/cfd-schematics/src/geometry/metadata/blueprint.rs
+++ b/crates/cfd-schematics/src/geometry/metadata/blueprint.rs
@@ -1,25 +1,35 @@
 use serde::{Deserialize, Serialize};
 
+/// Render hints consumed by visualizers and renderers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlueprintRenderHints {
+    /// Stage sequence label.
     pub stage_sequence: String,
+    /// Number of visible split layers.
     pub split_layers: usize,
+    /// Venturi throat count hint.
     pub throat_count_hint: usize,
+    /// Treatment label, e.g. "venturi" or "ultrasound".
     pub treatment_label: String,
+    /// Mirror the geometry about the vertical axis.
     #[serde(default)]
     pub mirror_x: bool,
+    /// Mirror the geometry about the horizontal axis.
     #[serde(default)]
     pub mirror_y: bool,
 }
 
 crate::impl_metadata!(BlueprintRenderHints, "BlueprintRenderHints");
 
+/// Provenance marking a blueprint as authored by the canonical geometry pipeline.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GeometryAuthoringProvenance {
+    /// Provenance source identifier.
     pub source: String,
 }
 
 impl GeometryAuthoringProvenance {
+    /// Provenance for the canonical `create_geometry` pipeline.
     #[must_use]
     pub fn create_geometry() -> Self {
         Self {
@@ -27,6 +37,7 @@ impl GeometryAuthoringProvenance {
         }
     }
 
+    /// Provenance for the selective-tree wrapper around `create_geometry`.
     #[must_use]
     pub fn selective_wrapper() -> Self {
         Self {

--- a/crates/cfd-schematics/src/geometry/metadata/flow_metadata.rs
+++ b/crates/cfd-schematics/src/geometry/metadata/flow_metadata.rs
@@ -1,37 +1,53 @@
 use aequitas::systems::si::quantities::{Length, Pressure, VolumetricFlowRate};
 use serde::{Deserialize, Serialize};
 
+/// Fluid-flow metadata computed by the reduced-order solver.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FlowMetadata {
+    /// Volumetric flow rate.
     pub flow_rate: f64,
+    /// Pressure drop across the channel.
     pub pressure_drop: f64,
+    /// Dimensionless Reynolds number of the flow.
     pub reynolds_number: f64,
+    /// Mean flow velocity.
     pub velocity: f64,
 }
 
 crate::impl_metadata!(FlowMetadata, "FlowMetadata");
 
+/// Thermal metadata associated with a channel.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ThermalMetadata {
+    /// Channel temperature.
     pub temperature: f64,
+    /// Convective heat transfer coefficient.
     pub heat_transfer_coefficient: f64,
+    /// Material thermal conductivity.
     pub thermal_conductivity: f64,
 }
 
 crate::impl_metadata!(ThermalMetadata, "ThermalMetadata");
 
+/// Manufacturing metadata associated with a channel.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ManufacturingMetadata {
+    /// Toleranced channel width.
     pub width_tolerance: f64,
+    /// Toleranced channel height.
     pub height_tolerance: f64,
+    /// Surface roughness value.
     pub surface_roughness: f64,
+    /// Manufacturing method identifier.
     pub manufacturing_method: String,
 }
 
 crate::impl_metadata!(ManufacturingMetadata, "ManufacturingMetadata");
 
+/// Channel geometry metadata used by the reduced-order solver.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChannelGeometryMetadata {
+    /// Equivalent channel diameter.
     pub channel_diameter_m: Length<f64>,
 }
 
@@ -45,12 +61,16 @@ crate::impl_metadata!(ChannelGeometryMetadata, "ChannelGeometryMetadata");
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum BranchBoundarySpecification {
     /// Fixed pressure boundary.
-    Pressure { pressure_pa: Pressure<f64> },
+    Pressure {
+        /// Applied pressure at the branch.
+        pressure_pa: Pressure<f64>,
+    },
     /// Fixed volumetric flow boundary.
     ///
     /// The sign convention matches the 1D solver: positive values act as a
     /// source term, negative values as a sink term.
     FlowRate {
+        /// Applied volumetric flow rate.
         flow_rate_m3_s: VolumetricFlowRate<f64>,
     },
 }
@@ -61,6 +81,7 @@ pub enum BranchBoundarySpecification {
 /// must override the default inlet/outlet pressure inference.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct BranchBoundaryMetadata {
+    /// Boundary condition specification applied at this branch end.
     pub boundary: BranchBoundarySpecification,
 }
 
@@ -112,22 +133,33 @@ mod tests {
     }
 }
 
+/// Optimization metadata recorded for a length-optimized channel.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OptimizationMetadata {
+    /// Authored channel length before optimization.
     pub original_length: f64,
+    /// Channel length after optimization.
     pub optimized_length: f64,
+    /// Relative length improvement as a percentage.
     pub improvement_percentage: f64,
+    /// Number of optimization iterations.
     pub iterations: usize,
+    /// Wall-clock optimization time in milliseconds.
     pub optimization_time_ms: u64,
+    /// Optimization profile identifier.
     pub optimization_profile: String,
 }
 
 crate::impl_metadata!(OptimizationMetadata, "OptimizationMetadata");
 
+/// Performance metadata recorded for blueprint generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PerformanceMetadata {
+    /// Generation time in microseconds.
     pub generation_time_us: u64,
+    /// Peak memory usage in bytes.
     pub memory_usage_bytes: usize,
+    /// Number of path points in the generated geometry.
     pub path_points_count: usize,
 }
 

--- a/crates/cfd-schematics/src/geometry/metadata/mod.rs
+++ b/crates/cfd-schematics/src/geometry/metadata/mod.rs
@@ -13,9 +13,13 @@ pub use self::{blueprint::*, flow_metadata::*, schematic::*, therapy::*};
 
 /// Base trait for all metadata types.
 pub trait Metadata: Any + Debug + Send + Sync {
+    /// Stable type name used for diagnostics and storage keys.
     fn metadata_type_name(&self) -> &'static str;
+    /// Clone this metadata as a boxed trait object.
     fn clone_metadata(&self) -> Box<dyn Metadata>;
+    /// Downcast access to the concrete value.
     fn as_any(&self) -> &dyn Any;
+    /// Mutable downcast access to the concrete value.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
@@ -26,6 +30,7 @@ pub struct MetadataContainer {
 }
 
 impl MetadataContainer {
+    /// Create an empty metadata container.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -33,10 +38,12 @@ impl MetadataContainer {
         }
     }
 
+    /// Insert a typed metadata value, replacing any value of the same type.
     pub fn insert<T: Metadata + Clone + 'static>(&mut self, metadata: T) {
         self.data.insert(TypeId::of::<T>(), Box::new(metadata));
     }
 
+    /// Borrow the stored metadata value of type `T`, if present.
     #[must_use]
     pub fn get<T: Metadata + 'static>(&self) -> Option<&T> {
         self.data
@@ -44,21 +51,25 @@ impl MetadataContainer {
             .and_then(|boxed| boxed.as_any().downcast_ref::<T>())
     }
 
+    /// Mutably borrow the stored metadata value of type `T`, if present.
     pub fn get_mut<T: Metadata + 'static>(&mut self) -> Option<&mut T> {
         self.data
             .get_mut(&TypeId::of::<T>())
             .and_then(|boxed| boxed.as_any_mut().downcast_mut::<T>())
     }
 
+    /// Remove and return the stored metadata value of type `T`, if present.
     pub fn remove<T: Metadata + 'static>(&mut self) -> Option<Box<dyn Metadata>> {
         self.data.remove(&TypeId::of::<T>())
     }
 
+    /// Whether a metadata value of type `T` is stored.
     #[must_use]
     pub fn contains<T: Metadata + 'static>(&self) -> bool {
         self.data.contains_key(&TypeId::of::<T>())
     }
 
+    /// Stable type names of all stored metadata values.
     #[must_use]
     pub fn metadata_types(&self) -> Vec<&'static str> {
         self.data
@@ -67,11 +78,13 @@ impl MetadataContainer {
             .collect()
     }
 
+    /// Whether the container holds no metadata.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 
+    /// Number of stored metadata values.
     #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()

--- a/crates/cfd-schematics/src/geometry/metadata/schematic.rs
+++ b/crates/cfd-schematics/src/geometry/metadata/schematic.rs
@@ -1,45 +1,69 @@
 use serde::{Deserialize, Serialize};
 
+/// Layout metadata positioning a node in schematic coordinates.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct NodeLayoutMetadata {
+    /// Horizontal position in millimetres.
     pub x_mm: f64,
+    /// Vertical position in millimetres.
     pub y_mm: f64,
 }
 
 crate::impl_metadata!(NodeLayoutMetadata, "NodeLayoutMetadata");
 
+/// Visual role of a channel for rendering and analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ChannelVisualRole {
+    /// Inlet trunk segment.
     Trunk,
+    /// Center treatment-path segment.
     CenterTreatment,
+    /// Peripheral RBC-bypass segment.
     PeripheralBypass,
+    /// Outlet merge collector segment.
     MergeCollector,
+    /// Venturi throat segment.
     VenturiThroat,
+    /// Diffuser segment adjacent to a throat.
     Diffuser,
+    /// Internal link segment between stages.
     InternalLink,
 }
 
+/// Authored channel path metadata for rendering.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChannelPathMetadata {
+    /// Centerline polyline in millimetres.
     pub polyline_mm: Vec<(f64, f64)>,
+    /// Visual role of the channel.
     pub visual_role: ChannelVisualRole,
 }
 
 crate::impl_metadata!(ChannelPathMetadata, "ChannelPathMetadata");
 
+/// Family of a junction in the schematic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum JunctionFamily {
+    /// Two-way split junction.
     Bifurcation,
+    /// Three-way split junction.
     Trifurcation,
+    /// Offset tee junction.
     Tee,
+    /// Four-way crossing junction.
     Cross,
+    /// Convergence junction.
     Merge,
 }
 
+/// Junction geometry metadata describing branch angles.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JunctionGeometryMetadata {
+    /// Family of the junction.
     pub junction_family: JunctionFamily,
+    /// Outgoing branch angles in degrees.
     pub branch_angles_deg: Vec<f64>,
+    /// Incoming merge angles in degrees.
     pub merge_angles_deg: Vec<f64>,
 }
 

--- a/crates/cfd-schematics/src/geometry/metadata/therapy.rs
+++ b/crates/cfd-schematics/src/geometry/metadata/therapy.rs
@@ -3,15 +3,24 @@ use aequitas::systems::si::quantities::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Dimensional metadata describing a venturi-like geometry.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VenturiGeometryMetadata {
+    /// Throat channel width.
     pub throat_width_m: Length<f64>,
+    /// Throat channel height.
     pub throat_height_m: Length<f64>,
+    /// Axial length of the throat section.
     pub throat_length_m: Length<f64>,
+    /// Width of the inlet section.
     pub inlet_width_m: Length<f64>,
+    /// Width of the outlet section.
     pub outlet_width_m: Length<f64>,
+    /// Half-angle of the convergent section.
     pub convergent_half_angle: Angle<f64>,
+    /// Half-angle of the divergent section.
     pub divergent_half_angle: Angle<f64>,
+    /// Fractional position of the throat along the channel.
     #[serde(default = "default_throat_position")]
     pub throat_position: Dimensionless<f64>,
 }
@@ -22,44 +31,65 @@ fn default_throat_position() -> Dimensionless<f64> {
 
 crate::impl_metadata!(VenturiGeometryMetadata, "VenturiGeometryMetadata");
 
+/// Parameters describing a cascade of filtration levels.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CascadeParams {
+    /// Number of cascade levels.
     pub n_levels: u8,
+    /// Fractional position of the cascade center along the channel.
     pub center_frac: f64,
 }
 
 crate::impl_metadata!(CascadeParams, "CascadeParams");
 
+/// Parameters describing incremental filtration with a tri-level prefilter.
 #[derive(Debug, Clone, PartialEq)]
 pub struct IncrementalFiltrationParams {
+    /// Number of pre-treatment tri-levels.
     pub n_pretri: u8,
+    /// Fractional center position of the pre-treatment tri-levels.
     pub pretri_center_frac: f64,
+    /// Fractional center position of the terminal tri-levels.
     pub terminal_tri_center_frac: f64,
+    /// Fractional extent of the bi-treatment section.
     pub bi_treat_frac: f64,
+    /// Axial length of the outlet tail.
     pub outlet_tail_length_m: Length<f64>,
 }
 
 crate::impl_metadata!(IncrementalFiltrationParams, "IncrementalFiltrationParams");
 
+/// Parameters describing an asymmetric trifurcation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AsymmetricTrifurcationParams {
+    /// Fractional center position of the trifurcation.
     pub center_frac: f64,
+    /// Fractional flow share toward the left branch.
     pub left_frac: f64,
+    /// Fractional flow share toward the right branch.
     pub right_frac: f64,
 }
 
 crate::impl_metadata!(AsymmetricTrifurcationParams, "AsymmetricTrifurcationParams");
 
+/// Specification for a channel containing venturi throat segments.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChannelVenturiSpec {
+    /// Number of venturi throat segments in the channel.
     pub n_throats: u8,
+    /// Whether the stream is a CTC (center-to-cavity) stream.
     pub is_ctc_stream: bool,
+    /// Throat segment width.
     pub throat_width_m: Length<f64>,
+    /// Channel height.
     pub height_m: Length<f64>,
+    /// Axial spacing between successive throats.
     pub inter_throat_spacing_m: Length<f64>,
 }
 
 impl ChannelVenturiSpec {
+    /// Return the cumulative cavitation dose after all throats, compounding
+    /// the per-throat probability of a non-cavitating pass.
     #[must_use]
     pub fn cumulative_cavitation_dose(
         &self,
@@ -72,6 +102,8 @@ impl ChannelVenturiSpec {
         Dimensionless::from_base((1.0 - (1.0 - p).powi(i32::from(self.n_throats))).clamp(0.0, 1.0))
     }
 
+    /// Return the total pressure drop across all throats for the given flow
+    /// rate, blood density, and diffuser recovery coefficient.
     #[must_use]
     pub fn total_throat_pressure_drop(
         &self,
@@ -101,19 +133,28 @@ impl ChannelVenturiSpec {
 
 crate::impl_metadata!(ChannelVenturiSpec, "ChannelVenturiSpec");
 
+/// FDA cavitation-compliance assessment for a therapy geometry.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FdaCavitationCompliance {
+    /// Mechanical-index equivalent derived from the throat pressure drop.
     pub mi_equiv: Dimensionless<f64>,
+    /// Whether the mechanical-index equivalent stays below the FDA limit.
     pub fda_mi_compliant: bool,
+    /// Lower bound of the therapeutic mechanical-index window.
     pub therapeutic_mi_lower: Dimensionless<f64>,
+    /// Whether the mechanical-index equivalent lies in the therapeutic window.
     pub in_therapeutic_window: bool,
 }
 
 impl FdaCavitationCompliance {
+    /// FDA exposure limit for the mechanical index.
     pub const FDA_MI_LIMIT: Dimensionless<f64> = Dimensionless::from_base(1.9);
+    /// Mechanical-index threshold below which inertial cavitation is negligible.
     pub const INERTIAL_CAV_THRESHOLD_MI: Dimensionless<f64> = Dimensionless::from_base(0.3);
+    /// Reference sound speed in blood.
     pub const SOUND_SPEED_BLOOD_M_S: Velocity<f64> = Velocity::from_base(1540.0);
 
+    /// Assess compliance from a throat pressure drop and blood density.
     #[must_use]
     pub fn from_throat_dp(dp_throat: Pressure<f64>, blood_density: MassDensity<f64>) -> Self {
         let dp_throat = dp_throat.into_base();

--- a/crates/cfd-schematics/src/geometry/strategies/straight.rs
+++ b/crates/cfd-schematics/src/geometry/strategies/straight.rs
@@ -169,6 +169,7 @@ impl SmoothTransitionConfig {
 }
 
 impl SmoothStraightChannelStrategy {
+    /// Create a smooth-straight channel strategy with the given transition config.
     #[must_use]
     pub const fn new(config: SmoothTransitionConfig) -> Self {
         Self {

--- a/crates/cfd-schematics/src/geometry/types/mod.rs
+++ b/crates/cfd-schematics/src/geometry/types/mod.rs
@@ -30,8 +30,11 @@ pub type Point2D = (f64, f64);
 /// Categories of channel types for visualization and analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChannelTypeCategory {
+    /// Channels without curvature or taper.
     Straight,
+    /// Channels with directional change.
     Curved,
+    /// Channels with varying width along their length.
     Tapered,
 }
 
@@ -48,30 +51,46 @@ impl From<&ChannelType> for ChannelTypeCategory {
 /// Represents the different types of channels that can be generated.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub enum ChannelType {
+    /// Straight channel.
     #[default]
     Straight,
+    /// Smoothly curved channel following the given path.
     SmoothStraight {
+        /// Centerline waypoints.
         path: Vec<Point2D>,
     },
+    /// Serpentine channel following the given path.
     Serpentine {
+        /// Centerline waypoints.
         path: Vec<Point2D>,
     },
+    /// Circular-arc channel following the given path.
     Arc {
+        /// Centerline waypoints.
         path: Vec<Point2D>,
     },
+    /// Tapered channel with authored inlet, throat, and outlet widths.
     Frustum {
+        /// Centerline waypoints.
         path: Vec<Point2D>,
+        /// Per-waypoint widths along the centerline.
         widths: Vec<f64>,
+        /// Inlet width of the taper.
         #[serde(default = "default_frustum_inlet_width")]
         inlet_width: f64,
+        /// Narrowest width of the taper.
         #[serde(default = "default_frustum_throat_width")]
         throat_width: f64,
+        /// Outlet width of the taper.
         #[serde(default = "default_frustum_outlet_width")]
         outlet_width: f64,
+        /// Profile governing the transition between widths.
         #[serde(default = "default_frustum_taper_profile")]
         taper_profile: TaperProfile,
+        /// Normalized position of the throat along the centerline.
         #[serde(default = "default_frustum_throat_position")]
         throat_position: f64,
+        /// Whether the taper represents a venturi throat.
         #[serde(default = "default_has_venturi_throat")]
         has_venturi_throat: bool,
     },
@@ -104,15 +123,28 @@ fn default_frustum_outlet_width() -> f64 {
 /// Defines the type of channel splitting pattern.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum SplitType {
+    /// Two-way split.
     Bifurcation,
-    AsymmetricBifurcation { ratio: f64 },
+    /// Two-way split with an asymmetric width ratio.
+    AsymmetricBifurcation {
+        /// Ratio of the wider branch to the inlet width.
+        ratio: f64,
+    },
+    /// Three-way split.
     Trifurcation,
-    SymmetricTrifurcation { center_ratio: f64 },
+    /// Three-way split with a symmetric center branch.
+    SymmetricTrifurcation {
+        /// Center-branch width fraction.
+        center_ratio: f64,
+    },
+    /// Four-way split.
     Quadfurcation,
+    /// Five-way split.
     Pentafurcation,
 }
 
 impl SplitType {
+    /// Number of outlet branches for this split pattern.
     #[must_use]
     pub const fn branch_count(&self) -> usize {
         match self {

--- a/crates/cfd-schematics/src/geometry/types/volume.rs
+++ b/crates/cfd-schematics/src/geometry/types/volume.rs
@@ -37,6 +37,7 @@ pub struct ChannelFluidVolumeSummary {
 }
 
 impl NetworkBlueprint {
+    /// Compute per-channel fluid-volume summaries from the blueprint geometry.
     #[must_use]
     pub fn channel_fluid_volume_summaries(&self) -> Vec<ChannelFluidVolumeSummary> {
         self.channels
@@ -71,6 +72,7 @@ impl NetworkBlueprint {
             .collect()
     }
 
+    /// Compute the aggregate fluid-volume summary for the whole system.
     #[must_use]
     pub fn fluid_volume_summary(&self) -> FluidVolumeSummary {
         let channel_summaries = self.channel_fluid_volume_summaries();

--- a/crates/cfd-schematics/src/infrastructure/adapters/petgraph_graph_sink.rs
+++ b/crates/cfd-schematics/src/infrastructure/adapters/petgraph_graph_sink.rs
@@ -5,8 +5,10 @@ use cfd_core::error::{Error, Result};
 use petgraph::graph::{DiGraph, NodeIndex};
 use std::collections::HashMap;
 
+/// Petgraph adjacency-graph representation of a network blueprint.
 pub type DesignGraph = DiGraph<NodeSpec, ChannelSpec>;
 
+/// `GraphSink` adapter that builds a [`DesignGraph`] from a blueprint.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PetgraphGraphSink;
 
@@ -45,6 +47,7 @@ impl GraphSink for PetgraphGraphSink {
     }
 }
 
+/// Build a design graph from a blueprint through the default graph sink.
 pub fn build_design_graph(blueprint: &NetworkBlueprint) -> Result<DesignGraph> {
     NetworkGenerationService::new(PetgraphGraphSink).generate(blueprint)
 }

--- a/crates/cfd-schematics/src/infrastructure/mod.rs
+++ b/crates/cfd-schematics/src/infrastructure/mod.rs
@@ -1,1 +1,4 @@
+//! Infrastructure adapters implementing application ports.
+
+/// Concrete adapter implementations over external infrastructure.
 pub mod adapters;

--- a/crates/cfd-schematics/src/interface/mod.rs
+++ b/crates/cfd-schematics/src/interface/mod.rs
@@ -1,1 +1,4 @@
+//! Public preset factory functions for network blueprints.
+
+/// Blueprint preset factory functions by design family.
 pub mod presets;

--- a/crates/cfd-schematics/src/interface/presets/composite/mixed_tree.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/mixed_tree.rs
@@ -111,6 +111,7 @@ fn width_scaled_by_mixed_trifurcation(label: &str, main_width_m: f64, center_fra
 }
 
 #[must_use]
+/// Build a two-stage trifurcation→trifurcation venturi bundle blueprint.
 pub fn double_trifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,
@@ -146,6 +147,7 @@ pub fn double_trifurcation_venturi_rect(
 }
 
 #[must_use]
+/// Build a two-stage bifurcation→trifurcation venturi bundle blueprint.
 pub fn bifurcation_trifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,
@@ -182,6 +184,7 @@ pub fn bifurcation_trifurcation_venturi_rect(
 }
 
 #[must_use]
+/// Build a two-stage trifurcation→bifurcation venturi bundle blueprint.
 pub fn trifurcation_bifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,
@@ -219,6 +222,8 @@ pub fn trifurcation_bifurcation_venturi_rect(
 
 #[must_use]
 #[allow(clippy::too_many_arguments)]
+/// Build a three-stage trifurcation→bifurcation→bifurcation venturi bundle
+/// blueprint.
 pub fn trifurcation_bifurcation_bifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,

--- a/crates/cfd-schematics/src/interface/presets/composite/multi_level.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/multi_level.rs
@@ -108,6 +108,7 @@ fn width_scaled_by_trifurcation(label: &str, main_width_m: f64, center_frac: f64
 }
 
 #[must_use]
+/// Build a two-stage bifurcation→bifurcation venturi bundle blueprint.
 pub fn double_bifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,
@@ -143,6 +144,8 @@ pub fn double_bifurcation_venturi_rect(
 }
 
 #[must_use]
+/// Build a three-stage bifurcation→bifurcation→bifurcation venturi bundle
+/// blueprint.
 pub fn triple_bifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,
@@ -180,6 +183,8 @@ pub fn triple_bifurcation_venturi_rect(
 
 #[must_use]
 #[allow(clippy::too_many_arguments)]
+/// Build a three-stage trifurcation→trifurcation→trifurcation venturi bundle
+/// blueprint.
 pub fn triple_trifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,
@@ -218,6 +223,8 @@ pub fn triple_trifurcation_venturi_rect(
 
 #[must_use]
 #[allow(clippy::too_many_arguments)]
+/// Build a four-stage trifurcation→trifurcation→trifurcation→trifurcation
+/// venturi bundle blueprint.
 pub fn quad_trifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,

--- a/crates/cfd-schematics/src/interface/presets/composite/n_furcation.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/n_furcation.rs
@@ -33,6 +33,7 @@ fn parallel_channels_for_n_furcation(
         .collect()
 }
 
+/// N-furcation trunk with a straight venturi throat in the central channel.
 #[must_use]
 pub fn n_furcation_venturi_rect(
     name: impl Into<String>,
@@ -66,6 +67,7 @@ pub fn n_furcation_venturi_rect(
     )
 }
 
+/// N-furcation trunk with serpentine segments in each arm channel.
 #[must_use]
 pub fn n_furcation_serpentine_rect(
     name: impl Into<String>,

--- a/crates/cfd-schematics/src/interface/presets/composite/series.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/series.rs
@@ -2,6 +2,7 @@ use super::finalize_preset_blueprint;
 use crate::topology::presets::{serial_double_venturi_series_spec, venturi_serpentine_series_spec};
 use crate::BlueprintTopologyFactory;
 
+/// Venturi throat upstream of a serpentine residence segment in series.
 #[must_use]
 pub fn venturi_serpentine_rect(
     name: impl Into<String>,
@@ -28,6 +29,7 @@ pub fn venturi_serpentine_rect(
     )
 }
 
+/// Two venturi throats in series with an inter-throat straight segment.
 #[must_use]
 pub fn serial_double_venturi_rect(
     name: impl Into<String>,

--- a/crates/cfd-schematics/src/interface/presets/composite/specialized/basic.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/specialized/basic.rs
@@ -18,6 +18,7 @@ use crate::topology::{SerpentineSpec, TreatmentActuationMode};
 use crate::BlueprintTopologyFactory;
 use aequitas::systems::si::quantities::Length;
 
+/// Rectangular primitive selective split-tree blueprint with venturi treatment.
 pub fn primitive_selective_split_tree_rect(
     name: impl Into<String>,
     box_dims_mm: (f64, f64),

--- a/crates/cfd-schematics/src/interface/presets/composite/specialized/filtration.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/specialized/filtration.rs
@@ -6,6 +6,7 @@ use crate::geometry::generator::{
 };
 use aequitas::systems::si::quantities::Length;
 
+/// Cascade center-trifurcation selective tree with optional venturi treatment.
 pub fn cascade_center_trifurcation_rect(
     name: impl Into<String>,
     trunk_length_m: f64,

--- a/crates/cfd-schematics/src/interface/presets/composite/specialized/mod.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/specialized/mod.rs
@@ -1,4 +1,4 @@
-﻿//! Specialized composite presets: cell separation, asymmetric, constriction,
+//! Specialized composite presets: cell separation, asymmetric, constriction,
 //! spiral, parallel microchannel array, and selective tree topologies.
 
 mod basic;
@@ -46,7 +46,10 @@ mod tests {
         bp.channels
             .iter()
             .find(|c| c.id.as_str() == id)
-            .map_or_else(|| panic!("channel {id} must exist"), |c| c.length_m.into_base())
+            .map_or_else(
+                || panic!("channel {id} must exist"),
+                |c| c.length_m.into_base(),
+            )
     }
 
     #[test]

--- a/crates/cfd-schematics/src/interface/presets/composite/specialized/parallel_lane.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/specialized/parallel_lane.rs
@@ -14,8 +14,11 @@ use aequitas::systems::si::quantities::{Angle, Length};
 /// Optional serpentine geometry applied only to center treatment lanes.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CenterSerpentineSpec {
+    /// Number of serpentine segments.
     pub segments: usize,
+    /// Serpentine bend radius.
     pub bend_radius_m: Length<f64>,
+    /// Length of each serpentine segment.
     pub segment_length_m: Length<f64>,
 }
 

--- a/crates/cfd-schematics/src/interface/presets/composite/specialized/trifurcation.rs
+++ b/crates/cfd-schematics/src/interface/presets/composite/specialized/trifurcation.rs
@@ -7,6 +7,7 @@ use crate::geometry::generator::{
 };
 use aequitas::systems::si::quantities::Length;
 
+/// Asymmetric trifurcation with a venturi throat on the center arm.
 pub fn asymmetric_trifurcation_venturi_rect(
     name: impl Into<String>,
     trunk_length_m: f64,

--- a/crates/cfd-schematics/src/interface/presets/serpentine.rs
+++ b/crates/cfd-schematics/src/interface/presets/serpentine.rs
@@ -3,6 +3,7 @@ use crate::topology::presets::{serpentine_bend_venturi_series_spec, serpentine_s
 use crate::BlueprintTopologyFactory;
 
 #[must_use]
+/// Build a serpentine chain blueprint with the given segment count.
 pub fn serpentine_chain(
     name: impl Into<String>,
     segments: usize,
@@ -18,6 +19,7 @@ pub fn serpentine_chain(
 }
 
 #[must_use]
+/// Build a serpentine rectangle blueprint with the given segment count.
 pub fn serpentine_rect(
     name: impl Into<String>,
     segments: usize,
@@ -33,6 +35,7 @@ pub fn serpentine_rect(
 }
 
 #[must_use]
+/// Build a serpentine venturi blueprint with a throat at each bend.
 pub fn serpentine_venturi_rect(
     name: impl Into<String>,
     segments: usize,

--- a/crates/cfd-schematics/src/interface/presets/venturi.rs
+++ b/crates/cfd-schematics/src/interface/presets/venturi.rs
@@ -2,6 +2,7 @@ use super::finalize_preset_blueprint;
 use crate::topology::presets::single_venturi_series_spec;
 use crate::BlueprintTopologyFactory;
 
+/// Circular cross-section venturi chain on a shared trunk.
 #[must_use]
 pub fn venturi_chain(
     name: impl Into<String>,

--- a/crates/cfd-schematics/src/lib.rs
+++ b/crates/cfd-schematics/src/lib.rs
@@ -116,10 +116,15 @@ pub mod state_management;
 pub mod visualizations;
 
 // ── CFDrs network / topology layer ───────────────────────────────────────────
+/// Application services for generating network designs.
 pub mod application;
+/// Domain models and invariants for schematic networks.
 pub mod domain;
+/// Infrastructure adapters for graph and persistence integrations.
 pub mod infrastructure;
+/// Public preset and use-case interfaces.
 pub mod interface;
+/// Typed topology specifications, factories, and queries.
 pub mod topology;
 
 // ── Flat convenience re-exports ───────────────────────────────────────────────

--- a/crates/cfd-schematics/src/state_management/constraints.rs
+++ b/crates/cfd-schematics/src/state_management/constraints.rs
@@ -19,22 +19,37 @@ where
     T: ConstraintValue,
 {
     /// Value must be within specified range (inclusive)
-    Range { min: T, max: T },
+    Range {
+        /// Minimum acceptable value.
+        min: T,
+        /// Maximum acceptable value.
+        max: T,
+    },
 
     /// Value must be one of the specified values
     Set(Vec<T>),
 
     /// Custom validation function with parameters
     Custom {
+        /// Name of the custom constraint.
         name: String,
+        /// Validation function returning a violation message on failure.
         validator: fn(&T) -> Result<(), String>,
     },
 
     /// Length range constraint for strings
-    LengthRange { min: usize, max: usize },
+    LengthRange {
+        /// Minimum acceptable length.
+        min: usize,
+        /// Maximum acceptable length.
+        max: usize,
+    },
 
     /// Contains pattern constraint for strings
-    Contains { pattern: String },
+    Contains {
+        /// Required substring.
+        pattern: String,
+    },
 
     /// Composite constraint (all must pass)
     All(Vec<ParameterConstraints<T>>),

--- a/crates/cfd-schematics/src/state_management/mod.rs
+++ b/crates/cfd-schematics/src/state_management/mod.rs
@@ -49,6 +49,7 @@ pub use self::{
 
 /// Re-export commonly used types for convenience
 pub type ParameterResult<T> = Result<T, ParameterError>;
+/// State-management operation result alias.
 pub type StateResult<T> = Result<T, StateManagementError>;
 
 /// Version information for the state management system

--- a/crates/cfd-schematics/src/topology/factory/core/mod.rs
+++ b/crates/cfd-schematics/src/topology/factory/core/mod.rs
@@ -15,44 +15,76 @@ use crate::topology::model::{
 /// High-level mutations available to the GA optimization engine.
 #[derive(Debug, Clone, PartialEq)]
 pub enum BlueprintTopologyMutation {
+    /// Update the branch width at a stage.
     UpdateBranchWidth {
+        /// Identifier of the topology stage.
         stage_id: String,
+        /// Label of the branch being resized.
         branch_label: String,
+        /// New branch width in meters.
         new_width_m: f64,
     },
+    /// Replace the split kind of a stage.
     ReplaceSplitKind {
+        /// Identifier of the topology stage.
         stage_id: String,
+        /// Replacement split kind.
         split_kind: SplitKind,
     },
+    /// Insert a new stage at the given index.
     InsertStage {
+        /// Position at which the stage is inserted.
         stage_index: usize,
+        /// Split kind of the inserted stage.
         split_kind: SplitKind,
     },
+    /// Update the venturi configuration.
     UpdateVenturiConfiguration {
+        /// Venturi placement specifications.
         placements: Vec<VenturiPlacementSpec>,
+        /// Treatment actuation mode.
         treatment_mode: TreatmentActuationMode,
     },
+    /// Set the treatment serpentine of a branch.
     SetTreatmentSerpentine {
+        /// Identifier of the topology stage.
         stage_id: String,
+        /// Label of the branch being modified.
         branch_label: String,
+        /// Serpentine specification, or `None` to clear it.
         serpentine: Option<SerpentineSpec>,
     },
+    /// Configure a treatment channel with serial venturi throats.
     SetTreatmentChannelVenturi {
+        /// Identifier of the target channel.
         target_channel_id: String,
+        /// Number of serial throat segments.
         serial_throat_count: u8,
+        /// Throat geometry specification.
         throat_geometry: ThroatGeometrySpec,
+        /// Placement mode for the throats.
         placement_mode: VenturiPlacementMode,
     },
+    /// Set the treatment serpentine of a channel.
     SetTreatmentChannelSerpentine {
+        /// Identifier of the target channel.
         target_channel_id: String,
+        /// Serpentine specification, or `None` to clear it.
         serpentine: Option<SerpentineSpec>,
     },
+    /// Insert a split-merge treatment structure into a channel.
     InsertTreatmentSplitMerge {
+        /// Identifier of the target channel.
         target_channel_id: String,
+        /// Split kind of the inserted structure.
         split_kind: SplitKind,
+        /// Serpentine applied to the treatment structure, if any.
         treatment_serpentine: Option<SerpentineSpec>,
+        /// Number of serial venturi throats, if any.
         venturi_serial_throat_count: Option<u8>,
+        /// Throat geometry specification, if any.
         venturi_throat_geometry: Option<ThroatGeometrySpec>,
+        /// Placement mode for the venturi throats.
         venturi_placement_mode: VenturiPlacementMode,
     },
 }

--- a/crates/cfd-schematics/src/topology/factory/core/spec_analysis_impl.rs
+++ b/crates/cfd-schematics/src/topology/factory/core/spec_analysis_impl.rs
@@ -10,6 +10,12 @@ use crate::topology::model::{
 use aequitas::systems::si::quantities::{Dimensionless, Length};
 
 impl BlueprintTopologyFactory {
+    /// Estimate Dean number and curvature geometry for a venturi placement.
+    ///
+    /// The curvature radius is taken from the spec serpentine when present,
+    /// otherwise estimated from the channel polyline by three-point
+    /// circumradius. Returns `None` when the target channel or a positive
+    /// hydraulic area is unavailable.
     pub fn estimate_dean_site(
         blueprint: &NetworkBlueprint,
         placement: &VenturiPlacementSpec,

--- a/crates/cfd-schematics/src/topology/model.rs
+++ b/crates/cfd-schematics/src/topology/model.rs
@@ -93,6 +93,11 @@ pub struct SerpentineSpec {
 }
 
 /// Geometric and therapy metadata for one channel route.
+/// Authoring specification for a flow channel between two endpoints.
+///
+/// Composes a rectangular duct cross-section with an optional serpentine
+/// waveform and the therapy-zone semantic tag driving mesh refinement and
+/// physics coupling downstream of topology authoring.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChannelRouteSpec {
     /// Total route length.

--- a/crates/cfd-schematics/src/topology/model.rs
+++ b/crates/cfd-schematics/src/topology/model.rs
@@ -1,13 +1,18 @@
+//! Typed topology specifications shared by schematic builders and queries.
+
 use crate::domain::therapy_metadata::TherapyZone;
 use aequitas::systems::si::quantities::{Angle, Dimensionless, Length};
 use serde::{Deserialize, Serialize};
 
+/// Describes how a topology stage branches a channel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SplitKind {
+    /// Split one channel into the requested number of branches.
     NFurcation(usize),
 }
 
 impl SplitKind {
+    /// Returns the number of branches described by this split.
     #[must_use]
     pub const fn branch_count(self) -> usize {
         match self {
@@ -16,24 +21,36 @@ impl SplitKind {
     }
 }
 
+/// Physiological role assigned to a branch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BranchRole {
+    /// Branch carrying the treatment flow.
     Treatment,
+    /// Branch collecting white blood cells.
     WbcCollection,
+    /// Branch bypassing red blood cells.
     RbcBypass,
+    /// Branch with no specialized treatment role.
     Neutral,
 }
 
+/// Treatment actuation used by a topology.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TreatmentActuationMode {
+    /// Apply ultrasound without a Venturi stage.
     UltrasoundOnly,
+    /// Apply ultrasound together with Venturi cavitation.
     VenturiCavitation,
 }
 
+/// Placement rule for a Venturi stage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VenturiPlacementMode {
+    /// Place the Venturi in a straight channel segment.
     StraightSegment,
+    /// Place the Venturi at the peak Dean-number site of a curve.
     CurvaturePeakDeanNumber,
+    /// Place the Venturi at a diffuser shoulder.
     DiffuserShoulder,
 }
 
@@ -59,10 +76,14 @@ pub enum SerpentineWaveType {
     Triangular,
 }
 
+/// Geometric parameters for a serpentine route.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SerpentineSpec {
+    /// Number of repeated channel segments.
     pub segments: usize,
+    /// Radius of each bend.
     pub bend_radius_m: Length<f64>,
+    /// Length of each straight segment.
     pub segment_length_m: Length<f64>,
     /// Waveform type controlling bend geometry and 1D loss model.
     /// Defaults to `Sine` for backward compatibility with existing
@@ -71,13 +92,19 @@ pub struct SerpentineSpec {
     pub wave_type: SerpentineWaveType,
 }
 
+/// Geometric and therapy metadata for one channel route.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChannelRouteSpec {
+    /// Total route length.
     pub length_m: Length<f64>,
+    /// Route width.
     pub width_m: Length<f64>,
+    /// Route height.
     pub height_m: Length<f64>,
+    /// Optional serpentine geometry applied to the route.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub serpentine: Option<SerpentineSpec>,
+    /// Therapy zone served by the route.
     #[serde(default = "default_therapy_zone")]
     pub therapy_zone: TherapyZone,
 }
@@ -86,124 +113,197 @@ fn default_therapy_zone() -> TherapyZone {
     TherapyZone::MixedFlow
 }
 
+/// Geometry and label for one recovery branch.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SubBranchSpec {
+    /// Stable label used to derive the channel identifier.
     pub label: String,
+    /// Sub-branch width.
     pub width_m: Length<f64>,
+    /// Sub-branch height.
     pub height_m: Length<f64>,
 }
 
+/// Secondary split used to recover a branch of the flow.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecoverySubSplit {
+    /// Branches created by the recovery split.
     pub sub_branches: Vec<SubBranchSpec>,
+    /// Index of the branch carrying the recovery flow.
     pub recovery_arm_index: usize,
 }
 
+/// Complete specification of one topology branch.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BranchSpec {
+    /// Stable branch label used to derive the channel identifier.
     pub label: String,
+    /// Physiological role of the branch.
     pub role: BranchRole,
+    /// Whether this branch is part of the treatment path.
     pub treatment_path: bool,
+    /// Geometry and therapy metadata for the branch route.
     pub route: ChannelRouteSpec,
+    /// Optional second split used to recover the bypass flow.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recovery_sub_split: Option<RecoverySubSplit>,
 }
 
+/// One ordered branching stage in a topology.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SplitStageSpec {
+    /// Stable identifier for the split stage.
     pub stage_id: String,
+    /// Branching operation performed at this stage.
     pub split_kind: SplitKind,
+    /// Branch definitions emitted by this stage.
     pub branches: Vec<BranchSpec>,
 }
 
+/// Identifier and route specification for one channel.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TopologyChannelSpec {
+    /// Stable channel identifier.
     pub channel_id: String,
+    /// Geometry and therapy metadata for the channel.
     pub route: ChannelRouteSpec,
 }
 
+/// Channel specification used in a series segment.
 pub type SeriesChannelSpec = TopologyChannelSpec;
+/// Channel specification used in a parallel segment.
 pub type ParallelChannelSpec = TopologyChannelSpec;
 
+/// Cross-sectional and taper geometry for a Venturi throat.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThroatGeometrySpec {
+    /// Venturi throat width.
     pub throat_width_m: Length<f64>,
+    /// Venturi throat height.
     pub throat_height_m: Length<f64>,
+    /// Venturi throat length.
     pub throat_length_m: Length<f64>,
+    /// Inlet channel width before contraction.
     pub inlet_width_m: Length<f64>,
+    /// Outlet channel width after expansion.
     pub outlet_width_m: Length<f64>,
+    /// Half-angle of the convergent section.
     pub convergent_half_angle: Angle<f64>,
+    /// Half-angle of the divergent section.
     pub divergent_half_angle: Angle<f64>,
 }
 
+/// Shared Venturi configuration for one or more channels.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VenturiConfig {
+    /// Channel identifiers targeted by the configuration.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub target_channel_ids: Vec<String>,
+    /// Number of serial throats.
     pub serial_throat_count: u8,
+    /// Geometry shared by the configured throats.
     pub throat_geometry: ThroatGeometrySpec,
+    /// Rule used to choose the placement site.
     pub placement_mode: VenturiPlacementMode,
 }
 
+/// Explicit Venturi placement on one channel.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VenturiPlacementSpec {
+    /// Stable identifier for the placement.
     pub placement_id: String,
+    /// Channel receiving the Venturi stage.
     pub target_channel_id: String,
+    /// Number of serial throats at this placement.
     pub serial_throat_count: u8,
+    /// Geometry of the placed throats.
     pub throat_geometry: ThroatGeometrySpec,
+    /// Rule used to choose the placement site.
     pub placement_mode: VenturiPlacementMode,
 }
 
+/// Estimated Dean-number site used for geometry placement.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
 pub struct DeanSiteEstimate {
+    /// Dean number estimated at the selected site.
     pub dean_number: Dimensionless<f64>,
+    /// Local curvature radius.
     pub curvature_radius_m: Length<f64>,
+    /// Local arc length used for the estimate.
     pub arc_length_m: Length<f64>,
 }
 
+/// Complete authored topology input for schematic generation.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlueprintTopologySpec {
+    /// Stable blueprint identifier.
     pub topology_id: String,
+    /// Human-readable design name.
     pub design_name: String,
+    /// Width and height of the enclosing plate.
     pub box_dims_m: (Length<f64>, Length<f64>),
+    /// Inlet width.
     pub inlet_width_m: Length<f64>,
+    /// Outlet width.
     pub outlet_width_m: Length<f64>,
+    /// Length of the main trunk.
     pub trunk_length_m: Length<f64>,
+    /// Length of the outlet tail.
     pub outlet_tail_length_m: Length<f64>,
+    /// Channels arranged in series.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub series_channels: Vec<SeriesChannelSpec>,
+    /// Channels arranged in parallel.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parallel_channels: Vec<ParallelChannelSpec>,
+    /// Ordered split stages in the topology.
     pub split_stages: Vec<SplitStageSpec>,
+    /// Explicit Venturi placements.
     #[serde(default)]
     pub venturi_placements: Vec<VenturiPlacementSpec>,
+    /// Physical actuation mode for the blueprint.
     pub treatment_mode: TreatmentActuationMode,
 }
 
+/// Stages in the topology optimization lineage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TopologyOptimizationStage {
+    /// Optimize residence-time separation at an asymmetric split.
     AsymmetricSplitResidenceSeparation,
+    /// Optimize Venturi cavitation selectivity at an asymmetric split.
     AsymmetricSplitVenturiCavitationSelectivity,
+    /// Refine an in-place Dean-serpentine route.
     InPlaceDeanSerpentineRefinement,
 }
 
+/// One mutation recorded in a topology optimization lineage.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TopologyLineageEvent {
+    /// Optimization stage that produced the mutation.
     pub stage: TopologyOptimizationStage,
+    /// Human-readable description of the mutation.
     pub mutation: String,
+    /// Blueprint from which the mutation was derived, when known.
     pub source_blueprint: Option<String>,
 }
 
+/// Lineage metadata for an optimized topology blueprint.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TopologyLineageMetadata {
+    /// Name of the root blueprint in the lineage.
     pub root_blueprint_name: String,
+    /// Current optimization stage.
     pub current_stage: TopologyOptimizationStage,
+    /// Optional source blueprint for the first optimization option.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub option1_source_blueprint: Option<String>,
+    /// Optional source blueprint for the second optimization option.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub option2_source_blueprint: Option<String>,
+    /// Optional blueprint used to seed the genetic algorithm.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ga_seed_blueprint: Option<String>,
+    /// Ordered mutations applied to the lineage.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mutations: Vec<TopologyLineageEvent>,
 }
@@ -232,6 +332,7 @@ impl BlueprintTopologySpec {
         )
     }
 
+    /// Finds a route by its series, parallel, or derived split-channel ID.
     #[must_use]
     pub fn channel_route(&self, channel_id: &str) -> Option<&ChannelRouteSpec> {
         self.series_channels
@@ -254,6 +355,7 @@ impl BlueprintTopologySpec {
             })
     }
 
+    /// Returns the stable IDs of channels on the treatment path.
     #[must_use]
     pub fn treatment_channel_ids(&self) -> Vec<String> {
         if !self.split_stages.is_empty() {
@@ -287,6 +389,7 @@ impl BlueprintTopologySpec {
         ids
     }
 
+    /// Derives a channel ID from a split stage and branch label.
     #[must_use]
     pub fn branch_channel_id(stage_id: &str, branch_label: &str) -> String {
         format!("{stage_id}_{branch_label}")

--- a/crates/cfd-schematics/src/topology/presets/milestone12/build.rs
+++ b/crates/cfd-schematics/src/topology/presets/milestone12/build.rs
@@ -13,6 +13,12 @@ use super::support::{
 };
 use super::{Milestone12PrimitiveSelectiveSpec, Milestone12TopologyRequest};
 
+/// Build the raw Milestone 12 primitive selective split-tree topology spec
+/// (before mirror and venturi placement are applied).
+///
+/// Stage layouts default to [`milestone12_default_stage_layouts`] when the
+/// request carries none, and the split-kind/branch-count consistency of every
+/// stage is asserted before construction.
 #[must_use]
 pub fn milestone12_primitive_selective_tree_spec(
     request: &Milestone12PrimitiveSelectiveSpec,

--- a/crates/cfd-schematics/src/topology/presets/milestone12/mod.rs
+++ b/crates/cfd-schematics/src/topology/presets/milestone12/mod.rs
@@ -15,42 +15,72 @@ pub use build::{
 pub use catalog::enumerate_milestone12_topologies;
 pub use support::milestone12_default_stage_layouts;
 
+/// Branch specification within a Milestone 12 stage layout.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Milestone12StageBranchSpec {
+    /// Branch label used to derive channel identifiers.
     pub label: String,
+    /// Branch role within the treatment network.
     pub role: BranchRole,
+    /// Whether this branch carries the treatment path.
     pub treatment_path: bool,
+    /// Authored branch width.
     pub width_m: Length<f64>,
 }
 
+/// Stage layout within a Milestone 12 topology.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Milestone12StageLayout {
+    /// Split kind of the stage.
     pub split_kind: SplitKind,
+    /// Branch specifications for the stage.
     pub branches: Vec<Milestone12StageBranchSpec>,
 }
 
+/// Canonical declarative Milestone 12 topology request.
 #[derive(Debug, Clone)]
 pub struct Milestone12PrimitiveSelectiveSpec {
+    /// Stable topology identifier.
     pub topology_id: String,
+    /// Human-readable design name used for catalog lookup.
     pub design_name: String,
+    /// Mirror the geometry about the vertical axis.
     pub mirror_x: bool,
+    /// Mirror the geometry about the horizontal axis.
     pub mirror_y: bool,
+    /// Authored plate envelope in meters.
     pub box_dims_m: (Length<f64>, Length<f64>),
+    /// Ordered split kinds per stage.
     pub split_kinds: Vec<SplitKind>,
+    /// Inlet channel width.
     pub inlet_width_m: Length<f64>,
+    /// Uniform channel height.
     pub channel_height_m: Length<f64>,
+    /// Authored branch segment length.
     pub branch_length_m: Length<f64>,
+    /// Length of the outlet tail segments.
     pub outlet_tail_length_m: Length<f64>,
+    /// Explicit stage layouts, overriding derived defaults when non-empty.
     pub stage_layouts: Vec<Milestone12StageLayout>,
+    /// Center-line fraction for the first trifurcation stage.
     pub first_trifurcation_center_frac: f64,
+    /// Center-line fraction for later trifurcation stages.
     pub later_trifurcation_center_frac: f64,
+    /// Fraction of the bifurcation consumed by the treatment path.
     pub bifurcation_treatment_frac: f64,
+    /// Treatment actuation mode.
     pub treatment_mode: TreatmentActuationMode,
+    /// Number of serial venturi throats.
     pub venturi_throat_count: u8,
+    /// Venturi throat width.
     pub venturi_throat_width_m: Length<f64>,
+    /// Venturi throat length.
     pub venturi_throat_length_m: Length<f64>,
+    /// Serpentine applied to the center branch, if any.
     pub center_serpentine: Option<SerpentineSpec>,
+    /// Placement mode for venturi throats.
     pub venturi_placement_mode: VenturiPlacementMode,
+    /// Explicit venturi target channel identifiers.
     pub venturi_target_channel_ids: Vec<String>,
 }
 
@@ -64,6 +94,8 @@ impl Milestone12PrimitiveSelectiveSpec {
         )
     }
 
+    /// Construct a primitive selective spec from its structural inputs,
+    /// applying canonical Milestone 12 defaults for the remaining fields.
     #[must_use]
     pub fn new(
         topology_id: impl Into<String>,
@@ -103,7 +135,7 @@ impl Milestone12PrimitiveSelectiveSpec {
     }
 }
 
-/// Canonical declarative Milestone 12 topology request.
+/// Alias of the canonical Milestone 12 topology request shape.
 ///
 /// This is the single-source request shape consumed by
 /// [`build_milestone12_blueprint`] and

--- a/crates/cfd-schematics/src/topology/presets/milestone12/support.rs
+++ b/crates/cfd-schematics/src/topology/presets/milestone12/support.rs
@@ -248,6 +248,10 @@ fn default_stage_branch_specs(
     }
 }
 
+/// Derive default per-stage branch layouts for a Milestone 12 request.
+///
+/// Widths propagate from the inlet width; the parent width for each stage is
+/// the accumulated treatment-branch width of the previous stage.
 #[must_use]
 pub fn milestone12_default_stage_layouts(
     request: &Milestone12PrimitiveSelectiveSpec,

--- a/crates/cfd-schematics/src/topology/presets/sequence.rs
+++ b/crates/cfd-schematics/src/topology/presets/sequence.rs
@@ -44,9 +44,13 @@ pub enum PrimitiveSplitSequence {
     TriTriBi,
     /// Trifurcation → trifurcation → trifurcation (27 leaves).
     TriTriTri,
+    /// Single quadfurcation (4 leaves).
     Quad,
+    /// Single pentafurcation (5 leaves).
     Penta,
+    /// Trifurcation → quadfurcation (12 leaves).
     TriQuad,
+    /// Trifurcation → pentafurcation (15 leaves).
     TriPenta,
     /// Quadfurcation → bifurcation (8 leaves).
     QuadBi,

--- a/crates/cfd-schematics/src/visualizations/annotations/mod.rs
+++ b/crates/cfd-schematics/src/visualizations/annotations/mod.rs
@@ -15,17 +15,26 @@ pub use geometry::{
 /// Marker role for node/throat annotation points.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum MarkerRole {
+    /// Inlet node.
     Inlet,
+    /// Outlet node.
     Outlet,
+    /// Split junction.
     Split,
+    /// Merge junction.
     Merge,
+    /// Venturi throat point.
     VenturiThroat,
+    /// Therapy target point.
     TherapyTarget,
+    /// Bypass route point.
     Bypass,
+    /// Internal point.
     Internal,
 }
 
 impl MarkerRole {
+    /// Human-readable legend label for this role.
     #[must_use]
     pub const fn legend_label(self) -> &'static str {
         match self {
@@ -44,8 +53,11 @@ impl MarkerRole {
 /// Text label density control for annotations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabelDensity {
+    /// No labels rendered.
     None,
+    /// Only critical labels rendered.
     Critical,
+    /// All labels rendered.
     All,
 }
 
@@ -108,14 +120,18 @@ impl AnnotationStyle {
 /// A single schematic marker.
 #[derive(Debug, Clone)]
 pub struct AnnotationMarker {
+    /// Marker position in schematic coordinates.
     pub point: Point2D,
+    /// Role of the marker.
     pub role: MarkerRole,
+    /// Optional label text.
     pub label: Option<String>,
     /// True when this label should still be shown under `LabelDensity::Critical`.
     pub critical_label: bool,
 }
 
 impl AnnotationMarker {
+    /// Create an unlabelled marker at the given point.
     #[must_use]
     pub fn new(point: Point2D, role: MarkerRole) -> Self {
         Self {
@@ -126,6 +142,7 @@ impl AnnotationMarker {
         }
     }
 
+    /// Attach a label to the marker.
     #[must_use]
     pub fn with_label(mut self, label: impl Into<String>, critical_label: bool) -> Self {
         self.label = Some(label.into());
@@ -137,8 +154,11 @@ impl AnnotationMarker {
 /// Full annotation payload for one render.
 #[derive(Debug, Clone)]
 pub struct SchematicAnnotations {
+    /// Markers to render.
     pub markers: Vec<AnnotationMarker>,
+    /// Label density governing which labels render.
     pub label_density: LabelDensity,
+    /// Rendering style.
     pub style: AnnotationStyle,
     /// Optional free-text legend note (e.g. throat count summary).
     pub legend_note: Option<String>,

--- a/crates/cfd-schematics/src/visualizations/plotters_backend/drawer.rs
+++ b/crates/cfd-schematics/src/visualizations/plotters_backend/drawer.rs
@@ -18,6 +18,7 @@ pub struct PlottersDrawer<'area, 'chart, DB: DrawingBackend> {
 }
 
 impl<'area, 'chart, DB: DrawingBackend> PlottersDrawer<'area, 'chart, DB> {
+    /// Create a drawer bound to a drawing area and optional chart context.
     #[must_use]
     pub const fn new(
         drawing_area: &'area DrawingArea<DB, Shift>,
@@ -31,11 +32,13 @@ impl<'area, 'chart, DB: DrawingBackend> PlottersDrawer<'area, 'chart, DB> {
         }
     }
 
+    /// Borrow the underlying drawing area.
     #[must_use]
     pub const fn drawing_area(&self) -> &DrawingArea<DB, Shift> {
         self.drawing_area
     }
 
+    /// Borrow the chart context, or fail when none is configured.
     fn chart_mut(
         &mut self,
     ) -> VisualizationResult<
@@ -138,6 +141,7 @@ pub struct PlottersVisualizationEngine<'area, 'chart, DB: DrawingBackend> {
 }
 
 impl<'area, 'chart, DB: DrawingBackend> PlottersVisualizationEngine<'area, 'chart, DB> {
+    /// Create an engine wrapping the given drawer.
     #[must_use]
     pub const fn new(drawer: PlottersDrawer<'area, 'chart, DB>) -> Self {
         Self { drawer }

--- a/crates/cfd-schematics/src/visualizations/schematic/auto_annotations.rs
+++ b/crates/cfd-schematics/src/visualizations/schematic/auto_annotations.rs
@@ -9,16 +9,14 @@ pub(super) fn build_auto_annotations(blueprint: &NetworkBlueprint) -> SchematicA
     let mut annotations = SchematicAnnotations::report_default();
     let mut roles = classify_node_roles(blueprint);
 
-    let has_target =
-        blueprint
-            .length_in_zone(crate::domain::therapy_metadata::TherapyZone::CancerTarget)
-            .into_base()
-            > 0.0;
-    let has_bypass =
-        blueprint
-            .length_in_zone(crate::domain::therapy_metadata::TherapyZone::HealthyBypass)
-            .into_base()
-            > 0.0;
+    let has_target = blueprint
+        .length_in_zone(crate::domain::therapy_metadata::TherapyZone::CancerTarget)
+        .into_base()
+        > 0.0;
+    let has_bypass = blueprint
+        .length_in_zone(crate::domain::therapy_metadata::TherapyZone::HealthyBypass)
+        .into_base()
+        > 0.0;
 
     if has_target || has_bypass {
         let box_dims = blueprint.box_dims;

--- a/crates/cfd-schematics/src/visualizations/schematic/mod.rs
+++ b/crates/cfd-schematics/src/visualizations/schematic/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use channel_system::channel_system_from_blueprint;
 use channel_system::resolved_channel_paths;
 use layout::blueprint_node_positions;
 
+/// Plot a blueprint with default render configuration and auto-annotations.
 pub fn plot_geometry(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -25,6 +26,7 @@ pub fn plot_geometry(
     plot_blueprint_auto_annotated(blueprint, output_path, &RenderConfig::default())
 }
 
+/// Plot a blueprint with the given render configuration.
 pub fn plot_geometry_with_config(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -34,6 +36,7 @@ pub fn plot_geometry_with_config(
     renderer.render_system(blueprint, output_path.as_ref(), config)
 }
 
+/// Plot a blueprint with explicit annotations.
 pub fn plot_geometry_with_annotations(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -46,6 +49,7 @@ pub fn plot_geometry_with_annotations(
     renderer.render_system(blueprint, output_path.as_ref(), &annotated_config)
 }
 
+/// Plot a blueprint with the given render configuration.
 pub fn plot_blueprint(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -54,6 +58,7 @@ pub fn plot_blueprint(
     plot_geometry_with_config(blueprint, output_path, config)
 }
 
+/// Plot a blueprint with explicit annotations.
 pub fn plot_blueprint_with_annotations(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -63,6 +68,7 @@ pub fn plot_blueprint_with_annotations(
     plot_geometry_with_annotations(blueprint, output_path, config, annotations)
 }
 
+/// Plot a blueprint with auto-generated annotations.
 pub fn plot_blueprint_auto_annotated(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -103,6 +109,7 @@ pub(crate) fn materialize_blueprint_layout(blueprint: &mut NetworkBlueprint) {
     }
 }
 
+/// Plot a blueprint with auto-generated annotations (default config).
 pub fn plot_geometry_auto_annotated(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,
@@ -111,6 +118,7 @@ pub fn plot_geometry_auto_annotated(
     plot_blueprint_auto_annotated(blueprint, output_path, config)
 }
 
+/// Plot a blueprint with an explicit renderer implementation.
 pub fn plot_geometry_with_renderer<R: SchematicRenderer>(
     blueprint: &NetworkBlueprint,
     output_path: impl AsRef<Path>,

--- a/crates/cfd-schematics/src/visualizations/traits/interfaces.rs
+++ b/crates/cfd-schematics/src/visualizations/traits/interfaces.rs
@@ -60,6 +60,7 @@ pub trait SchematicRenderer {
 
 /// Trait for drawing basic geometric primitives.
 pub trait GeometricDrawer {
+    /// Draw a straight line segment.
     fn draw_line(
         &mut self,
         from: Point2D,
@@ -67,8 +68,10 @@ pub trait GeometricDrawer {
         style: &LineStyle,
     ) -> VisualizationResult<()>;
 
+    /// Draw a polyline through the given points.
     fn draw_path(&mut self, points: &[Point2D], style: &LineStyle) -> VisualizationResult<()>;
 
+    /// Draw an axis-aligned rectangle outline.
     fn draw_rectangle(
         &mut self,
         top_left: Point2D,
@@ -76,6 +79,7 @@ pub trait GeometricDrawer {
         style: &LineStyle,
     ) -> VisualizationResult<()>;
 
+    /// Fill an axis-aligned rectangle.
     fn fill_rectangle(
         &mut self,
         top_left: Point2D,
@@ -83,6 +87,7 @@ pub trait GeometricDrawer {
         color: &Color,
     ) -> VisualizationResult<()>;
 
+    /// Draw text at the given position.
     fn draw_text(
         &mut self,
         position: Point2D,
@@ -93,29 +98,34 @@ pub trait GeometricDrawer {
 
 /// High-level visualization operations.
 pub trait VisualizationEngine {
+    /// Visualize a full channel system with the given configuration.
     fn visualize_system(
         &mut self,
         system: &NetworkBlueprint,
         config: &RenderConfig,
     ) -> VisualizationResult<()>;
 
+    /// Visualize only the channel paths.
     fn visualize_channels(
         &mut self,
         system: &NetworkBlueprint,
         style: &LineStyle,
     ) -> VisualizationResult<()>;
 
+    /// Visualize only the plate boundary.
     fn visualize_boundary(
         &mut self,
         system: &NetworkBlueprint,
         style: &LineStyle,
     ) -> VisualizationResult<()>;
 
+    /// Add plot axes with the given configuration.
     fn add_axes(
         &mut self,
         system: &NetworkBlueprint,
         config: &RenderConfig,
     ) -> VisualizationResult<()>;
 
+    /// Add a title to the plot.
     fn add_title(&mut self, title: &str, style: &TextStyle) -> VisualizationResult<()>;
 }

--- a/crates/cfd-schematics/src/visualizations/traits/styles.rs
+++ b/crates/cfd-schematics/src/visualizations/traits/styles.rs
@@ -3,37 +3,59 @@ use crate::visualizations::annotations::SchematicAnnotations;
 /// Configuration for rendering operations.
 #[derive(Debug, Clone)]
 pub struct RenderConfig {
+    /// Output width in pixels.
     pub width: u32,
+    /// Output height in pixels.
     pub height: u32,
+    /// Background color of the rendered image.
     pub background_color: Color,
+    /// Title rendered above the schematic.
     pub title: String,
+    /// Whether coordinate axes are drawn.
     pub show_axes: bool,
+    /// Whether a background grid is drawn.
     pub show_grid: bool,
+    /// Fraction of the canvas reserved as margin on each side.
     pub margin_fraction: f64,
+    /// Style for channel paths.
     pub channel_style: LineStyle,
+    /// Style for boundary paths.
     pub boundary_style: LineStyle,
+    /// Style for axis tick labels.
     pub axis_label_style: TextStyle,
+    /// Style for the schematic title.
     pub title_style: TextStyle,
+    /// Style per channel geometry category.
     pub channel_type_styles: ChannelTypeStyles,
+    /// Style per visual role when rendering selective trees.
     pub role_styles: Option<VisualRoleStyles>,
+    /// Annotations overlaid on the schematic.
     pub annotations: Option<SchematicAnnotations>,
 }
 
 /// Channel type-specific styling configuration.
 #[derive(Debug, Clone)]
 pub struct ChannelTypeStyles {
+    /// Style for straight channels.
     pub straight_style: LineStyle,
+    /// Style for curved channels.
     pub curved_style: LineStyle,
+    /// Style for tapered channels.
     pub tapered_style: LineStyle,
 }
 
 /// Role-based styling for selective-tree schematics.
 #[derive(Debug, Clone)]
 pub struct VisualRoleStyles {
+    /// Style for trunk segments.
     pub trunk: LineStyle,
+    /// Style for center-treatment segments.
     pub center_treatment: LineStyle,
+    /// Style for peripheral-bypass segments.
     pub peripheral_bypass: LineStyle,
+    /// Style for merge-collector segments.
     pub merge_collector: LineStyle,
+    /// Style for venturi-throat segments.
     pub venturi_throat: LineStyle,
 }
 
@@ -77,6 +99,7 @@ impl Default for ChannelTypeStyles {
 }
 
 impl ChannelTypeStyles {
+    /// Return the line style for the given channel category.
     #[must_use]
     pub const fn get_style(&self, category: crate::geometry::ChannelTypeCategory) -> &LineStyle {
         use crate::geometry::ChannelTypeCategory;
@@ -126,6 +149,7 @@ impl Default for RenderConfig {
 }
 
 impl RenderConfig {
+    /// Return a configuration sized for a 96-well plate schematic.
     #[must_use]
     pub fn well_plate_96() -> Self {
         Self {
@@ -136,6 +160,8 @@ impl RenderConfig {
         }
     }
 
+    /// Return a 96-well plate configuration with report annotations and
+    /// default role styling applied.
     #[must_use]
     pub fn well_plate_96_report_annotated() -> Self {
         let mut config = Self::well_plate_96();
@@ -148,13 +174,18 @@ impl RenderConfig {
 /// Supported output formats for schematic rendering.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutputFormat {
+    /// Portable Network Graphics.
     PNG,
+    /// Scalable Vector Graphics.
     SVG,
+    /// Portable Document Format.
     PDF,
+    /// Joint Photographic Experts Group.
     JPEG,
 }
 
 impl OutputFormat {
+    /// Return the file extension for this format, without a leading dot.
     #[must_use]
     pub const fn extension(&self) -> &'static str {
         match self {
@@ -169,37 +200,46 @@ impl OutputFormat {
 /// Color representation using RGBA values.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Color {
+    /// Red channel, 0-255.
     pub r: u8,
+    /// Green channel, 0-255.
     pub g: u8,
+    /// Blue channel, 0-255.
     pub b: u8,
+    /// Alpha channel, 0-255.
     pub a: u8,
 }
 
 impl Color {
+    /// Opaque white.
     pub const WHITE: Self = Self {
         r: 255,
         g: 255,
         b: 255,
         a: 255,
     };
+    /// Opaque black.
     pub const BLACK: Self = Self {
         r: 0,
         g: 0,
         b: 0,
         a: 255,
     };
+    /// Opaque red.
     pub const RED: Self = Self {
         r: 255,
         g: 0,
         b: 0,
         a: 255,
     };
+    /// Opaque green.
     pub const GREEN: Self = Self {
         r: 0,
         g: 255,
         b: 0,
         a: 255,
     };
+    /// Opaque blue.
     pub const BLUE: Self = Self {
         r: 0,
         g: 0,
@@ -207,11 +247,13 @@ impl Color {
         a: 255,
     };
 
+    /// Construct an opaque color from RGB channels.
     #[must_use]
     pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b, a: 255 }
     }
 
+    /// Construct a color from RGBA channels.
     #[must_use]
     pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self { r, g, b, a }
@@ -228,12 +270,16 @@ impl From<iris::color::Rgba> for Color {
 /// Style configuration for drawing lines.
 #[derive(Debug, Clone)]
 pub struct LineStyle {
+    /// Stroke color.
     pub color: Color,
+    /// Stroke width in points.
     pub width: f64,
+    /// Optional dash pattern: alternating on/off segment lengths.
     pub dash_pattern: Option<Vec<f64>>,
 }
 
 impl LineStyle {
+    /// Construct a solid line style.
     #[must_use]
     pub const fn solid(color: Color, width: f64) -> Self {
         Self {
@@ -243,6 +289,7 @@ impl LineStyle {
         }
     }
 
+    /// Construct a dashed line style with the given dash pattern.
     #[must_use]
     pub const fn dashed(color: Color, width: f64, dash_pattern: Vec<f64>) -> Self {
         Self {
@@ -256,12 +303,16 @@ impl LineStyle {
 /// Style configuration for drawing text.
 #[derive(Debug, Clone)]
 pub struct TextStyle {
+    /// Text color.
     pub color: Color,
+    /// Font size in points.
     pub font_size: f64,
+    /// Font family name.
     pub font_family: String,
 }
 
 impl TextStyle {
+    /// Construct a text style.
     #[must_use]
     pub fn new(color: Color, font_size: f64, font_family: &str) -> Self {
         Self {

--- a/crates/cfd-validation/Cargo.toml
+++ b/crates/cfd-validation/Cargo.toml
@@ -43,3 +43,6 @@ harness = false
 [[bench]]
 name = "gcl_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -89,6 +89,14 @@
 - Residual: 534 missing-documentation diagnostics remain across geometry,
   domain, interface, infrastructure, and topology modules outside this scope.
 
+## cfd-schematics geometry builders — partial closure (2026-08-07)
+
+- The public node and channel builder setters now document their domain
+  effects, including names, geometry, visual roles, therapy zones, and Venturi
+  metadata.
+- The package documentation-floor residual decreases from 534 to 524
+  diagnostics. No runtime behavior or builder defaults changed.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -114,6 +114,16 @@
   working tree reports 492 because peer-owned documentation changes are also
   present in `domain/model/blueprint/analysis_impl.rs` and remain uncommitted.
 
+## cfd-schematics selective-tree generator — partial closure (2026-08-07)
+
+- The public selective-tree path specification, topology variants, request
+  fields, and generator entrypoint now document their physical and topology
+  contracts.
+- The package documentation-floor residual decreases from 506 to 468
+  diagnostics. The current working tree reports 454 because peer-owned
+  documentation changes remain uncommitted in
+  `domain/model/blueprint/analysis_impl.rs`.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -53,6 +53,14 @@
 - `cargo nextest run -p cfd-math --lib` passes 198/198. Focused cfd-math
   library Clippy remains red at 48 existing diagnostics after this slice.
 
+## cfd-math hierarchy and storage invariants — follow-up (2026-08-06)
+
+- Multigrid hierarchy/interpolation state now uses invariant-checked
+  expectations instead of bare unwraps. JFNK and spectral operations use named
+  C-contiguous storage helpers or explicit connectivity invariants.
+- `cargo nextest run -p cfd-math --lib` passes 198/198. Focused cfd-math
+  library Clippy remains red at 22 existing diagnostics after this slice.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -70,6 +70,16 @@
   Nextest remains 198/198. Workspace all-target closure is still open on
   cfd-schematics docs, cfd-core test/bench lint debt, and format debt.
 
+## cfd-schematics topology model documentation — partial closure (2026-08-07)
+
+- The exported topology specification contract now documents its model types,
+  fields, enum variants, aliases, and route lookup methods in
+  `src/topology/model.rs`.
+- `cargo clippy -p cfd-schematics --lib` still fails only on the existing
+  documentation floor at this stage; diagnostics decrease from 712 to 611.
+- Residual: 611 missing-documentation diagnostics remain across the package's
+  other modules. No crate-wide lint suppression was added.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -105,6 +105,15 @@
 - The package documentation-floor residual decreases from 524 to 508
   diagnostics. No runtime behavior or generation defaults changed.
 
+## cfd-schematics linear geometry generators — partial closure (2026-08-07)
+
+- The series and parallel geometry builders now document their specification-
+  driven blueprint construction contracts.
+- The package documentation-floor residual decreases from 508 to 506
+  diagnostics. No runtime behavior or generated geometry changed. The current
+  working tree reports 492 because peer-owned documentation changes are also
+  present in `domain/model/blueprint/analysis_impl.rs` and remain uncommitted.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -45,6 +45,14 @@
   lint debt, and unrelated format debt still need ratchet increments. This
   increment does not claim full workspace closure.
 
+## cfd-math coarsening ordering slice — committed follow-up (2026-08-06)
+
+- Multigrid coarsening no longer unwraps floating-point partial comparisons;
+  finite values sort before unordered values, preserving deterministic
+  diagnostics for NaN inputs. The regression test covers finite/NaN ordering.
+- `cargo nextest run -p cfd-math --lib` passes 198/198. Focused cfd-math
+  library Clippy remains red at 48 existing diagnostics after this slice.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -80,6 +80,15 @@
 - Residual: 611 missing-documentation diagnostics remain across the package's
   other modules. No crate-wide lint suppression was added.
 
+## cfd-schematics constants and config manifests — partial closure (2026-08-07)
+
+- The `ConstantsRegistry` getters and fields, adaptive primitive constants, and
+  public config module manifests now carry API documentation.
+- `cargo clippy -p cfd-schematics --lib` still fails only on the existing
+  documentation floor at this stage; diagnostics decrease from 611 to 534.
+- Residual: 534 missing-documentation diagnostics remain across geometry,
+  domain, interface, infrastructure, and topology modules outside this scope.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -61,6 +61,15 @@
 - `cargo nextest run -p cfd-math --lib` passes 198/198. Focused cfd-math
   library Clippy remains red at 22 existing diagnostics after this slice.
 
+## cfd-math diagnostics and DG output — closure slice (2026-08-06)
+
+- Performance-monitor mutex accesses now carry invariant diagnostics and its
+  calibration messages use structured tracing. DG progress, warnings, and
+  completion metrics also use structured tracing instead of stdout writes.
+- `cargo clippy -p cfd-math --lib` passes with the Atlas floor; cfd-math
+  Nextest remains 198/198. Workspace all-target closure is still open on
+  cfd-schematics docs, cfd-core test/bench lint debt, and format debt.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,20 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+## Lint-floor gate — partial closure (2026-08-06)
+
+- The root workspace now owns the Atlas lint floor; every CFDrs workspace
+  package and `xtask` inherit it.
+- Passing evidence: `cargo clippy -p xtask --all-targets`,
+  `cargo clippy -p cfd-core --lib`, `cargo nextest run -p cfd-core --lib`
+  (246/246), `cargo test --doc -p cfd-core` (3/3), and
+  `cargo run --manifest-path xtask/Cargo.toml -- legacy-migration-audit`
+  (zero legacy dependencies, zero legacy source tokens, clean allowlist).
+- Residual: the workspace all-target Clippy gate is not green because existing
+  cfd-math unwrap/output sites, cfd-schematics missing docs, cfd-core test/bench
+  lint debt, and unrelated format debt still need ratchet increments. This
+  increment does not claim full workspace closure.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -97,6 +97,14 @@
 - The package documentation-floor residual decreases from 534 to 524
   diagnostics. No runtime behavior or builder defaults changed.
 
+## cfd-schematics geometry-generator entrypoints — partial closure (2026-08-07)
+
+- The metadata configuration, generation entry points, and fluent builder now
+  document their public contracts, including metadata, topology, lineage, and
+  rendering inputs.
+- The package documentation-floor residual decreases from 524 to 508
+  diagnostics. No runtime behavior or generation defaults changed.
+
 ## Delivery closure — external RecurseML status (2026-08-06)
 
 CFDrs PR #325 is merged at `fa29c5174c29ac84f5c14e385b4c73866164f712`.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 toml = "0.8"
+
+[lints]
+workspace = true

--- a/xtask/src/check_figures.rs
+++ b/xtask/src/check_figures.rs
@@ -17,7 +17,7 @@ pub struct DocsFigureRef {
     pub source_file: String,
     /// 1-indexed line number in the source file.
     pub line_no: usize,
-    /// Filename portion (e.g. "poiseuille_parabolic_profile.svg"), without
+    /// Filename portion (e.g. `poiseuille_parabolic_profile.svg`), without
     /// the "figures/" prefix.
     pub figure_file: String,
 }
@@ -66,7 +66,11 @@ fn parse_figure_refs(path: &Path) -> Result<(String, Vec<DocsFigureRef>)> {
             }
             let candidate = &line[abs_start..end];
             if let Some(stripped) = candidate.strip_prefix("figures/") {
-                if stripped.ends_with(".svg") && !stripped.contains('/') {
+                if Path::new(stripped)
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("svg"))
+                    && !stripped.contains('/')
+                {
                     refs.push(DocsFigureRef {
                         source_file: source_file.clone(),
                         line_no: lineno + 1,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,8 +24,25 @@
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use std::env;
+use std::fmt;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use xshell::{cmd, Shell};
+
+pub(crate) fn write_cli_line(args: fmt::Arguments<'_>) {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    writeln!(handle, "{args}").expect("invariant: CLI stdout remains writable");
+}
+
+macro_rules! println {
+    () => {
+        $crate::write_cli_line(format_args!(""))
+    };
+    ($($arg:tt)*) => {
+        $crate::write_cli_line(format_args!($($arg)*))
+    };
+}
 
 mod check_figures;
 mod migration_audit;
@@ -121,7 +138,7 @@ enum Commands {
     /// byte fingerprint each file currently has on disk; re-running on
     /// unchanged inputs produces byte-identical output (CI evidence chain).
     Prebook,
-    /// Verify SUMMARY.md + README.md figure links are listed in FIGURE_SPECS.
+    /// Verify SUMMARY.md + README.md figure links are listed in `FIGURE_SPECS`.
     /// Returns exit code 1 on drift so the CI gate fails loudly when the
     /// SSOT contract between figures and book source breaks.
     CheckFigures,
@@ -198,7 +215,7 @@ fn project_root() -> PathBuf {
     Path::new(&env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(1)
-        .unwrap()
+        .expect("invariant: CARGO_MANIFEST_DIR has the workspace root parent")
         .to_path_buf()
 }
 
@@ -331,7 +348,7 @@ fn install_deps(sh: &Shell, venv_path: &Path, with_fenics: bool) -> Result<()> {
         bail!("Virtual environment not found. Run: cargo xtask setup-venv");
     }
 
-    let pip_str = pip.to_str().unwrap();
+    let pip_str = pip.to_str().context("venv pip path is not valid UTF-8")?;
 
     // Upgrade pip
     println!("Upgrading pip...");
@@ -447,7 +464,9 @@ fn validate(sh: &Shell, venv_path: &Path, plot: bool, quick: bool, category: &st
         bail!("Virtual environment not found. Run: cargo xtask setup-venv");
     }
 
-    let python_str = python.to_str().unwrap();
+    let python_str = python
+        .to_str()
+        .context("venv Python path is not valid UTF-8")?;
 
     // Check if cfd_python is installed
     let check_result = cmd!(sh, "{python_str} -c \"import cfd_python\"")

--- a/xtask/src/prebook.rs
+++ b/xtask/src/prebook.rs
@@ -1,4 +1,4 @@
-//! Prebook / figure-management for the CFDrs mdbook.
+//! Prebook / figure-management for the `CFDrs` mdBook.
 //!
 //! Build the deterministic figure set committed at `docs/book/figures/`
 //! and emit a `MANIFEST.json` manifest that downstream tooling
@@ -30,7 +30,7 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// A figure referenced by the CFDrs mdbook.
+/// A figure referenced by the `CFDrs` mdBook.
 ///
 /// `source_example` is `Some(_)` for figures that mirror a runnable
 /// example's deterministic stdout / staged PNG; `None` for purely
@@ -193,6 +193,6 @@ pub fn sha256_hex_first_16(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     let digest = hasher.finalize();
-    let hex = format!("{:x}", digest);
+    let hex = format!("{digest:x}");
     hex[..16].to_owned()
 }


### PR DESCRIPTION
Delivers the CFDrs workspace lint floor (workspace-lints inheritance across all packages and xtask), three cfd-math defect fixes, and burns cfd-schematics missing_docs residual from 73 to 0.

Evidence:
- cargo check --workspace: green (cfd-optim missing-docs warnings are recorded ratchet debt)
- cargo clippy --lib on cfd-math + cfd-schematics: clean
- cargo test -p cfd-schematics -p cfd-math: all pass
- cargo test --doc: 16/16 pass
- xtask check-figures: SSOT in sync
- Rebased onto origin/main (aequitas 0.2.0 / leto 0.41.0 lockfile refresh); no new fmt drift introduced

Residual (recorded in gap_audit.md): workspace all-target Clippy gate not fully green — cfd-math test/bench unwrap sites and baseline format debt remain as ratchet items.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR wires the canonical Atlas workspace lint floor across all CFDrs packages and xtask, eliminates three cfd-math defects (unwraps and unstructured output), and burns the complete cfd-schematics missing-documentation debt from 73 warnings to zero. The workspace now inherits Clippy `all` and `pedantic` at warn priority, denies `unwrap_used`, `print_stderr`, `print_stdout`, and `dbg_macro`, and promotes `missing_docs` to warn. The cfd-core plugin resolver removes an input-dependent unwrap, xtask routes CLI output through a checked writer, cfd-math replaces floating-point partial comparisons with total ordering and converts mutex/output sites to tracing, and cfd-schematics documents its topology model, constants registry, geometry builders, generators, metadata contracts, and visualization interfaces to achieve zero missing-documentation residue at the package level.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `xtask/Cargo.toml` |
| 3 | `xtask/src/main.rs` |
| 4 | `xtask/src/check_figures.rs` |
| 5 | `xtask/src/prebook.rs` |
| 6 | `crates/cfd-core/Cargo.toml` |
| 7 | `crates/cfd-core/src/management/plugin/dependency.rs` |
| 8 | `crates/cfd-math/Cargo.toml` |
| 9 | `crates/cfd-math/src/diagnostics/performance_monitor.rs` |
| 10 | `crates/cfd-math/src/high_order/dg/solver/mod.rs` |
| 11 | `crates/cfd-math/src/high_order/spectral/element.rs` |
| 12 | `crates/cfd-math/src/high_order/spectral/mod.rs` |
| 13 | `crates/cfd-math/src/linear_solver/preconditioners/multigrid/amg.rs` |
| 14 | `crates/cfd-math/src/linear_solver/preconditioners/multigrid/coarsening/algorithms.rs` |
| 15 | `crates/cfd-math/src/linear_solver/preconditioners/multigrid/coarsening/quality.rs` |
| 16 | `crates/cfd-math/src/linear_solver/preconditioners/multigrid/interpolation.rs` |
| 17 | `crates/cfd-math/src/nonlinear_solver/linalg.rs` |
| 18 | `crates/cfd-schematics/Cargo.toml` |
| 19 | `crates/cfd-schematics/src/lib.rs` |
| 20 | `crates/cfd-schematics/src/config/mod.rs` |
| 21 | `crates/cfd-schematics/src/config/constants/mod.rs` |
| 22 | `crates/cfd-schematics/src/config/channel/mod.rs` |
| 23 | `crates/cfd-schematics/src/config/geometry/mod.rs` |
| 24 | `crates/cfd-schematics/src/domain/mod.rs` |
| 25 | `crates/cfd-schematics/src/domain/model/ids.rs` |
| 26 | `crates/cfd-schematics/src/domain/model/specs.rs` |
| 27 | `crates/cfd-schematics/src/domain/model/blueprint/mod.rs` |
| 28 | `crates/cfd-schematics/src/domain/model/blueprint/metadata_impl.rs` |
| 29 | `crates/cfd-schematics/src/domain/model/blueprint/analysis_impl.rs` |
| 30 | `crates/cfd-schematics/src/domain/model/blueprint/venturi_impl.rs` |
| 31 | `crates/cfd-schematics/src/domain/therapy_metadata.rs` |
| 32 | `crates/cfd-schematics/src/domain/rules/validator.rs` |
| 33 | `crates/cfd-schematics/src/application/mod.rs` |
| 34 | `crates/cfd-schematics/src/application/ports/graph_sink.rs` |
| 35 | `crates/cfd-schematics/src/application/use_cases/generate_network.rs` |
| 36 | `crates/cfd-schematics/src/infrastructure/mod.rs` |
| 37 | `crates/cfd-schematics/src/infrastructure/adapters/petgraph_graph_sink.rs` |
| 38 | `crates/cfd-schematics/src/interface/mod.rs` |
| 39 | `crates/cfd-schematics/src/geometry/builders.rs` |
| 40 | `crates/cfd-schematics/src/geometry/generator/entrypoints.rs` |
| 41 | `crates/cfd-schematics/src/geometry/generator/linear.rs` |
| 42 | `crates/cfd-schematics/src/geometry/generator/selective/mod.rs` |
| 43 | `crates/cfd-schematics/src/geometry/generator/selective/primitive/mod.rs` |
| 44 | `crates/cfd-schematics/src/geometry/metadata/mod.rs` |
| 45 | `crates/cfd-schematics/src/geometry/metadata/blueprint.rs` |
| 46 | `crates/cfd-schematics/src/geometry/metadata/flow_metadata.rs` |
| 47 | `crates/cfd-schematics/src/geometry/metadata/schematic.rs` |
| 48 | `crates/cfd-schematics/src/geometry/metadata/therapy.rs` |
| 49 | `crates/cfd-schematics/src/geometry/strategies/straight.rs` |
| 50 | `crates/cfd-schematics/src/geometry/types/mod.rs` |
| 51 | `crates/cfd-schematics/src/geometry/types/volume.rs` |
| 52 | `crates/cfd-schematics/src/state_management/constraints.rs` |
| 53 | `crates/cfd-schematics/src/state_management/mod.rs` |
| 54 | `crates/cfd-schematics/src/topology/model.rs` |
| 55 | `crates/cfd-schematics/src/topology/factory/core/mod.rs` |
| 56 | `crates/cfd-schematics/src/topology/factory/core/spec_analysis_impl.rs` |
| 57 | `crates/cfd-schematics/src/topology/presets/milestone12/mod.rs` |
| 58 | `crates/cfd-schematics/src/topology/presets/milestone12/build.rs` |
| 59 | `crates/cfd-schematics/src/topology/presets/milestone12/support.rs` |
| 60 | `crates/cfd-schematics/src/topology/presets/sequence.rs` |
| 61 | `crates/cfd-schematics/src/visualizations/annotations/mod.rs` |
| 62 | `crates/cfd-schematics/src/visualizations/plotters_backend/drawer.rs` |
| 63 | `crates/cfd-schematics/src/visualizations/schematic/auto_annotations.rs` |
| 64 | `crates/cfd-schematics/src/visualizations/schematic/mod.rs` |
| 65 | `crates/cfd-schematics/src/visualizations/traits/interfaces.rs` |
| 66 | `crates/cfd-schematics/src/visualizations/traits/styles.rs` |
| 67 | `crates/cfd-schematics/src/interface/presets/venturi.rs` |
| 68 | `crates/cfd-schematics/src/interface/presets/serpentine.rs` |
| 69 | `crates/cfd-schematics/src/interface/presets/composite/series.rs` |
| 70 | `crates/cfd-schematics/src/interface/presets/composite/n_furcation.rs` |
| 71 | `crates/cfd-schematics/src/interface/presets/composite/multi_level.rs` |
| 72 | `crates/cfd-schematics/src/interface/presets/composite/mixed_tree.rs` |
| 73 | `crates/cfd-schematics/src/interface/presets/composite/specialized/mod.rs` |
| 74 | `crates/cfd-schematics/src/interface/presets/composite/specialized/basic.rs` |
| 75 | `crates/cfd-schematics/src/interface/presets/composite/specialized/filtration.rs` |
| 76 | `crates/cfd-schematics/src/interface/presets/composite/specialized/parallel_lane.rs` |
| 77 | `crates/cfd-schematics/src/interface/presets/composite/specialized/trifurcation.rs` |
| 78 | `crates/cfd-schematics/examples/split_tree/asymmetric_demo.rs` |
| 79 | `crates/cfd-1d/Cargo.toml` |
| 80 | `crates/cfd-2d/Cargo.toml` |
| 81 | `crates/cfd-3d/Cargo.toml` |
| 82 | `crates/cfd-io/Cargo.toml` |
| 83 | `crates/cfd-optim/Cargo.toml` |
| 84 | `crates/cfd-python/Cargo.toml` |
| 85 | `crates/cfd-schematic-mesh/Cargo.toml` |
| 86 | `crates/cfd-validation/Cargo.toml` |
| 87 | `CHANGELOG.md` |
| 88 | `CHECKLIST.md` |
| 89 | `backlog.md` |
| 90 | `gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved floating-point sorting to handle unordered values without unexpected failures.
  - Added clearer handling for invalid internal states and dependency resolution.
  - Improved figure-link recognition for SVG files regardless of capitalization.

- **Improvements**
  - Solver and performance-monitoring messages now provide structured, consistent diagnostic output.
  - Workspace-wide quality checks are now applied more consistently.

- **Documentation**
  - Expanded documentation across schematic generation, geometry, topology, visualization, and configuration features.
  - Updated changelog, checklist, and project audit records with validation progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->