### PR TITLE
build(cfd): Adopt Iris package identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
 hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
 tyche-core = { version = "0.1.0", git = "https://github.com/ryancinsight/tyche" }
 eunomia = { version = "0.8.0", git = "https://github.com/ryancinsight/eunomia", default-features = false, features = ["std"] }
-iris = { version = "0.1.0", git = "https://github.com/ryancinsight/iris" }
+iris = { package = "iris-viz", version = "0.1.0", git = "https://github.com/ryancinsight/iris" }
 approx = "0.5"
 bytemuck = "1.14"
 rand = "0.8"


### PR DESCRIPTION
Update the CFDrs workspace dependency to request Iris's published package name iris-viz while preserving the import name iris. This one-file consumer-contract fix is based on current main and excludes the existing dirty provider-migration worktree.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Updates the workspace dependency for the `iris` package to explicitly reference the published package name `iris-viz` while maintaining the import name as `iris`. This is a simple dependency configuration update to align with the Iris package's published identity.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workspace dependency mapping for improved package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->