### PR TITLE
ci(book): Upload the html subdirectory mdbook actually writes

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -31,7 +31,10 @@ jobs:
       pages: write
       id-token: write
     with:
-      output-path: target/book/cfdrs
+      # With a second renderer configured ([output.linkcheck2]) mdbook writes
+      # each backend into its own subdirectory, so the HTML lands in html/
+      # rather than at build-dir. gaia points at the same subdirectory.
+      output-path: target/book/cfdrs/html
       # book.toml declares [output.linkcheck2] without optional = true, so
       # mdbook fails the render unless the backend binary is installed.
       mdbook-linkcheck2-version: "0.12.2"


### PR DESCRIPTION
With the linkcheck2 backend now installed, mdbook renders — but the upload still fails:

```
INFO Invoking the "linkcheck2" renderer
mdbook produced no target/book/cfdrs/index.html; check the book's build-dir against the output-path input
```

Once a **second** `[output.*]` backend exists, mdbook writes each renderer into its own subdirectory, so the HTML lands at `<build-dir>/html/` rather than at `build-dir`. The caller was pointing at the parent.

gaia has the identical `[output.html]` + `[output.linkcheck2]` pair and uploads `target/book/gaia/html` — this matches it.

Same shape as the helios Pages bug fixed earlier: the artifact root had no `index.html` because the upload pointed one level too high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a deployment issue in the GitHub Pages workflow for the documentation book. When `mdbook` has multiple output backends configured (HTML and linkcheck2), it writes each renderer's output into separate subdirectories. The upload path was pointing to `target/book/cfdrs` but needed to be updated to `target/book/cfdrs/html` to match where the actual HTML files are generated. This aligns with how the gaia project handles the same configuration.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/book-pages.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->