### PR TITLE
ci(book): Install the linkcheck2 backend the book declares

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -24,7 +24,7 @@ jobs:
     # Body owned once by Atlas (ADR 0035), pinned by SHA like any action. The
     # shared workflow keeps the pull-request build and skips deployment there,
     # so PRs still prove the book builds without publishing it.
-    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@d875348197be12ad593f993a6f1b8a62d3b8b195
+    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@50c6cde7fff9c6af62687f9d43e5f0f9b4b64262
     permissions:
       contents: read
       # The shared deploy job publishes to Pages over OIDC.
@@ -32,3 +32,6 @@ jobs:
       id-token: write
     with:
       output-path: target/book/cfdrs
+      # book.toml declares [output.linkcheck2] without optional = true, so
+      # mdbook fails the render unless the backend binary is installed.
+      mdbook-linkcheck2-version: "0.12.2"


### PR DESCRIPTION
`docs/book/book.toml` declares `[output.linkcheck2]` without `optional = true`, and mdbook fails the render outright when a declared backend is missing:

```
ERROR The command `mdbook-linkcheck2` wasn't found, is the `linkcheck2` backend installed?
ERROR Rendering failed
```

The book has failed on **every run since 2026-08-04** for this reason — nothing in this repo could fix it, because the shared workflow installed mdbook but not the backend.

atlas added an opt-in `mdbook-linkcheck2-version` input; this passes `0.12.2` (the version gaia already pins for the same backend) and advances the Atlas pin to pick it up.

Link checking stays enabled — setting `optional = true` would have made the build pass by discarding the check the book asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes a CI failure in the mdbook rendering process by installing the `mdbook-linkcheck2` backend (version 0.12.2) that the book configuration requires. The book has been failing since 2026-08-04 because the shared workflow installed mdbook but not the linkcheck2 backend, which is declared as non-optional in `book.toml`. The fix updates the Atlas workflow pin and passes the required version parameter to ensure the backend is installed during CI runs.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/book-pages.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use a newer shared workflow version.
  * Added the required link-checking tool version for documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->