### PR TITLE
ci: Refresh Atlas workflow pin

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -24,7 +24,7 @@ jobs:
     # Body owned once by Atlas (ADR 0035), pinned by SHA like any action. The
     # shared workflow keeps the pull-request build and skips deployment there,
     # so PRs still prove the book builds without publishing it.
-    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@4c31dd7
+    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@4c31dd753f06dd93b4c04798cf781df253e3e532
     permissions:
       contents: read
       # The shared deploy job publishes to Pages over OIDC.

--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -24,7 +24,7 @@ jobs:
     # Body owned once by Atlas (ADR 0035), pinned by SHA like any action. The
     # shared workflow keeps the pull-request build and skips deployment there,
     # so PRs still prove the book builds without publishing it.
-    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@50c6cde7fff9c6af62687f9d43e5f0f9b4b64262
+    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@4c31dd7
     permissions:
       contents: read
       # The shared deploy job publishes to Pages over OIDC.


### PR DESCRIPTION
Refresh every Atlas reusable-workflow caller in this repository to root workflow commit `4c31dd7`.

This branch changes workflow pins only; no Rust source, manifest, lockfile, or generated artifact is modified.

The caller passes the existing workflow inputs unchanged.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the Atlas reusable workflow reference in the GitHub Actions workflow from a full SHA pin (`50c6cde7fff9c6af62687f9d43e5f0f9b4b64262`) to a shortened commit reference (`4c31dd7`). The change refreshes the workflow dependency without modifying any Rust source code, manifests, lockfiles, or other artifacts, and keeps all existing workflow inputs unchanged.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/book-pages.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->