### PR TITLE
build(deps): Pin Hermes SIMD 0.6 source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ consus-io = { version = "0.1.0", git = "https://github.com/ryancinsight/consus.g
 ritk-vtk = { version = "0.2.0", git = "https://github.com/ryancinsight/ritk" }
 # hermes: SIMD abstraction workspace. Provides generic runtime-dispatched
 # SIMD operations (dot, elementwise, reductions) over f32/f64/i32.
-hermes-simd = { version = "0.6.0", git = "https://github.com/ryancinsight/hermes.git" }
+hermes-simd = { version = "0.6.0", git = "https://github.com/ryancinsight/hermes.git", rev = "03e5e1759f25e694d521a2b26eb116698931a85c" }
 # moirai: unified concurrency runtime replacing tokio + rayon. Moirai's parallel,
 # Mnemosyne, and Melinoe surfaces are enabled for the CFDrs workspace.
 moirai = { version = "0.5.0", git = "https://github.com/ryancinsight/Moirai", package = "moirai-runtime", default-features = false, features = ["parallel", "mnemosyne-memory", "melinoe"] }


### PR DESCRIPTION
Rebased onto current `main` at `11fe470e26f4f41e40e5e8baace4b4d265d3f9b9`.

## Scope

- Keeps one atomic Hermes SIMD 0.6 overlay-unification change.
- Pins `hermes-simd = 0.6.0` to provider revision `03e5e1759f25e694d521a2b26eb116698931a85c`.
- Retains current `main`'s `Cargo.lock`; its Hermes SIMD 0.6 packages already resolve to that revision.
- Removes the stale Iris-only commit. Current `main` already contains the Iris identity change through #332, so no separate Iris integration change is required.
- The delivered diff is one file and one line; it contains no Iris references.

## Verification at head `3b2fffaa9c9ae3ad2ada790993cc73b86cfe8ec2`

- `git diff origin/main HEAD --check`: pass.
- `cargo metadata --locked --no-deps`: pass.
- Static `Cargo.lock` inspection: `hermes-simd`, `hermes-simd-core`, `hermes-simd-intrinsics`, `hermes-simd-macros`, and `hermes-simd-types` are all 0.6.0 at revision `03e5e1759f25e694d521a2b26eb116698931a85c`.
- Hosted CI run [31622421938](https://github.com/ryancinsight/CFDrs/actions/runs/31622421938): success. Job `Check book figures SSOT`: success.
- `cargo check -p cfd-math --locked`: blocked before compilation because the shared Atlas overlay attempts to rewrite `Cargo.lock`; the exact unrelated mismatch is required/locked `tyche-core 0.2.0` versus local overlay `0.1.0`.
- `cargo fmt --all -- --check`: not clean because of pre-existing formatting drift in unrelated files; no formatting changes were included.
- No Tyche changes are included in this PR.