### PR TITLE
build(deps): Advance leto/apollo/hephaestus/moirai to cascade versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -114,7 +114,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apollo-fft"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -130,7 +130,7 @@ dependencies = [
  "rand 0.10.2",
  "rustc-hash 2.1.3",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-leto-interop"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "leto",
 ]
@@ -162,7 +162,7 @@ dependencies = [
  "mnemosyne-memory",
  "moirai-runtime",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -306,9 +306,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -318,13 +318,13 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -338,13 +338,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -367,9 +367,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -390,7 +390,7 @@ dependencies = [
  "cfd-schematics",
  "criterion",
  "eunomia",
- "iris",
+ "iris-viz",
  "leto",
  "leto-ops",
  "petgraph",
@@ -419,7 +419,7 @@ dependencies = [
  "criterion",
  "eunomia",
  "gaia",
- "iris",
+ "iris-viz",
  "leto",
  "leto-ops",
  "moirai-runtime",
@@ -602,7 +602,7 @@ version = "0.3.0"
 dependencies = [
  "aequitas",
  "cfd-core",
- "iris",
+ "iris-viz",
  "petgraph",
  "plotters",
  "serde",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-autograd"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -765,12 +765,12 @@ dependencies = [
  "coeus-tensor",
  "leto-ops",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "coeus-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -778,12 +778,13 @@ dependencies = [
  "mnemosyne-memory",
  "moirai-runtime",
  "smallvec",
- "thiserror 2.0.19",
+ "themis-topology",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "coeus-leto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "coeus-core",
  "leto",
@@ -792,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-nn"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -800,12 +801,12 @@ dependencies = [
  "coeus-ops",
  "coeus-tensor",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "coeus-ops"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -817,12 +818,12 @@ dependencies = [
  "leto-ops",
  "melinoe",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "coeus-optim"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -830,29 +831,29 @@ dependencies = [
  "coeus-tensor",
  "leto",
  "leto-ops",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "coeus-sparse"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "coeus-tensor"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytemuck",
  "coeus-core",
  "coeus-leto",
  "rkyv",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1198,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -1307,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1322,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1332,15 +1333,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1349,38 +1350,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1479,7 +1480,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1534,19 +1535,19 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hephaestus-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aequitas",
  "bytemuck",
  "eunomia",
  "leto",
  "themis-topology",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "hephaestus-wgpu"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1565,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1577,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1588,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-intrinsics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1596,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1605,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-simd-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1675,7 +1676,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "iris"
+name = "iris-viz"
 version = "0.1.0"
 
 [[package]]
@@ -1728,9 +1729,9 @@ checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1745,19 +1746,19 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leto"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "aequitas",
  "bytemuck",
  "eunomia",
  "mnemosyne-memory",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "leto-ops"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1766,7 +1767,7 @@ dependencies = [
  "moirai-runtime",
  "serde",
  "themis-topology",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1868,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-arena"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
@@ -1889,7 +1890,7 @@ version = "0.2.0"
 
 [[package]]
 name = "mnemosyne-decay"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1898,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-heap"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1911,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-local"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1925,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "mnemosyne-memory"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
@@ -1952,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-async"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures",
  "libc",
@@ -1967,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-async-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1976,17 +1977,18 @@ dependencies = [
 
 [[package]]
 name = "moirai-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "libc",
  "mnemosyne-memory",
  "moirai-utils",
+ "themis-topology",
 ]
 
 [[package]]
 name = "moirai-executor"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -1994,11 +1996,12 @@ dependencies = [
  "moirai-pal",
  "moirai-scheduler",
  "moirai-utils",
+ "themis-topology",
 ]
 
 [[package]]
 name = "moirai-gpu"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "mnemosyne-memory-core",
  "moirai-core",
@@ -2008,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-iter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures",
  "libc",
@@ -2023,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-pal"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "js-sys",
  "libc",
@@ -2037,16 +2040,17 @@ dependencies = [
 
 [[package]]
 name = "moirai-parallel"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "melinoe",
  "moirai-core",
  "moirai-executor",
+ "themis-topology",
 ]
 
 [[package]]
 name = "moirai-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2063,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-scheduler"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "mnemosyne-memory",
  "moirai-core",
@@ -2074,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-sync"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libc",
  "moirai-core",
@@ -2083,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-transport"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "moirai-core",
@@ -2093,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "moirai-utils"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "munge"
@@ -2137,7 +2141,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-ident",
 ]
 
@@ -2150,7 +2154,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
  "rustc-hash 1.1.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2481,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2553,29 +2557,29 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc153f5fd745cc038b5eed86622125969f8a39834a57bc96beaaf2512b1da729"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -2587,18 +2591,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb77d9aa6d647507b55c69ee714d266d84c526c78ff0bc6dd8757f58591e64d1"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3160087aa5733bce7d9a729f8c55f85a2a53b74742a09613178eeebff0722253"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2606,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f9d455db760a9a0b0ddeaac25f1390b8a36ba73dfbda9f127cac6fc340d4d5"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2618,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e343bcec300ff262f5806a33a4e51b6d097a8a46435f512fcb83e95592581625"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2657,9 +2661,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rancor"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
 dependencies = [
  "ptr_meta",
 ]
@@ -2810,7 +2814,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2879,7 +2883,7 @@ version = "0.1.0"
 dependencies = [
  "leto",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2890,7 +2894,7 @@ dependencies = [
  "coeus-core",
  "consus-io",
  "gaia",
- "iris",
+ "iris-viz",
  "ritk-image",
  "ritk-spatial",
  "serde_json",
@@ -2903,9 +2907,9 @@ version = "0.1.0"
 
 [[package]]
 name = "rkyv"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -2922,13 +2926,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3217,11 +3221,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3237,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3495,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3508,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3518,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3528,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3541,18 +3545,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3611,7 +3615,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
@@ -3674,7 +3678,7 @@ dependencies = [
  "renderdoc-sys",
  "smallvec",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wgpu-naga-bridge",
  "wgpu-types",
  "windows 0.62.2",
@@ -4058,18 +4062,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4111,6 +4115,14 @@ dependencies = [
 ]
 
 [[patch.unused]]
+name = "consus-npy"
+version = "0.1.0"
+
+[[patch.unused]]
+name = "consus-onnx"
+version = "0.1.0"
+
+[[patch.unused]]
 name = "ritk-core"
 version = "0.9.0"
 
@@ -4127,6 +4139,10 @@ name = "ritk-registration"
 version = "0.53.0"
 
 [[patch.unused]]
+name = "apollo-sht"
+version = "0.7.0"
+
+[[patch.unused]]
 name = "asclepius"
 version = "0.1.0"
 
@@ -4135,37 +4151,21 @@ name = "asclepius-coeus"
 version = "0.1.0"
 
 [[patch.unused]]
-name = "hephaestus-cuda"
-version = "0.18.0"
-
-[[patch.unused]]
-name = "hephaestus-metal"
-version = "0.18.0"
-
-[[patch.unused]]
-name = "hephaestus-rocm"
-version = "0.18.0"
-
-[[patch.unused]]
-name = "apollo-sht"
-version = "0.7.0"
+name = "moirai-http"
+version = "0.5.0"
 
 [[patch.unused]]
 name = "horae"
 version = "0.1.0"
 
 [[patch.unused]]
-name = "consus-npy"
-version = "0.1.0"
+name = "hephaestus-cuda"
+version = "0.19.0"
 
 [[patch.unused]]
-name = "consus-onnx"
-version = "0.1.0"
+name = "hephaestus-metal"
+version = "0.19.0"
 
 [[patch.unused]]
-name = "consus-zarr"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "moirai-http"
-version = "0.4.0"
+name = "hephaestus-rocm"
+version = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ cfd-core = { path = "crates/cfd-core", default-features = false }
 cfd-math = { path = "crates/cfd-math" }
 cfd-io = { path = "crates/cfd-io" }
 # Editable working copies live at the atlas root under repos/{gaia,apollo,consus};
-cfd-mesh = { version = "0.3.0", git = "https://github.com/ryancinsight/gaia", package = "gaia" }
+cfd-mesh = { version = "0.4.0", git = "https://github.com/ryancinsight/gaia", package = "gaia-mesh" }
 apollo-fft = { version = "0.26.0", git = "https://github.com/ryancinsight/apollo" }
 apollo-nufft = { version = "0.7.0", git = "https://github.com/ryancinsight/apollo" }
 leto = { version = "0.42.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,10 @@ cfd-math = { path = "crates/cfd-math" }
 cfd-io = { path = "crates/cfd-io" }
 # Editable working copies live at the atlas root under repos/{gaia,apollo,consus};
 cfd-mesh = { version = "0.3.0", git = "https://github.com/ryancinsight/gaia", package = "gaia" }
-apollo-fft = { version = "0.25.0", git = "https://github.com/ryancinsight/apollo" }
+apollo-fft = { version = "0.26.0", git = "https://github.com/ryancinsight/apollo" }
 apollo-nufft = { version = "0.7.0", git = "https://github.com/ryancinsight/apollo" }
-leto = { version = "0.41.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
-leto-ops = { version = "0.41.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
+leto = { version = "0.42.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
+leto-ops = { version = "0.42.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
 # consus: pure-Rust scientific storage formats (HDF5 etc.). Consumed by cfd-io
 # behind the `hdf5` feature for real HDF5 output.
 consus-core = { version = "0.1.0", git = "https://github.com/ryancinsight/consus.git", default-features = false }
@@ -90,10 +90,10 @@ consus-io = { version = "0.1.0", git = "https://github.com/ryancinsight/consus.g
 ritk-vtk = { version = "0.1.0", git = "https://github.com/ryancinsight/ritk" }
 # hermes: SIMD abstraction workspace. Provides generic runtime-dispatched
 # SIMD operations (dot, elementwise, reductions) over f32/f64/i32.
-hermes-simd = { version = "0.5.0", git = "https://github.com/ryancinsight/hermes.git" }
+hermes-simd = { version = "0.6.0", git = "https://github.com/ryancinsight/hermes.git" }
 # moirai: unified concurrency runtime replacing tokio + rayon. Moirai's parallel,
 # Mnemosyne, and Melinoe surfaces are enabled for the CFDrs workspace.
-moirai = { version = "0.4.0", git = "https://github.com/ryancinsight/Moirai", package = "moirai-runtime", default-features = false, features = ["parallel", "mnemosyne-memory", "melinoe"] }
+moirai = { version = "0.5.0", git = "https://github.com/ryancinsight/Moirai", package = "moirai-runtime", default-features = false, features = ["parallel", "mnemosyne-memory", "melinoe"] }
 # themis: typed NUMA/topology placement law (consumed by the compute layer for
 # first-touch buffer locality; the melinoe feature enables branded placement).
 themis = { version = "0.10.1", git = "https://github.com/ryancinsight/themis", package = "themis-topology" }
@@ -101,7 +101,7 @@ themis = { version = "0.10.1", git = "https://github.com/ryancinsight/themis", p
 melinoe = { version = "0.9.0", git = "https://github.com/ryancinsight/melinoe.git", default-features = false }
 # hephaestus-wgpu: Atlas GPU provider used for device acquisition and the
 # ongoing replacement of CFDrs-owned raw WGPU kernels.
-hephaestus-wgpu = { version = "0.18.0", git = "https://github.com/ryancinsight/hephaestus" }
+hephaestus-wgpu = { version = "0.19.0", git = "https://github.com/ryancinsight/hephaestus" }
 # athena: backend-neutral Krylov solver suite (athena-core = contracts,
 # athena-leto = Leto CPU backend). Used by cfd-math/linear_solver/krylov.rs.
 athena-core = { version = "0.1.0", git = "https://github.com/ryancinsight/athena" }
@@ -131,7 +131,7 @@ pedantic = { level = "warn", priority = -1 }
 # Canonical Atlas library hygiene: deny the four output/panic-erasure
 # patterns at workspace level. Pre-existing violations carry per-site
 # `#[expect(lint, reason="ratchet cfd-<id>")]`; the floor itself never
-# `allow`s them — that would erase the ratchet signal.
+# `allow`s them â€” that would erase the ratchet signal.
 unwrap_used = "deny"
 print_stderr = "deny"
 print_stdout = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ consus-hdf5 = { version = "0.1.0", git = "https://github.com/ryancinsight/consus
 consus-io = { version = "0.1.0", git = "https://github.com/ryancinsight/consus.git" }
 # ritk: RITK imaging toolkit; owns the VTK data model and I/O. Consumed by
 # cfd-io behind the `vtk` feature for VTK creation.
-ritk-vtk = { version = "0.1.0", git = "https://github.com/ryancinsight/ritk" }
+ritk-vtk = { version = "0.2.0", git = "https://github.com/ryancinsight/ritk" }
 # hermes: SIMD abstraction workspace. Provides generic runtime-dispatched
 # SIMD operations (dot, elementwise, reductions) over f32/f64/i32.
 hermes-simd = { version = "0.6.0", git = "https://github.com/ryancinsight/hermes.git" }


### PR DESCRIPTION
Bumps leto 0.42, apollo-fft 0.26, hephaestus 0.19, moirai 0.5 to match the published releases; unblocks overlay unification.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates four core Atlas dependencies (`leto` from 0.41 to 0.42, `apollo-fft` from 0.25 to 0.26, `hephaestus` from 0.18 to 0.19, and `moirai` from 0.4 to 0.5) to their latest published releases in order to unblock overlay unification. The changes involve version bumps in `Cargo.toml` for direct dependencies and cascading transitive dependency updates in `Cargo.lock`, including updates to `thiserror`, `syn`, various `wasm-bindgen` crates, `futures`, and other ecosystem packages.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal component versions to newer releases.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->