### PR TITLE
build(deps): Advance tyche-core to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aequitas"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/aequitas#f181ce617f61811fcb1f6d35c0d217dfb5fbfb34"
 dependencies = [
  "eunomia",
  "serde",
@@ -115,6 +116,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "apollo-fft"
 version = "0.26.0"
+source = "git+https://github.com/ryancinsight/apollo#5a1545ac6165c0e372f5141e99d324b3b6c8980c"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -136,6 +138,7 @@ dependencies = [
 [[package]]
 name = "apollo-fft-macros"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/apollo#5a1545ac6165c0e372f5141e99d324b3b6c8980c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -145,6 +148,7 @@ dependencies = [
 [[package]]
 name = "apollo-leto-interop"
 version = "0.18.0"
+source = "git+https://github.com/ryancinsight/apollo#5a1545ac6165c0e372f5141e99d324b3b6c8980c"
 dependencies = [
  "leto",
 ]
@@ -152,6 +156,7 @@ dependencies = [
 [[package]]
 name = "apollo-nufft"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/apollo#5a1545ac6165c0e372f5141e99d324b3b6c8980c"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -183,6 +188,7 @@ dependencies = [
 [[package]]
 name = "athena-core"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/athena#107b51d1bf8e37f0b7177388b5c4c06a10b1ffeb"
 dependencies = [
  "eunomia",
 ]
@@ -190,6 +196,7 @@ dependencies = [
 [[package]]
 name = "athena-leto"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/athena#107b51d1bf8e37f0b7177388b5c4c06a10b1ffeb"
 dependencies = [
  "athena-core",
  "eunomia",
@@ -418,7 +425,7 @@ dependencies = [
  "cfd-validation",
  "criterion",
  "eunomia",
- "gaia",
+ "gaia-mesh",
  "iris-viz",
  "leto",
  "leto-ops",
@@ -451,7 +458,7 @@ dependencies = [
  "cfd-validation",
  "criterion",
  "eunomia",
- "gaia",
+ "gaia-mesh",
  "leto",
  "leto-ops",
  "moirai-runtime",
@@ -548,7 +555,7 @@ dependencies = [
  "cfd-schematics",
  "cfd-validation",
  "chrono",
- "gaia",
+ "gaia-mesh",
  "hyperion",
  "moirai-runtime",
  "petgraph",
@@ -574,7 +581,7 @@ dependencies = [
  "cfd-core",
  "cfd-validation",
  "eunomia",
- "gaia",
+ "gaia-mesh",
  "leto",
  "numpy",
  "pyo3",
@@ -589,7 +596,7 @@ dependencies = [
  "aequitas",
  "cfd-io",
  "cfd-schematics",
- "gaia",
+ "gaia-mesh",
  "hashbrown 0.15.5",
  "serde",
  "serde_json",
@@ -628,7 +635,7 @@ dependencies = [
  "chrono",
  "criterion",
  "eunomia",
- "gaia",
+ "gaia-mesh",
  "leto",
  "leto-ops",
  "moirai-runtime",
@@ -757,6 +764,7 @@ dependencies = [
 [[package]]
 name = "coeus-autograd"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -771,6 +779,7 @@ dependencies = [
 [[package]]
 name = "coeus-core"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -785,6 +794,7 @@ dependencies = [
 [[package]]
 name = "coeus-leto"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "coeus-core",
  "leto",
@@ -794,6 +804,7 @@ dependencies = [
 [[package]]
 name = "coeus-nn"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -807,6 +818,7 @@ dependencies = [
 [[package]]
 name = "coeus-ops"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -824,6 +836,7 @@ dependencies = [
 [[package]]
 name = "coeus-optim"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -837,6 +850,7 @@ dependencies = [
 [[package]]
 name = "coeus-sparse"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -847,6 +861,7 @@ dependencies = [
 [[package]]
 name = "coeus-tensor"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#d4503e8a308d19e74ab8f98fc60ace6c5e75c420"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -871,6 +886,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "consus-compression"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#e8f6b228f012d859fe39c73296e5bffa1e4a1180"
 dependencies = [
  "byteorder",
  "consus-core",
@@ -879,6 +895,7 @@ dependencies = [
 [[package]]
 name = "consus-core"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#e8f6b228f012d859fe39c73296e5bffa1e4a1180"
 dependencies = [
  "byteorder",
  "smallvec",
@@ -888,6 +905,7 @@ dependencies = [
 [[package]]
 name = "consus-hdf5"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#e8f6b228f012d859fe39c73296e5bffa1e4a1180"
 dependencies = [
  "byteorder",
  "consus-compression",
@@ -898,6 +916,7 @@ dependencies = [
 [[package]]
 name = "consus-io"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#e8f6b228f012d859fe39c73296e5bffa1e4a1180"
 dependencies = [
  "consus-core",
 ]
@@ -1175,6 +1194,7 @@ dependencies = [
 [[package]]
 name = "eunomia"
 version = "0.8.0"
+source = "git+https://github.com/ryancinsight/eunomia#085f217f9af2588887a940e4947957fea14771c7"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1395,8 +1415,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "gaia"
-version = "0.3.0"
+name = "gaia-mesh"
+version = "0.4.0"
+source = "git+https://github.com/ryancinsight/gaia#34c071b31cb8f45bc2b6996231cc0f158ff32fdd"
 dependencies = [
  "anyhow",
  "eunomia",
@@ -1536,6 +1557,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hephaestus-core"
 version = "0.19.0"
+source = "git+https://github.com/ryancinsight/hephaestus#3be20f436aa2622bc210cd34605fedf5f0530427"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1548,6 +1570,7 @@ dependencies = [
 [[package]]
 name = "hephaestus-wgpu"
 version = "0.19.0"
+source = "git+https://github.com/ryancinsight/hephaestus#3be20f436aa2622bc210cd34605fedf5f0530427"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1567,6 +1590,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd"
 version = "0.6.0"
+source = "git+https://github.com/ryancinsight/hermes.git#03e5e1759f25e694d521a2b26eb116698931a85c"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1579,6 +1603,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-core"
 version = "0.6.0"
+source = "git+https://github.com/ryancinsight/hermes.git#03e5e1759f25e694d521a2b26eb116698931a85c"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1590,6 +1615,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-intrinsics"
 version = "0.6.0"
+source = "git+https://github.com/ryancinsight/hermes.git#03e5e1759f25e694d521a2b26eb116698931a85c"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1598,6 +1624,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-macros"
 version = "0.6.0"
+source = "git+https://github.com/ryancinsight/hermes.git#03e5e1759f25e694d521a2b26eb116698931a85c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1607,6 +1634,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-types"
 version = "0.6.0"
+source = "git+https://github.com/ryancinsight/hermes.git#03e5e1759f25e694d521a2b26eb116698931a85c"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1621,6 +1649,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "hyperion"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/hyperion#86e89450974f9787beae6d0af263b46ee4a10996"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1678,6 +1707,7 @@ dependencies = [
 [[package]]
 name = "iris-viz"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/iris#4f6d29f48ecebf0948416a1695aada2ff1ee279c"
 
 [[package]]
 name = "is-terminal"
@@ -1747,6 +1777,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leto"
 version = "0.42.0"
+source = "git+https://github.com/ryancinsight/leto.git#50da39db556fdf84c4a9e7db483f30341fc2a7e8"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1759,6 +1790,7 @@ dependencies = [
 [[package]]
 name = "leto-ops"
 version = "0.42.0"
+source = "git+https://github.com/ryancinsight/leto.git#50da39db556fdf84c4a9e7db483f30341fc2a7e8"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1850,6 +1882,7 @@ dependencies = [
 [[package]]
 name = "melinoe"
 version = "0.9.0"
+source = "git+https://github.com/ryancinsight/melinoe.git#6d80c3331fab1fe88fd872a41c66ec098b931392"
 
 [[package]]
 name = "memchr"
@@ -1870,6 +1903,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-arena"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
@@ -1880,6 +1914,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "mnemosyne-memory-core",
 ]
@@ -1887,10 +1922,12 @@ dependencies = [
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.3.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1900,6 +1937,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-heap"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1913,6 +1951,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-local"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1927,6 +1966,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
@@ -1941,10 +1981,12 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory-core"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 
 [[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#7541069888e7453ad9f10e1bb4a927276fab5c9f"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -1954,6 +1996,7 @@ dependencies = [
 [[package]]
 name = "moirai-async"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "futures",
  "libc",
@@ -1969,6 +2012,7 @@ dependencies = [
 [[package]]
 name = "moirai-async-macros"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1978,6 +2022,7 @@ dependencies = [
 [[package]]
 name = "moirai-core"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "bytemuck",
  "libc",
@@ -1989,6 +2034,7 @@ dependencies = [
 [[package]]
 name = "moirai-executor"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2002,6 +2048,7 @@ dependencies = [
 [[package]]
 name = "moirai-gpu"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "mnemosyne-memory-core",
  "moirai-core",
@@ -2012,6 +2059,7 @@ dependencies = [
 [[package]]
 name = "moirai-iter"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "futures",
  "libc",
@@ -2027,6 +2075,7 @@ dependencies = [
 [[package]]
 name = "moirai-pal"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "js-sys",
  "libc",
@@ -2041,6 +2090,7 @@ dependencies = [
 [[package]]
 name = "moirai-parallel"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "melinoe",
  "moirai-core",
@@ -2051,6 +2101,7 @@ dependencies = [
 [[package]]
 name = "moirai-runtime"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2068,6 +2119,7 @@ dependencies = [
 [[package]]
 name = "moirai-scheduler"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "mnemosyne-memory",
  "moirai-core",
@@ -2079,6 +2131,7 @@ dependencies = [
 [[package]]
 name = "moirai-sync"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "libc",
  "moirai-core",
@@ -2088,6 +2141,7 @@ dependencies = [
 [[package]]
 name = "moirai-transport"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 dependencies = [
  "bytemuck",
  "moirai-core",
@@ -2098,6 +2152,7 @@ dependencies = [
 [[package]]
 name = "moirai-utils"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
 
 [[package]]
 name = "munge"
@@ -2192,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2550,6 +2605,7 @@ dependencies = [
 [[package]]
 name = "proteus"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/proteus#0003266c40224f77c82a368dfe6a3364f734318c"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -2863,7 +2919,8 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "ritk-image"
-version = "0.2.0"
+version = "0.3.0"
+source = "git+https://github.com/ryancinsight/ritk#f018ffef7fea71377fadb18358f43ac6c59ae088"
 dependencies = [
  "anyhow",
  "coeus-autograd",
@@ -2879,7 +2936,8 @@ dependencies = [
 
 [[package]]
 name = "ritk-spatial"
-version = "0.1.0"
+version = "0.2.0"
+source = "git+https://github.com/ryancinsight/ritk#f018ffef7fea71377fadb18358f43ac6c59ae088"
 dependencies = [
  "leto",
  "serde",
@@ -2888,12 +2946,13 @@ dependencies = [
 
 [[package]]
 name = "ritk-vtk"
-version = "0.1.0"
+version = "0.2.0"
+source = "git+https://github.com/ryancinsight/ritk#f018ffef7fea71377fadb18358f43ac6c59ae088"
 dependencies = [
  "anyhow",
  "coeus-core",
  "consus-io",
- "gaia",
+ "gaia-mesh",
  "iris-viz",
  "ritk-image",
  "ritk-spatial",
@@ -2903,7 +2962,8 @@ dependencies = [
 
 [[package]]
 name = "ritk-wgpu-compat"
-version = "0.1.0"
+version = "0.2.0"
+source = "git+https://github.com/ryancinsight/ritk#f018ffef7fea71377fadb18358f43ac6c59ae088"
 
 [[package]]
 name = "rkyv"
@@ -3206,6 +3266,7 @@ dependencies = [
 [[package]]
 name = "themis-topology"
 version = "0.10.1"
+source = "git+https://github.com/ryancinsight/themis#12f4531bed770166dd3194a3bede4bc7f811eacb"
 dependencies = [
  "melinoe",
 ]
@@ -3394,7 +3455,8 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "tyche-core"
-version = "0.1.0"
+version = "0.2.0"
+source = "git+https://github.com/ryancinsight/tyche#63d06940faa4aeccc7b779b238b564b07cc101f5"
 dependencies = [
  "eunomia",
 ]
@@ -4113,59 +4175,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "consus-npy"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "consus-onnx"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "ritk-core"
-version = "0.9.0"
-
-[[patch.unused]]
-name = "ritk-dicom"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "ritk-io"
-version = "0.2.0"
-
-[[patch.unused]]
-name = "ritk-registration"
-version = "0.53.0"
-
-[[patch.unused]]
-name = "apollo-sht"
-version = "0.7.0"
-
-[[patch.unused]]
-name = "asclepius"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "asclepius-coeus"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "moirai-http"
-version = "0.5.0"
-
-[[patch.unused]]
-name = "horae"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "hephaestus-cuda"
-version = "0.19.0"
-
-[[patch.unused]]
-name = "hephaestus-metal"
-version = "0.19.0"
-
-[[patch.unused]]
-name = "hephaestus-rocm"
-version = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = "0.3"
 aequitas = { version = "0.2.0", git = "https://github.com/ryancinsight/aequitas", default-features = false, features = ["std"] }
 proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
 hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
-tyche-core = { version = "0.1.0", git = "https://github.com/ryancinsight/tyche" }
+tyche-core = { version = "0.2.0", git = "https://github.com/ryancinsight/tyche" }
 eunomia = { version = "0.8.0", git = "https://github.com/ryancinsight/eunomia", default-features = false, features = ["std"] }
 iris = { package = "iris-viz", version = "0.1.0", git = "https://github.com/ryancinsight/iris" }
 approx = "0.5"


### PR DESCRIPTION
`tyche` re-released at **0.2.0** onto eunomia 0.8. The published `tyche-core 0.1.0` required `eunomia ^0.7.0`, which put two semver-incompatible eunomia crates in any consumer's graph — `RealField` from 0.7 does not satisfy a bound written against 0.8.

The git source is now 0.2.0, so a `version = "0.1.0"` requirement **no longer resolves against it** and this build would break without the bump.

## Verification
`cargo tree` resolves `tyche-core v0.2.0`; `cargo check --workspace` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `tyche-core` dependency from version **0.1.0** to **0.2.0** to resolve a semver incompatibility issue. The original `tyche-core 0.1.0` required `eunomia ^0.7.0`, which conflicted with the workspace's use of `eunomia 0.8`, causing trait bound resolution failures. The new version **0.2.0** is built against `eunomia 0.8`, ensuring compatibility across the dependency graph. Additionally, the lockfile reflects various other git source updates and removes unused patch entries.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Tyche Core component to version 0.2.0 for improved compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->