### PR TITLE
feat(turbulence): Calibrate k-ε log-law constants against DNS via coeus-optim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "cfd-math",
  "cfd-schematics",
  "cfd-validation",
+ "coeus-optim",
  "criterion",
  "eunomia",
  "gaia-mesh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,10 @@ hephaestus-wgpu = { version = "0.19.0", git = "https://github.com/ryancinsight/h
 # athena-leto = Leto CPU backend). Used by cfd-math/linear_solver/krylov.rs.
 athena-core = { version = "0.1.0", git = "https://github.com/ryancinsight/athena" }
 athena-leto = { version = "0.1.0", git = "https://github.com/ryancinsight/athena" }
+# coeus: Atlas tensor/autodiff/NN/optimizer stack. coeus-optim's least-squares
+# (Levenberg-Marquardt) solver calibrates turbulence model constants against
+# DNS reference profiles in cfd-2d/physics/turbulence/constants_validation.
+coeus-optim = { version = "0.10.0", git = "https://github.com/ryancinsight/Coeus.git" }
 cfd-schematics = { path = "crates/cfd-schematics" }
 cfd-schematic-mesh = { path = "crates/cfd-schematic-mesh" }
 cfd-1d = { path = "crates/cfd-1d" }

--- a/crates/cfd-2d/Cargo.toml
+++ b/crates/cfd-2d/Cargo.toml
@@ -24,6 +24,7 @@ moirai.workspace = true
 eunomia.workspace = true
 leto.workspace = true
 leto-ops.workspace = true
+coeus-optim.workspace = true
 tracing.workspace = true
 aequitas = { workspace = true, features = ["serde"] }
 

--- a/crates/cfd-2d/src/physics/turbulence/constants_validation/calibration.rs
+++ b/crates/cfd-2d/src/physics/turbulence/constants_validation/calibration.rs
@@ -1,0 +1,296 @@
+//! Turbulence-constant calibration against DNS via Coeus least-squares.
+//!
+//! The sensitivity analysis in this module answers "how wrong is each
+//! constant?" by perturbing it ±10%. This submodule answers the complementary
+//! question — "which constants best reproduce the DNS reference?" — by
+//! nonlinear least-squares. The fit is solved by Coeus's
+//! Levenberg-Marquardt solver ([`coeus_optim::least_squares`]), keeping Coeus
+//! the single source of truth for first-order model calibration in CFDrs.
+//!
+//! # Identifiability of the k-ε constants
+//!
+//! In the equilibrium log-law region the standard k-ε model reduces to
+//!
+//! ```text
+//! κ² = √C_μ · (C_ε2 − C_ε1) · σ_ε
+//! ```
+//!
+//! so the mean-velocity profile `u⁺ = (1/κ) ln y⁺ + B` identifies only the
+//! *combination* κ — not the four constants separately (Pope 2000, §10.4).
+//! This module therefore calibrates the identifiable quantity (κ, together
+//! with the log-law intercept `B`) and reports how the fitted κ compares to
+//! the value the standard constants imply, rather than over-claiming a
+//! per-constant fit that the equilibrium data cannot support.
+
+use coeus_optim::{
+    levenberg_marquardt, LeastSquaresProblem, LeastSquaresReport, LevenbergMarquardtConfig,
+    ProblemError, Termination,
+};
+
+use super::dns_database::DnsChannelFlowDatabase;
+use crate::physics::turbulence::constants::{C1_EPSILON, C2_EPSILON, C_MU, SIGMA_EPSILON};
+
+/// Lower bound of the equilibrium log-law region in wall units.
+const LOG_LAW_Y_MIN: f64 = 30.0;
+
+/// Fraction of `Re_τ` that bounds the log-law region from above.
+const LOG_LAW_Y_MAX_FRACTION: f64 = 0.3;
+
+/// The equilibrium log-law problem: fit `u⁺ = (1/κ) ln y⁺ + B` to DNS.
+///
+/// Free parameters are `[κ, B]` (the von Karman constant and the log-law
+/// intercept). The DNS samples are restricted to `30 ≤ y⁺ ≤ 0.3·Re_τ`, where
+/// the equilibrium law-of-the-wall holds.
+pub struct LogLawProblem {
+    /// DNS mean-velocity samples in the log-law region, as `(y⁺, u⁺)` pairs.
+    points: Vec<(f64, f64)>,
+}
+
+impl LogLawProblem {
+    /// Build the problem from the DNS database, selecting the log-law region.
+    #[must_use]
+    pub fn from_database(db: &DnsChannelFlowDatabase) -> Self {
+        let y_max = LOG_LAW_Y_MAX_FRACTION * db.re_tau;
+        let points = db
+            .mean_velocity_profile
+            .iter()
+            .copied()
+            .filter(|(y, _)| *y >= LOG_LAW_Y_MIN && *y <= y_max)
+            .collect();
+        Self { points }
+    }
+
+    /// The number of free parameters (κ and B).
+    const PARAMETER_COUNT: usize = 2;
+
+    /// The log-law-region samples this problem fits against.
+    #[must_use]
+    pub fn points(&self) -> &[(f64, f64)] {
+        &self.points
+    }
+}
+
+impl LeastSquaresProblem<f64> for LogLawProblem {
+    fn residual_count(&self) -> usize {
+        self.points.len()
+    }
+
+    fn parameter_count(&self) -> usize {
+        Self::PARAMETER_COUNT
+    }
+
+    fn residuals(&self, parameters: &[f64], residuals: &mut [f64]) -> Result<(), ProblemError> {
+        let kappa = parameters[0];
+        let intercept = parameters[1];
+        if kappa <= 0.0 {
+            return Err(ProblemError::Domain {
+                reason: format!("non-positive von Karman constant κ = {kappa}"),
+            });
+        }
+        for (slot, (y, u_dns)) in residuals.iter_mut().zip(&self.points) {
+            *slot = y.ln() / kappa + intercept - u_dns;
+        }
+        Ok(())
+    }
+
+    fn jacobian(&self, parameters: &[f64], jacobian: &mut [f64]) -> Result<(), ProblemError> {
+        let kappa = parameters[0];
+        if kappa <= 0.0 {
+            return Err(ProblemError::Domain {
+                reason: format!("non-positive von Karman constant κ = {kappa}"),
+            });
+        }
+        let kappa_sq = kappa * kappa;
+        for (row, (y, _)) in self.points.iter().enumerate() {
+            // ∂u/∂κ = −ln y / κ², ∂u/∂B = 1.
+            jacobian[row * Self::PARAMETER_COUNT] = -y.ln() / kappa_sq;
+            jacobian[row * Self::PARAMETER_COUNT + 1] = 1.0;
+        }
+        Ok(())
+    }
+}
+
+/// Outcome of a log-law calibration.
+#[derive(Debug, Clone)]
+pub struct LogLawCalibration {
+    /// Calibrated von Karman constant κ.
+    pub kappa: f64,
+    /// Calibrated log-law intercept B.
+    pub intercept: f64,
+    /// `0.5‖r‖²` at the calibrated point.
+    pub cost: f64,
+    /// Iterations executed by the solver.
+    pub iterations: usize,
+    /// Why the solver stopped.
+    pub termination: Termination,
+}
+
+impl LogLawCalibration {
+    /// Root-mean-square residual of the calibrated fit against the DNS.
+    #[must_use]
+    pub fn rms_residual(&self, residual_count: usize) -> f64 {
+        if residual_count == 0 {
+            return 0.0;
+        }
+        (2.0 * self.cost / residual_count as f64).sqrt()
+    }
+}
+
+/// Calibrate the log-law `(κ, B)` against the DNS mean velocity.
+///
+/// The solver is started from the textbook values `κ = 0.41`, `B = 5.0` and
+/// refines them to the DNS samples in the log-law region.
+///
+/// # Panics
+///
+/// Panics if the solver returns an error. The problem is well-posed
+/// (two parameters, at least six residuals), so the only error paths are
+/// programmer error in this module rather than data-dependent failure.
+#[must_use]
+pub fn calibrate_log_law(db: &DnsChannelFlowDatabase) -> LogLawCalibration {
+    let problem = LogLawProblem::from_database(db);
+    let initial = [0.41_f64, 5.0_f64];
+    let config = LevenbergMarquardtConfig::default();
+    let report: LeastSquaresReport<f64> =
+        levenberg_marquardt(&problem, &initial, &config).expect("log-law fit is well-posed");
+    LogLawCalibration {
+        kappa: report.parameters[0],
+        intercept: report.parameters[1],
+        cost: report.cost,
+        iterations: report.iterations,
+        termination: report.termination,
+    }
+}
+
+/// The von Karman constant implied by the standard k-ε constants.
+///
+/// This is the equilibrium relation `κ² = √C_μ · (C_ε2 − C_ε1) · σ_ε`.
+#[must_use]
+pub fn kappa_from_k_epsilon_constants(
+    c_mu: f64,
+    c1_epsilon: f64,
+    c2_epsilon: f64,
+    sigma_epsilon: f64,
+) -> f64 {
+    (c_mu.sqrt() * (c2_epsilon - c1_epsilon) * sigma_epsilon).sqrt()
+}
+
+/// The κ implied by CFDrs's standard k-ε constants.
+#[must_use]
+pub fn standard_kappa() -> f64 {
+    kappa_from_k_epsilon_constants(C_MU, C1_EPSILON, C2_EPSILON, SIGMA_EPSILON)
+}
+
+/// Calibrate the k-ε log-law against DNS and compare to the standard constants.
+#[derive(Debug, Clone)]
+pub struct KepsilonCalibrationReport {
+    /// The raw log-law fit.
+    pub log_law: LogLawCalibration,
+    /// κ implied by the standard k-ε constants.
+    pub standard_kappa: f64,
+    /// Whether the calibrated κ stays within 10% of the standard value.
+    pub within_standard_band: bool,
+}
+
+impl KepsilonCalibrationReport {
+    /// Run the calibration and produce the comparison report.
+    #[must_use]
+    pub fn run(db: &DnsChannelFlowDatabase) -> Self {
+        let log_law = calibrate_log_law(db);
+        let standard_kappa = standard_kappa();
+        let within_standard_band = (log_law.kappa - standard_kappa).abs() <= 0.1 * standard_kappa;
+        Self {
+            log_law,
+            standard_kappa,
+            within_standard_band,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn database() -> DnsChannelFlowDatabase {
+        DnsChannelFlowDatabase::moser_1999_re590()
+    }
+
+    #[test]
+    fn standard_constants_imply_kappa_near_0_41() {
+        let kappa = standard_kappa();
+        assert!((kappa - 0.41).abs() < 0.05, "κ = {kappa}");
+    }
+
+    #[test]
+    fn log_law_region_contains_only_wall_units_between_30_and_177() {
+        let db = database();
+        let problem = LogLawProblem::from_database(&db);
+        assert!(problem.residual_count() >= problem.parameter_count());
+        for (y, _) in problem.points() {
+            assert!(*y >= LOG_LAW_Y_MIN && *y <= LOG_LAW_Y_MAX_FRACTION * db.re_tau);
+        }
+    }
+
+    #[test]
+    fn jacobian_matches_finite_differences() {
+        let db = database();
+        let problem = LogLawProblem::from_database(&db);
+        let parameters = [0.41_f64, 5.0_f64];
+        let n = problem.residual_count();
+        let p = problem.parameter_count();
+
+        let mut analytic = vec![0.0; n * p];
+        problem
+            .jacobian(&parameters, &mut analytic)
+            .expect("jacobian evaluation");
+
+        let h = 1e-6;
+        for column in 0..p {
+            let mut plus = parameters;
+            let mut minus = parameters;
+            plus[column] += h;
+            minus[column] -= h;
+            let mut r_plus = vec![0.0; n];
+            let mut r_minus = vec![0.0; n];
+            problem
+                .residuals(&plus, &mut r_plus)
+                .expect("residual evaluation");
+            problem
+                .residuals(&minus, &mut r_minus)
+                .expect("residual evaluation");
+            for row in 0..n {
+                let finite = (r_plus[row] - r_minus[row]) / (2.0 * h);
+                let analytic_value = analytic[row * p + column];
+                let tol = 1e-5 * (1.0 + analytic_value.abs());
+                assert!(
+                    (finite - analytic_value).abs() < tol,
+                    "row {row} col {column}: finite {finite} vs analytic {analytic_value}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn calibration_converges_and_reduces_error() {
+        let db = database();
+        let report = KepsilonCalibrationReport::run(&db);
+        assert!(report.log_law.termination.is_converged());
+        assert!(report.log_law.kappa > 0.2 && report.log_law.kappa < 0.6);
+        assert!(report.log_law.cost.is_finite());
+        // The fit must do better than the standard-constants profile at the
+        // same intercept, otherwise calibration bought nothing.
+        let problem = LogLawProblem::from_database(&db);
+        let standard = [standard_kappa(), 5.0_f64];
+        let mut residuals = vec![0.0; problem.residual_count()];
+        problem
+            .residuals(&standard, &mut residuals)
+            .expect("residual evaluation");
+        let standard_cost = 0.5 * residuals.iter().map(|r| r * r).sum::<f64>();
+        assert!(
+            report.log_law.cost < standard_cost,
+            "calibrated {:.6} should beat standard {:.6}",
+            report.log_law.cost,
+            standard_cost
+        );
+    }
+}

--- a/crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs
+++ b/crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs
@@ -20,9 +20,14 @@
 //! enforces these constraints either through exact transport equations or bounded eddy-viscosity
 //! formulations, ensuring physical realizability and numerical stability.
 
+mod calibration;
 mod dns_database;
 mod sensitivity;
 
+pub use calibration::{
+    calibrate_log_law, kappa_from_k_epsilon_constants, standard_kappa, KepsilonCalibrationReport,
+    LogLawCalibration, LogLawProblem,
+};
 pub use dns_database::DnsChannelFlowDatabase;
 
 use eunomia::{FloatElement, NumericElement, RealField};


### PR DESCRIPTION
## Summary

Adopts **coeus-optim**'s nonlinear least-squares solver (Levenberg-Marquardt) as the single source of truth for turbulence-constant calibration in CFDrs — the genuine coeus surface for this consumer, since CFDrs's existing optimization is evolutionary (GA/NSGA-II) rather than gradient-based.

## What changed

- `coeus-optim = 0.10.0` workspace dep (canonical `Coeus.git` URL, matching ritk/kwavers/helios; coeus-optim was already in the lock transitively via ritk, so the lock diff is **one line**).
- New `constants_validation::calibration` module:
  - `LogLawProblem` implements `LeastSquaresProblem<f64>` (residual + row-major Jacobian) for `u⁺ = (1/κ) ln y⁺ + B` over the equilibrium log-law region (`30 ≤ y⁺ ≤ 0.3·Re_τ`) of the Moser 1999 DNS database.
  - `calibrate_log_law` refines `(κ, B)` from the textbook start `(0.41, 5.0)`.
  - `kappa_from_k_epsilon_constants` / `standard_kappa` report the κ the standard k-ε constants imply (`κ² = √C_μ·(C_ε2−C_ε1)·σ_ε`).
  - `KepsilonCalibrationReport` compares the calibrated κ against the standard band (±10%).
- Tests: identifiability guard, log-law-region filter, finite-difference Jacobian check, and a convergence test that asserts the fit beats the standard-constants profile.

## Why coeus (not a blanket import)

CFDrs's fitting sites are closed-form (dynamic Smagorinsky `C_s² = ⟨L·M⟩/⟨M·M⟩`) or sensitivity-only; the optimization crates are Pareto/NSGA-II. coeus's headline tensors/autodiff have no consumer-local need, but `coeus-optim::least_squares` is the natural SSOT for coefficient *calibration*, which CFDrs validates today but does not calibrate.

## Verification

- `cargo check -p cfd-2d` — clean (0 warnings from the new module)
- `cargo nextest run -p cfd-2d constants_validation` — 10/10 pass
- `rustfmt --check` on the new file — clean
- `cargo clippy -p cfd-2d --lib --no-deps` — no findings in the new module (remaining cfd-2d debt is pre-existing and untouched)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR integrates the `coeus-optim` crate to calibrate turbulence model constants for the k-ε model against DNS reference data using Levenberg-Marquardt nonlinear least-squares optimization. The implementation fits the von Karman constant (κ) and log-law intercept (B) to the Moser 1999 DNS database within the equilibrium log-law region (30 ≤ y⁺ ≤ 0.3·Re_τ), accounting for the identifiability constraint that prevents fitting the four k-ε constants separately. The calibration module provides residual and Jacobian implementations, calibration routines, and validation tests to verify the fitted constants improve upon the standard textbook values.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `crates/cfd-2d/Cargo.toml` |
| 3 | `Cargo.lock` |
| 4 | `crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs` |
| 5 | `crates/cfd-2d/src/physics/turbulence/constants_validation/calibration.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS-based calibration of turbulence log-law parameters.
  * Added fitting and validation for the von Kármán constant and log-law intercept.
  * Added reporting to compare calibrated results with standard k-ε model constants.
  * Added publicly available calibration utilities and result types.
* **Tests**
  * Added coverage for constant derivation, data-region selection, Jacobian accuracy, and solver convergence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->