### PR TITLE
chore(deps): Legacy-dep cleanup + migrate powf emulation to eunomia FloatElement

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -20,6 +20,20 @@
 - [x] Verify `cargo metadata --locked --no-deps` rc=0 (lockfile unchanged) and
       `cargo check --workspace --offline` rc=0 after the removal.
 
+## CFDRS-FLOATELEMENT-ROOTS-001 — Migrate powf root emulation to FloatElement — done 2026-08-13
+
+- [x] Replace `powf`-emulated scalar roots with the sign-preserving Eunomia
+      `FloatElement` surface across 18 files (cfd-1d/2d/3d, cfd-optim,
+      cfd-validation): `powf(1/3)` → `.cbrt()`, `powf(-1/3)` →
+      `.cbrt().recip()`, `powf(-0.5)` → `.rsqrt()`, `powf(0.25)` →
+      `.nth_root(4)`, `powf(0.2)` → `.nth_root(5)`, `powf(1/7)` →
+      `.nth_root(7)`.
+- [x] Add the missing `eunomia` workspace dep to `cfd-optim` and the
+      `FloatElement` import to each consumer file that needs it.
+- [x] Verify `cargo check --workspace --all-targets` rc=0 and
+      `cargo nextest run` (cfd-1d/2d/3d/optim/validation) 2277 passed /
+      0 failed.
+
 ## Owner: current Codex session — CFDRS-LINT-FLOOR-001 — in progress 2026-08-06
 
 - [x] Declare the Atlas `[workspace.lints]` floor and inherit it from all

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,16 @@
 # CFDrs Work Checklist
 
+## CFDRS-LEGACY-AUDIT-HARDEN-001 — Harden legacy-migration-audit coverage — done 2026-08-13
+
+- [x] Add `approx`, `num-traits`, `rustfft` to the audit's legacy manifest
+      dep list and `approx::`/`num_traits::`/`rustfft::` to its source-token
+      list (matching kwavers coverage).
+- [x] Add two unit tests locking manifest-dep and source-token detection for
+      the three crates.
+- [x] Verify `cargo test -p xtask` (2/2), a clean `legacy-migration-audit`
+      run, `cargo fmt -p xtask -- --check`, and `cargo clippy -p xtask
+      --all-targets -- -D warnings`.
+
 ## CFDRS-LEGACY-APPROX-001 — Remove orphaned approx workspace dep — done 2026-08-13
 
 - [x] Remove the orphaned `approx = "0.5"` workspace dependency: zero

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,14 @@
 # CFDrs Work Checklist
 
+## CFDRS-LEGACY-APPROX-001 — Remove orphaned approx workspace dep — done 2026-08-13
+
+- [x] Remove the orphaned `approx = "0.5"` workspace dependency: zero
+      consumers (`approx::`), zero manifest references, and absent from
+      `Cargo.lock`. CFDrs float comparison is already Eunomia-backed, so the
+      legacy comparison crate is fully superseded.
+- [x] Verify `cargo metadata --locked --no-deps` rc=0 (lockfile unchanged) and
+      `cargo check --workspace --offline` rc=0 after the removal.
+
 ## Owner: current Codex session — CFDRS-LINT-FLOOR-001 — in progress 2026-08-06
 
 - [x] Declare the Atlas `[workspace.lints]` floor and inherit it from all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,7 @@ dependencies = [
  "cfd-schematics",
  "cfd-validation",
  "chrono",
+ "eunomia",
  "gaia-mesh",
  "hyperion",
  "moirai-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "eunomia"
 version = "0.8.0"
-source = "git+https://github.com/ryancinsight/eunomia#085f217f9af2588887a940e4947957fea14771c7"
+source = "git+https://github.com/ryancinsight/eunomia#1a52590c05cb881a28443703c68d4659a17e4654"
 dependencies = [
  "bytemuck",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion"
 tyche-core = { version = "0.2.0", git = "https://github.com/ryancinsight/tyche" }
 eunomia = { version = "0.8.0", git = "https://github.com/ryancinsight/eunomia", default-features = false, features = ["std"] }
 iris = { package = "iris-viz", version = "0.1.0", git = "https://github.com/ryancinsight/iris" }
-approx = "0.5"
 bytemuck = "1.14"
 rand = "0.8"
 

--- a/backlog.md
+++ b/backlog.md
@@ -81,6 +81,18 @@
 
 ## Active integration
 
+- **CFDRS-LEGACY-AUDIT-HARDEN-001 [patch] - Harden legacy-migration-audit
+  coverage (done 2026-08-13; owner=current Codex session; scope=
+  `xtask/src/migration_audit.rs` only).** The audit's legacy classification
+  omitted `approx`, `num-traits`, and `rustfft` (manifest) plus
+  `approx::`/`num_traits::`/`rustfft::` (source tokens) — which is how the
+  orphaned `approx = "0.5"` workspace dep evaded CFDRS-LEGACY-APPROX-001.
+  The lists now match the kwavers audit coverage, and two unit tests lock
+  manifest-dep and source-token detection for all three crates. Evidence:
+  `cargo test -p xtask` 2/2, `cargo run -p xtask -- legacy-migration-audit`
+  clean (0 deps, 0 tokens), `cargo fmt -p xtask -- --check`,
+  `cargo clippy -p xtask --all-targets -- -D warnings` all rc=0.
+
 - **CFDRS-LEGACY-APPROX-001 [patch] - Remove orphaned approx workspace dep
   (done 2026-08-13; owner=current Codex session; scope=workspace
   `Cargo.toml` only).** The `approx = "0.5"` workspace dependency had zero

--- a/backlog.md
+++ b/backlog.md
@@ -107,6 +107,18 @@
   (no such package in the resolved graph), and a tree-wide grep showing zero
   `approx::`/`use approx` residue.
 
+- **CFDRS-FLOATELEMENT-ROOTS-001 [patch] - Migrate powf root emulation to
+  FloatElement cbrt/rsqrt/nth_root (done 2026-08-13; owner=current Codex
+  session; scope=18 source files across cfd-1d/2d/3d, cfd-optim, and
+  cfd-validation).** Swept `powf`-emulated scalar roots onto the
+  sign-preserving Eunomia `FloatElement` surface: `powf(1/3)` → `.cbrt()`,
+  `powf(-1/3)` → `.cbrt().recip()`, `powf(-0.5)` → `.rsqrt()`,
+  `powf(0.25)` → `.nth_root(4)`, `powf(0.2)` → `.nth_root(5)`, and
+  `powf(1/7)` → `.nth_root(7)`. Added the missing `eunomia` workspace dep
+  to `cfd-optim`. Evidence: `cargo check --workspace --all-targets` rc=0;
+  `cargo nextest run` (cfd-1d/2d/3d/optim/validation) 2277 passed /
+  0 failed.
+
 - **CFDRS-AEQ-MET-63 [major] - Type ChannelSpec hydraulic metrics
   (done 2026-08-06; owner=current Codex session; scope=
   `ChannelSpec` hydraulic coefficients and pump limits, valve loss metadata,

--- a/backlog.md
+++ b/backlog.md
@@ -81,6 +81,20 @@
 
 ## Active integration
 
+- **CFDRS-LEGACY-APPROX-001 [patch] - Remove orphaned approx workspace dep
+  (done 2026-08-13; owner=current Codex session; scope=workspace
+  `Cargo.toml` only).** The `approx = "0.5"` workspace dependency had zero
+  consumers — no `approx::` reference in any source file, no
+  `approx = { workspace = true }` in any package manifest, and no
+  `[[package]]` entry in `Cargo.lock` (the graph never resolved it). CFDrs
+  float comparison already routes through the Eunomia
+  `assert_relative_eq!`/`FloatElement` surface, so the legacy comparison
+  crate is fully superseded and the manifest entry was pure residue.
+  Evidence: `cargo metadata --locked --no-deps` rc=0 (lockfile unchanged),
+  `cargo check --workspace --offline` rc=0, `cargo tree -i approx` rc=101
+  (no such package in the resolved graph), and a tree-wide grep showing zero
+  `approx::`/`use approx` residue.
+
 - **CFDRS-AEQ-MET-63 [major] - Type ChannelSpec hydraulic metrics
   (done 2026-08-06; owner=current Codex session; scope=
   `ChannelSpec` hydraulic coefficients and pump limits, valve loss metadata,

--- a/crates/cfd-1d/src/physics/cell_separation/zweifach_fung.rs
+++ b/crates/cfd-1d/src/physics/cell_separation/zweifach_fung.rs
@@ -55,6 +55,7 @@
 
 use aequitas::systems::si::quantities::Length;
 use cfd_core::error::{Error, Result};
+use eunomia::FloatElement;
 
 /// Mean human RBC diameter \[µm].
 const RBC_DIAMETER_M: f64 = 8.0e-6;
@@ -119,13 +120,13 @@ pub fn critical_fractional_flow(channel_diameter: Length) -> f64 {
     let kappa = confinement_ratio(channel_diameter);
     // For kappa → 0 (very large channels), the 1/sqrt(kappa) term diverges,
     // so we clamp output to [0.5, 0.99].
-    (0.5 + 0.14 * kappa.powf(-0.5)).clamp(0.5, 0.99)
+    (0.5 + 0.14 * kappa.rsqrt()).clamp(0.5, 0.99)
 }
 
 /// Checked critical fractional flow evaluation for the Zweifach-Fung transition.
 pub fn checked_critical_fractional_flow(channel_diameter: Length) -> Result<f64> {
     let kappa = checked_confinement_ratio(channel_diameter)?;
-    Ok((0.5 + 0.14 * kappa.powf(-0.5)).clamp(0.5, 0.99))
+    Ok((0.5 + 0.14 * kappa.rsqrt()).clamp(0.5, 0.99))
 }
 
 /// Transition sharpness parameter for the sigmoid model.

--- a/crates/cfd-1d/src/physics/resistance/models/darcy_weisbach.rs
+++ b/crates/cfd-1d/src/physics/resistance/models/darcy_weisbach.rs
@@ -500,7 +500,7 @@ mod tests {
         // Re=100000, roughness=0 => Blasius: f = 0.316/Re^0.25 ~ 0.01778
         let model = DarcyWeisbachModel::circular(0.01, 1.0, 0.0);
         let f = model.calculate_friction_factor(100_000.0);
-        let blasius = 0.316 / 100_000.0_f64.powf(0.25);
+        let blasius = 0.316 / 100_000.0_f64.nth_root(4);
         assert_relative_eq!(f, blasius, max_relative = 0.05);
     }
 

--- a/crates/cfd-1d/src/physics/resistance/models/slug_flow.rs
+++ b/crates/cfd-1d/src/physics/resistance/models/slug_flow.rs
@@ -237,7 +237,7 @@ mod tests {
         // Multiplier = 1 + 0.17 * (1mm / 2mm) * (72000)^(1/3)
         // 72000^(1/3) = ~41.6016
         // Mult = 1 + 0.17 * 0.5 * 41.6016 = 4.536
-        let expected_mult = 1.0 + 0.17 * 0.5 * (72000.0_f64).powf(1.0 / 3.0);
+        let expected_mult = 1.0 + 0.17 * 0.5 * (72000.0_f64).cbrt();
         let expected_r = r_base * expected_mult;
 
         assert_relative_eq!(r1, expected_r, max_relative = 1e-10);

--- a/crates/cfd-1d/src/physics/vascular/murrays_law/law.rs
+++ b/crates/cfd-1d/src/physics/vascular/murrays_law/law.rs
@@ -234,7 +234,7 @@ mod tests {
         let murray = MurraysLaw::<f64>::new();
         let d0: f64 = 1.0e-3;
         let dd = murray.symmetric_daughter_diameter(d0);
-        let expected = d0 / 2.0_f64.powf(1.0 / 3.0);
+        let expected = d0 / 2.0_f64.cbrt();
         assert_relative_eq!(dd, expected, max_relative = 1e-12);
     }
 
@@ -248,7 +248,7 @@ mod tests {
         let d2 = murray
             .asymmetric_daughter_diameter(d0, d1)
             .expect("valid bifurcation");
-        let expected = (d0.powi(3) - d1.powi(3)).powf(1.0 / 3.0);
+        let expected = (d0.powi(3) - d1.powi(3)).cbrt();
         assert_relative_eq!(d2, expected, max_relative = 1e-12);
     }
 
@@ -271,7 +271,7 @@ mod tests {
     fn ideal_area_ratio_k3() {
         let murray = MurraysLaw::<f64>::new();
         let ar = murray.ideal_area_ratio();
-        let expected = 2.0_f64.powf(1.0 / 3.0);
+        let expected = 2.0_f64.cbrt();
         assert_relative_eq!(ar, expected, max_relative = 1e-12);
     }
 

--- a/crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs
+++ b/crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs
@@ -88,7 +88,7 @@ mod tests {
         let d0 = 10.0;
         let d_daughter = murray.symmetric_daughter_diameter(d0);
 
-        let expected = d0 / 2.0_f64.powf(1.0 / 3.0);
+        let expected = d0 / 2.0_f64.cbrt();
         assert_relative_eq!(d_daughter, expected, epsilon = 1e-10);
         assert_relative_eq!(d_daughter, 7.937, epsilon = 0.001);
     }
@@ -148,7 +148,7 @@ mod tests {
     fn test_ideal_area_ratio_k3() {
         let murray = MurraysLaw::<f64>::new();
         let ratio = murray.ideal_area_ratio();
-        assert_relative_eq!(ratio, 2.0_f64.powf(1.0 / 3.0), epsilon = 1e-10);
+        assert_relative_eq!(ratio, 2.0_f64.cbrt(), epsilon = 1e-10);
         assert_relative_eq!(ratio, 1.26, epsilon = 0.01);
     }
 
@@ -207,7 +207,7 @@ mod tests {
         let d1 = 6.0_f64;
         let d2 = 5.0_f64;
         let d3_cubed = d0.powi(3) - d1.powi(3) - d2.powi(3);
-        let d3 = d3_cubed.powf(1.0 / 3.0);
+        let d3 = d3_cubed.cbrt();
         let sum = d1.powi(3) + d2.powi(3) + d3.powi(3);
         assert_relative_eq!(d0.powi(3), sum, epsilon = 1e-10);
     }

--- a/crates/cfd-1d/tests/cell_separation_validation.rs
+++ b/crates/cfd-1d/tests/cell_separation_validation.rs
@@ -26,7 +26,7 @@ use cfd_1d::physics::cell_separation::{
     CellProperties, CellSeparationModel,
 };
 use cfd_1d::physics::resistance::{FlowConditions, VenturiModel};
-use eunomia::assert_relative_eq;
+use eunomia::{assert_relative_eq, FloatElement};
 
 // ── Blood properties (Casson model at 37°C) ───────────────────────────────────
 const BLOOD_DENSITY: f64 = 1060.0; // kg/m³
@@ -337,7 +337,7 @@ fn test_dean_flow_enhances_separation() {
 #[test]
 fn test_murray_law_symmetric_bifurcation() {
     // Murray's law: D_parent = 2^(1/3) × D_daughter for symmetric bifurcation
-    let murray_ratio = 2.0_f64.powf(1.0 / 3.0); // ≈ 1.2599
+    let murray_ratio = 2.0_f64.cbrt(); // ≈ 1.2599
 
     // Choose a parent diameter and compute the optimal daughter diameter
     let d_parent = 1.0e-3; // 1 mm parent vessel
@@ -381,7 +381,7 @@ fn test_murray_law_symmetric_bifurcation() {
     // R_parallel / R_parent = 0.5 * 2^(4/3) = 2^(-1) * 2^(4/3) = 2^(1/3)
     // We computed ratio = R_parent / R_parallel, so it should be 1 / 2^(1/3) = 2^(-1/3)
     let resistance_ratio = r_parent / r_daughters_parallel;
-    let expected_ratio = 2.0_f64.powf(-1.0 / 3.0); // = 2^(-1/3)
+    let expected_ratio = 2.0_f64.cbrt().recip(); // = 2^(-1/3)
     assert_relative_eq!(resistance_ratio, expected_ratio, epsilon = 1e-6);
 }
 
@@ -391,7 +391,7 @@ fn test_murray_law_symmetric_bifurcation() {
 /// → D_parent / D_daughter = 3^(1/3) ≈ 1.4422
 #[test]
 fn test_murray_law_symmetric_trifurcation() {
-    let murray_ratio_tri = 3.0_f64.powf(1.0 / 3.0); // ≈ 1.4422
+    let murray_ratio_tri = 3.0_f64.cbrt(); // ≈ 1.4422
 
     let d_parent = 1.0e-3;
     let d_daughter = d_parent / murray_ratio_tri;

--- a/crates/cfd-2d/examples/bifurcation_schematic.rs
+++ b/crates/cfd-2d/examples/bifurcation_schematic.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Murray's law: r_parent³ = r_d1³ + r_d2³ → r_d = r_p / 2^(1/3)
     // Using 1 mm parent radius → 0.794 mm daughter radius
     let r_parent = 1.0_f64; // mm
-    let r_daughter = r_parent / 2.0_f64.powf(1.0 / 3.0); // ≈ 0.794 mm
+    let r_daughter = r_parent / 2.0_f64.cbrt(); // ≈ 0.794 mm
     let w_parent = r_parent * 2.0;
     let w_daughter = r_daughter * 2.0;
 

--- a/crates/cfd-2d/src/physics/turbulence/validation/les_des.rs
+++ b/crates/cfd-2d/src/physics/turbulence/validation/les_des.rs
@@ -6,7 +6,7 @@ use crate::physics::turbulence::traits::TurbulenceModel;
 use crate::physics::turbulence::{
     DetachedEddySimulation, KEpsilonModel, KOmegaSSTModel, SmagorinskyLES,
 };
-use eunomia::RealField as EunomiaRealField;
+use eunomia::{FloatElement, RealField as EunomiaRealField};
 use leto::geometry::Vector2;
 use leto::Array2;
 
@@ -178,7 +178,7 @@ impl<T: EunomiaRealField + Copy> TurbulenceValidator<T> {
                 let idx = i * ny + j;
                 let y_over_delta = j as f64 / (ny - 1) as f64;
                 let u_velocity = if y_over_delta < 1.0 {
-                    free_stream_velocity * y_over_delta.powf(1.0 / 7.0)
+                    free_stream_velocity * y_over_delta.nth_root(7)
                 } else {
                     free_stream_velocity
                 };

--- a/crates/cfd-3d/examples/bifurcation_3d_blood.rs
+++ b/crates/cfd-3d/examples/bifurcation_3d_blood.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Murray's law analysis
-    let d_murray = d_parent / 2.0_f64.powf(1.0 / 3.0);
+    let d_murray = d_parent / 2.0_f64.cbrt();
     let murray_error = ((d_daughter - d_murray) / d_murray).abs() * 100.0;
 
     println!("Geometry:");

--- a/crates/cfd-3d/src/physics/turbulence/dynamic_gradient_smagorinsky.rs
+++ b/crates/cfd-3d/src/physics/turbulence/dynamic_gradient_smagorinsky.rs
@@ -310,7 +310,7 @@ mod tests {
 
         let gradient_norm_sq: f64 = gradient.iter().flatten().map(|value| value * value).sum();
         let gradient_magnitude = (2.0 * gradient_norm_sq).sqrt();
-        let delta = (dx * dy * dz).powf(1.0 / 3.0);
+        let delta = (dx * dy * dz).cbrt();
         let delta_hat = delta * model.test_filter_ratio;
         let scale = -2.0 * (delta_hat * delta_hat - delta * delta) * gradient_magnitude;
         let covariance = [

--- a/crates/cfd-3d/src/physics/turbulence/k_omega_sst.rs
+++ b/crates/cfd-3d/src/physics/turbulence/k_omega_sst.rs
@@ -285,7 +285,7 @@ mod tests {
             .expect("initialize_state must populate SST state");
         let expected_k = 1.5 * (4.0 * turbulence_intensity).powi(2);
         let c_mu = cfd_core::physics::constants::physics::turbulence::K_EPSILON_C_MU;
-        let expected_omega = expected_k.sqrt() / (c_mu.powf(0.25) * length_scale);
+        let expected_omega = expected_k.sqrt() / (c_mu.nth_root(4) * length_scale);
 
         assert_relative_eq!(state.k[0], expected_k, epsilon = 1e-12);
         assert_relative_eq!(state.omega[0], expected_omega, epsilon = 1e-12);

--- a/crates/cfd-optim/Cargo.toml
+++ b/crates/cfd-optim/Cargo.toml
@@ -31,6 +31,7 @@ cfd-math.workspace = true
 cfd-schematics.workspace = true
 cfd-validation.workspace = true
 aequitas = { workspace = true, features = ["serde"] }
+eunomia.workspace = true
 hyperion.workspace = true
 tyche-core.workspace = true
 tracing.workspace = true

--- a/crates/cfd-optim/src/application/objectives/ga.rs
+++ b/crates/cfd-optim/src/application/objectives/ga.rs
@@ -1,3 +1,4 @@
+use eunomia::FloatElement;
 use crate::application::objectives::BlueprintObjectiveEvaluation;
 use crate::domain::{BlueprintCandidate, OptimizationGoal};
 use crate::error::OptimError;
@@ -20,7 +21,7 @@ fn acoustic_residence_support_score(evaluation: &BlueprintEvaluation) -> f64 {
         + 0.12 * flow_frac
         + 0.22 * healthy_cell_protection
         + 0.10 * safety;
-    let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).powf(0.25);
+    let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).nth_root(4);
     (base + synergy).clamp(0.0, 1.0)
 }
 
@@ -149,7 +150,7 @@ pub fn evaluate_blueprint_genetic_refinement(
         * residence_norm
         * healthy_cell_protection
         * dean_norm;
-    let synergy = 0.18 * synergy_base.powf(0.2);
+    let synergy = 0.18 * synergy_base.nth_root(5);
     let screening_reasons = [(
         evaluation.safety.main_channel_margin <= 0.0,
         "main-channel safety margin must remain positive",

--- a/crates/cfd-optim/src/application/objectives/option1.rs
+++ b/crates/cfd-optim/src/application/objectives/option1.rs
@@ -1,3 +1,4 @@
+use eunomia::FloatElement;
 use crate::application::objectives::BlueprintObjectiveEvaluation;
 use crate::domain::{BlueprintCandidate, OptimizationGoal};
 use crate::metrics::{healthy_cell_protection_index, BlueprintEvaluation};
@@ -62,7 +63,7 @@ pub fn evaluate_selective_acoustic_residence_separation(
         + 0.12 * flow_frac
         + 0.22 * healthy_cell_protection
         + 0.10 * safety;
-    let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).powf(0.25);
+    let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).nth_root(4);
     let screening_reasons = [
         (
             evaluation.residence.treatment_flow_fraction <= 0.0,
@@ -119,6 +120,6 @@ pub fn score_selective_acoustic_residence_separation(
         + 0.12 * flow_frac
         + 0.22 * healthy_cell_protection
         + 0.10 * safety;
-    let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).powf(0.25);
+    let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).nth_root(4);
     Some((base + synergy).clamp(0.0, 1.0))
 }

--- a/crates/cfd-optim/src/application/search/pool.rs
+++ b/crates/cfd-optim/src/application/search/pool.rs
@@ -29,6 +29,7 @@
 
 use std::sync::Arc;
 
+use eunomia::FloatElement;
 use moirai::{fold_reduce_with, Adaptive};
 
 use crate::application::objectives::BlueprintObjectiveEvaluation;
@@ -149,7 +150,7 @@ impl ScoringSnapshot {
             + 0.12 * flow_frac
             + 0.22 * healthy_cell_protection
             + 0.10 * safety;
-        let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).powf(0.25);
+        let synergy = 0.12 * (sep * cancer * residence_norm * healthy_cell_protection).nth_root(4);
 
         Some((base + synergy).clamp(0.0, 1.0))
     }
@@ -229,7 +230,7 @@ impl ScoringSnapshot {
                 + 0.22 * acoustic_healthy_cell_protection
                 + 0.10 * safety;
             let synergy = 0.12
-                * (sep * cancer * residence_norm * acoustic_healthy_cell_protection).powf(0.25);
+                * (sep * cancer * residence_norm * acoustic_healthy_cell_protection).nth_root(4);
             (base + synergy).clamp(0.0, 1.0)
         };
 
@@ -249,7 +250,7 @@ impl ScoringSnapshot {
                 * residence_norm
                 * healthy_cell_protection
                 * dean_norm)
-                .powf(0.2);
+                .nth_root(5);
 
         Some((base + synergy).clamp(0.0, 1.0))
     }

--- a/crates/cfd-optim/src/metrics/venturi.rs
+++ b/crates/cfd-optim/src/metrics/venturi.rs
@@ -6,6 +6,7 @@ use cfd_core::physics::cavitation::{
     CellMechanicalState, CellPopulationIdentity, PopulationNucleationState,
     SelectiveCavitationInput, SelectiveCavitationPopulation,
 };
+use eunomia::FloatElement;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -36,7 +37,7 @@ fn venturi_selectivity_geometric_synergy(
     healthy_cell_protection: f64,
 ) -> f64 {
     0.15 * (cavitation_term * selective_margin_term * cancer_enrich * healthy_cell_protection)
-        .powf(0.25)
+        .nth_root(4)
 }
 
 fn selective_cavitation_input(

--- a/crates/cfd-optim/src/reporting/therapy_utility.rs
+++ b/crates/cfd-optim/src/reporting/therapy_utility.rs
@@ -27,6 +27,7 @@
 //! generating objective, while ultrasound-only designs are not misclassified as
 //! non-cavitating merely because they have no venturi throat.
 
+use eunomia::FloatElement;
 use crate::constraints::{PEDIATRIC_BLOOD_VOLUME_ML_PER_KG, PEDIATRIC_REFERENCE_WEIGHT_KG};
 use crate::SdtMetrics;
 
@@ -94,7 +95,7 @@ pub fn therapy_utility_components(metrics: &SdtMetrics) -> TherapyUtilityCompone
         0.0
     };
     let synergy = if has_cavitation_delivery {
-        0.10 * (cavitation_delivery * healthy_cell_protection * routing * residence).powf(0.25)
+        0.10 * (cavitation_delivery * healthy_cell_protection * routing * residence).nth_root(4)
     } else {
         0.0
     };

--- a/crates/cfd-validation/src/benchmarks/threed/bifurcation.rs
+++ b/crates/cfd-validation/src/benchmarks/threed/bifurcation.rs
@@ -180,7 +180,7 @@ mod tests {
     fn test_bifurcation_flow_3d_murray_and_mass() {
         let d_parent = 100e-6_f64;
         // Murray-optimal daughter diameter: D_d = D_p / 2^(1/3)
-        let d_daughter = d_parent / (2.0_f64.powf(1.0 / 3.0));
+        let d_daughter = d_parent / (2.0_f64.cbrt());
         let angle = PI / 6.0; // 30° half-angle
 
         let geometry = Bifurcation3D::symmetric(

--- a/crates/cfd-validation/tests/turbulence_model_validation.rs
+++ b/crates/cfd-validation/tests/turbulence_model_validation.rs
@@ -12,7 +12,7 @@
 //!   engineering applications". AIAA Journal, 32(8), 1598-1605.
 
 use cfd_2d::physics::turbulence::{k_epsilon::KEpsilonModel, traits::TurbulenceModel};
-use eunomia::assert_relative_eq;
+use eunomia::{assert_relative_eq, FloatElement};
 
 /// Flat plate boundary layer test case per White (2006)
 ///
@@ -30,7 +30,7 @@ fn test_k_epsilon_flat_plate_boundary_layer() {
     let x = re_x * nu / u_inf; // ≈ 1.5 m
 
     // Expected boundary layer thickness: δ ≈ 0.37 x / Re_x^(1/5)
-    let delta = 0.37 * x / re_x.powf(0.2); // ≈ 0.0148 m
+    let delta = 0.37 * x / re_x.nth_root(5); // ≈ 0.0148 m
 
     // k-ε model initialization
     let nx = 100;
@@ -55,7 +55,7 @@ fn test_k_epsilon_flat_plate_boundary_layer() {
 
     // Skin friction coefficient: C_f = 2 τ_w / (ρ U∞²)
     // For turbulent flat plate: C_f ≈ 0.058 / Re_x^(1/5) (White correlation)
-    let cf_white = 0.058 / re_x.powf(0.2); // ≈ 0.00296
+    let cf_white = 0.058 / re_x.nth_root(5); // ≈ 0.00296
 
     // Turbulent viscosity ratio near wall
     let nu_t_ratio = nu_t / rho / nu;

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,18 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+## Legacy-dep closure — orphaned approx workspace dependency (2026-08-13)
+
+- Closed: removed the `approx = "0.5"` workspace dependency. It was an
+  orphaned legacy comparison crate with zero direct or transitive consumers —
+  not present in `Cargo.lock` and not in the resolved crate graph. CFDrs float
+  comparison is already Eunomia-backed (`assert_relative_eq!` / `FloatElement`),
+  so `approx` is fully superseded and the manifest entry was pure residue.
+- Evidence: `cargo metadata --locked --no-deps` rc=0 (lockfile unchanged),
+  `cargo check --workspace --offline` rc=0, `cargo tree -i approx` rc=101
+  (package absent from the resolved graph), and a tree-wide grep showing zero
+  `approx::` / `use approx` residue.
+
 ## Lint-floor gate — partial closure (2026-08-06)
 
 - The root workspace now owns the Atlas lint floor; every CFDrs workspace

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -55,6 +55,16 @@
   (package absent from the resolved graph), and a tree-wide grep showing zero
   `approx::` / `use approx` residue.
 
+## Legacy root-emulation closure — powf → FloatElement cbrt/rsqrt/nth_root (2026-08-13)
+
+- Closed: swept `powf`-emulated scalar roots out of the tree in favor of the
+  sign-preserving Eunomia `FloatElement` surface. Covers 18 files: 13
+  cube-root sites, 1 reciprocal cube-root, 2 rsqrt, 9 4th-root, 4 5th-root,
+  and 1 7th-root. `cfd-optim` gained the `eunomia` workspace dependency it
+  was missing.
+- Evidence: `cargo check --workspace --all-targets` rc=0; `cargo nextest run`
+  (cfd-1d/2d/3d/optim/validation) 2277 passed / 0 failed / 30 skipped.
+
 ## Lint-floor gate — partial closure (2026-08-06)
 
 - The root workspace now owns the Atlas lint floor; every CFDrs workspace

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -31,6 +31,18 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+## Legacy-audit coverage gap — approx/num-traits/rustfft unclassified (2026-08-13)
+
+- Closed: the `xtask` legacy-migration-audit only classified `nalgebra`,
+  `ndarray`, `burn`, `tokio`, and `rayon`, so `approx`, `num-traits`, and
+  `rustfft` could regress silently (this is how the orphaned
+  `approx = "0.5"` workspace dep evaded detection until
+  CFDRS-LEGACY-APPROX-001). The lists now include all three, matching the
+  kwavers audit surface, and two unit tests lock the detection.
+- Evidence: `cargo test -p xtask` 2/2, clean audit (0 legacy deps, 0 legacy
+  tokens), `cargo fmt -p xtask -- --check` and `cargo clippy -p xtask
+  --all-targets -- -D warnings` rc=0.
+
 ## Legacy-dep closure — orphaned approx workspace dependency (2026-08-13)
 
 - Closed: removed the `approx = "0.5"` workspace dependency. It was an

--- a/xtask/src/migration_audit.rs
+++ b/xtask/src/migration_audit.rs
@@ -11,6 +11,9 @@ const LEGACY_MANIFEST_DEPS: &[&str] = &[
     "burn-ndarray",
     "tokio",
     "rayon",
+    "approx",
+    "num-traits",
+    "rustfft",
 ];
 
 const LEGACY_SOURCE_TOKENS: &[&str] = &[
@@ -20,6 +23,9 @@ const LEGACY_SOURCE_TOKENS: &[&str] = &[
     "burn_ndarray",
     "tokio::",
     "rayon::",
+    "approx::",
+    "num_traits::",
+    "rustfft::",
 ];
 
 const ATLAS_MANIFEST_DEPS: &[&str] = &["moirai", "leto", "hephaestus", "coeus"];
@@ -297,4 +303,65 @@ fn source_allowlist_entry(path: &Path) -> String {
 
 fn normalized(path: &Path) -> String {
     path.display().to_string().replace('\\', "/")
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test fixtures panic on setup/teardown failure")]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn audit_flags_approx_num_traits_rustfft_manifest_surface() {
+        let root = temp_root();
+        fs::create_dir_all(root.join("crates/cfd-test")).unwrap();
+        fs::write(
+            root.join("crates/cfd-test/Cargo.toml"),
+            "[dependencies]\napprox = \"0.5\"\nnum-traits = \"0.2\"\nrustfft = \"6.0\"\n",
+        )
+        .unwrap();
+
+        let report = scan_legacy_migration_surface(&root).unwrap();
+
+        assert_eq!(
+            report.manifest_dependencies,
+            vec![PathBuf::from("crates/cfd-test/Cargo.toml")]
+        );
+        assert!(report.source_references.is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn audit_flags_approx_num_traits_rustfft_source_tokens() {
+        let root = temp_root();
+        let source = root.join("crates/cfd-test/src/lib.rs");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(
+            &source,
+            "use approx::AbsDiffEq;\nuse num_traits::Float;\nuse rustfft::FftPlanner;\n",
+        )
+        .unwrap();
+
+        let report = scan_legacy_migration_surface(&root).unwrap();
+
+        assert!(report.manifest_dependencies.is_empty());
+        assert_eq!(
+            report.source_references,
+            vec![SourceReference {
+                path: PathBuf::from("crates/cfd-test/src/lib.rs"),
+                count: 3,
+            }]
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn temp_root() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("cfdrs-migration-audit-{nanos}"))
+    }
 }


### PR DESCRIPTION
## Summary

Closes the remaining legacy-dependency surface and migrates powf root emulation onto eunomia's sign-preserving `FloatElement`.

## Changes

- **`chore(deps)`**: removed the orphaned `approx = "0.5"` workspace dependency (zero consumers, never resolved in the graph).
- **`chore(xtask)`**: hardened `migration_audit.rs` to classify `approx`/`num-traits`/`rustfft` (manifest + source tokens) with two new unit tests — this is the gap that let `approx` slip through.
- **`refactor(deps)`**: migrated `powf` emulation sites onto eunomia:
  - `powf(1/3)` -> `.cbrt()`, `powf(-1/3)` -> `.cbrt().recip()`
  - `powf(-0.5)` -> `.rsqrt()`
  - `powf(0.25)`/`powf(0.2)` -> `.nth_root(4)`/`.nth_root(5)`
  - added `eunomia` dep to `cfd-optim`
- **`Cargo.lock`**: eunomia pin `085f217f` -> `1a52590`

## Verification

- `cargo check --workspace --offline` rc=0
- `cargo nextest run` (affected crates): **2277 passed, 0 failed**
- `cargo fmt` + `cargo clippy -p xtask --all-targets -- -D warnings` green

Depends on ryancinsight/eunomia#63 (merged).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR completes legacy dependency cleanup by removing the orphaned `approx = "0.5"` workspace dependency and migrating all `powf`-based root emulations to eunomia's `FloatElement` trait methods (`cbrt`, `rsqrt`, `nth_root`). The audit tooling in xtask was hardened to prevent similar gaps by extending legacy-crate detection to cover `approx`, `num-traits`, and `rustfft` with unit tests. The eunomia dependency was pinned to a newer commit and added to `cfd-optim` which previously lacked it. All 18 affected source files now use sign-preserving root methods instead of fractional-exponent `powf` calls, validated by 2277 passing tests.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `xtask/src/migration_audit.rs` |
| 2 | `Cargo.toml` |
| 3 | `Cargo.lock` |
| 4 | `crates/cfd-optim/Cargo.toml` |
| 5 | `crates/cfd-1d/src/physics/cell_separation/zweifach_fung.rs` |
| 6 | `crates/cfd-1d/src/physics/resistance/models/darcy_weisbach.rs` |
| 7 | `crates/cfd-1d/src/physics/resistance/models/slug_flow.rs` |
| 8 | `crates/cfd-1d/src/physics/vascular/murrays_law/law.rs` |
| 9 | `crates/cfd-1d/src/physics/vascular/murrays_law/mod.rs` |
| 10 | `crates/cfd-1d/tests/cell_separation_validation.rs` |
| 11 | `crates/cfd-2d/examples/bifurcation_schematic.rs` |
| 12 | `crates/cfd-2d/src/physics/turbulence/validation/les_des.rs` |
| 13 | `crates/cfd-3d/examples/bifurcation_3d_blood.rs` |
| 14 | `crates/cfd-3d/src/physics/turbulence/dynamic_gradient_smagorinsky.rs` |
| 15 | `crates/cfd-3d/src/physics/turbulence/k_omega_sst.rs` |
| 16 | `crates/cfd-optim/src/application/objectives/ga.rs` |
| 17 | `crates/cfd-optim/src/application/objectives/option1.rs` |
| 18 | `crates/cfd-optim/src/application/search/pool.rs` |
| 19 | `crates/cfd-optim/src/metrics/venturi.rs` |
| 20 | `crates/cfd-optim/src/reporting/therapy_utility.rs` |
| 21 | `crates/cfd-validation/src/benchmarks/threed/bifurcation.rs` |
| 22 | `crates/cfd-validation/tests/turbulence_model_validation.rs` |
| 23 | `CHECKLIST.md` |
| 24 | `backlog.md` |
| 25 | `gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated scientific calculations to use dedicated square-, cube-, fourth-, and fifth-root operations for more consistent numerical behavior.
  * Applied these improvements across flow, turbulence, vascular, optimization, validation, and example calculations.
  * Removed an unused dependency from the project.

* **Quality**
  * Expanded migration audits to detect legacy numerical dependencies and references.
  * Added verification coverage for the enhanced audit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->