### PR TITLE
ci(book): Pin the linkcheck2 toolchain fix by full SHA

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -24,7 +24,7 @@ jobs:
     # Body owned once by Atlas (ADR 0035), pinned by SHA like any action. The
     # shared workflow keeps the pull-request build and skips deployment there,
     # so PRs still prove the book builds without publishing it.
-    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@50c6cde7fff9c6af62687f9d43e5f0f9b4b64262
+    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@4c31dd753f06dd93b4c04798cf781df253e3e532
     permissions:
       contents: read
       # The shared deploy job publishes to Pages over OIDC.


### PR DESCRIPTION
The linkcheck2 install step needs a Rust toolchain, which the Atlas commit this repo pinned (`50c6cde7`) did not yet install — `cargo install mdbook-linkcheck2` has nothing to run. Atlas `4c31dd75` adds that toolchain step.

Supersedes #338, which advances to the same fix but records it as an **abbreviated** SHA (`@4c31dd7`). Every other Atlas reference across the stack is pinned by full 40-character SHA; an abbreviated ref is ambiguous and weakens the pin, which is the whole point of pinning a shared workflow like an action. #338 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the pinned Atlas workflow SHA to fix a broken linkcheck2 installation step. The previous commit (`50c6cde7`) was missing a Rust toolchain installation, causing `cargo install mdbook-linkcheck2` to fail. The new commit (`4c31dd75`) includes the necessary toolchain setup. This change also ensures the SHA pin uses the full 40-character format, maintaining consistency with other Atlas references and strengthening the pin's security guarantee.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/book-pages.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->