### PR TITLE
ci: Advance the Atlas workflow pin

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -24,7 +24,7 @@ jobs:
     # Body owned once by Atlas (ADR 0035), pinned by SHA like any action. The
     # shared workflow keeps the pull-request build and skips deployment there,
     # so PRs still prove the book builds without publishing it.
-    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@9772542cc9dbd53123da0b369a75f34a180da867
+    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@d875348197be12ad593f993a6f1b8a62d3b8b195
     permissions:
       contents: read
       # The shared deploy job publishes to Pages over OIDC.


### PR DESCRIPTION
Advances the pinned Atlas shared-workflow commit to `d875348197be12ad593f993a6f1b8a62d3b8b195`.

Updated: book-pages.yml

The pin is a SHA like any other action reference, so a repository stays on whatever Atlas commit it last recorded. These were behind, which meant they did not pick up shared-workflow fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the pinned commit SHA for the Atlas shared workflow from `9772542cc9dbd53123da0b369a75f34a180da867` to `d875348197be12ad593f993a6f1b8a62d3b8b195` in the `book-pages.yml` workflow file. The update ensures the repository picks up the latest shared-workflow fixes from Atlas, as the previous pin was behind.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/book-pages.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->