### PR TITLE
perf(cfd-2d): Reuse pressure CSR cache

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -35,6 +35,11 @@ jobs:
       # each backend into its own subdirectory, so the HTML lands in html/
       # rather than at build-dir. gaia points at the same subdirectory.
       output-path: target/book/cfdrs/html
+      # The book's workspace-context excerpts are explicitly ignored or text;
+      # the package build below is the compilation gate for the linked CFDrs
+      # examples, while mdBook catches any newly untyped Rust fence.
+      mdbook-test: true
+      cargo-package: cfd-validation
       # book.toml declares [output.linkcheck2] without optional = true, so
       # mdbook fails the render unless the backend binary is installed.
       mdbook-linkcheck2-version: "0.12.2"

--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -24,7 +24,7 @@ jobs:
     # Body owned once by Atlas (ADR 0035), pinned by SHA like any action. The
     # shared workflow keeps the pull-request build and skips deployment there,
     # so PRs still prove the book builds without publishing it.
-    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@4c31dd753f06dd93b4c04798cf781df253e3e532
+    uses: ryancinsight/atlas/.github/workflows/book-pages.yml@bb505e5e495c434c6ff1f52ffabe91deb594d23b
     permissions:
       contents: read
       # The shared deploy job publishes to Pages over OIDC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@
   separate local-resolution residual.
 - The Pages caller now builds `cfd-validation` and runs the shared `mdbook test`
   gate before publishing the CFDrs book.
+- **cfd-validation**: The backward-facing-step benchmark now borrows contiguous
+  Leto matrix storage once and hoists invariant stencil terms, removing repeated
+  layout work from its production hot loop without changing the update order or
+  committed Nextest budget. The preceding exact-head hosted run isolated the
+  remaining failure to `test_benchmark_run_integration` at 30.003 s.
 - `cfd-1d::giersiepen_hi` no longer hides a cfd-core validation error behind a
   zero result; documented negative inputs are handled before the provider call
   and the invariant is checked explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   35 µm and 3D trifurcation validation cases pass locally in 16.785 s and
   16.903 s under the unchanged nextest budget; hosted exact-head confirmation
   remains pending.
+- Book diagrams, equations, and commands now use explicit non-Rust fences, and
+  workspace-context API excerpts no longer enter mdBook's Rust doctest runner;
+  local `mdbook test` and rendered link-check build pass. Cargo example
+  verification remains gated on Apollo's public `PlanScratch` export.
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@
 - `cfd-1d::giersiepen_hi` no longer hides a cfd-core validation error behind a
   zero result; documented negative inputs are handled before the provider call
   and the invariant is checked explicitly.
-- `cfd-1d::giersiepen_hi` explicitly propagates NaN inputs as NaN, with
-  value-semantic regressions for both shear and exposure duration.
+- `cfd-1d::giersiepen_hi` explicitly propagates NaN inputs as NaN and
+  canonicalizes signed zero, with value-semantic regressions for both shear
+  and exposure duration.
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   graph and retained the documented `OPEN-033` fallback as the only orphan
   residual. The merged PM head `5b95fe3a` passes the provider Rust and
   book-figure gates at exact head.
+- cfd-2d pressure correction now borrows its immutable cached CSR Laplacian
+  instead of cloning the sparse matrix for every SIMPLE correction. The exact
+  35 µm and 3D trifurcation validation cases pass locally in 16.785 s and
+  16.903 s under the unchanged nextest budget; hosted exact-head confirmation
+  remains pending.
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 - `cfd-1d::giersiepen_hi` no longer hides a cfd-core validation error behind a
   zero result; documented negative inputs are handled before the provider call
   and the invariant is checked explicitly.
+- `cfd-1d::giersiepen_hi` explicitly propagates NaN inputs as NaN, with
+  value-semantic regressions for both shear and exposure duration.
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@
 - Book diagrams, equations, and commands now use explicit non-Rust fences, and
   workspace-context API excerpts no longer enter mdBook's Rust doctest runner;
   local `mdbook test` and rendered link-check build pass. Cargo example
-  verification remains gated on Apollo's public `PlanScratch` export.
+  verification is now gated on the merged Apollo default that exports the
+  provider-owned `PlanScratch` bound; the peer-dirty local overlay remains a
+  separate local-resolution residual.
+- The Pages caller now builds `cfd-validation` and runs the shared `mdbook test`
+  gate before publishing the CFDrs book.
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
   separate local-resolution residual.
 - The Pages caller now builds `cfd-validation` and runs the shared `mdbook test`
   gate before publishing the CFDrs book.
+- `cfd-1d::giersiepen_hi` no longer hides a cfd-core validation error behind a
+  zero result; documented negative inputs are handled before the provider call
+  and the invariant is checked explicitly.
 - Workspace packages now inherit the canonical Atlas lint floor; the initial
   ratchet increment also removes a cfd-core plugin resolver unwrap and makes
   xtask CLI output pass through a checked writer.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,14 +14,15 @@
 - [ ] Run the provider focused gate and publish the exact source head for
       hosted verification. Do not change the committed test budget or
       workload. Both exact hosted-timeout scenarios pass locally; hosted
-      confirmation remains the closure gate. At head `57722595`, the
+      confirmation remains the closure gate. At head `6ede137a`, the
       preceding Rust run `32043533301` failed before checkout on Atlas
       action-download 503/429 (`95426903063`), while the figure rerun passed
       (`95427953989`). Retry Pages job `95428903018` in run `32044071732` still
       failed before checkout on codeload 503/429, so the fontconfig fix has not
       yet executed hosted. Atlas `bb505e5` adds `libfontconfig1-dev` to that
-      shared workflow; this branch pins the exact fix. Figure rerun
-      `95428996925` passes and the Rust retry remains in progress.
+      shared workflow; this branch pins the exact fix. The source-correctness
+      head also defines NaN propagation for the hemolysis wrapper. New
+      exact-head CI and Pages runs `32044597678` and `32044597852` are queued.
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
       docs/book` and `mdbook build docs/book` pass.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,21 @@
 # CFDrs Work Checklist
 
+## ATLAS-CFDRS-PRESSURE-CACHE-102 [perf] — Remove repeated pressure-matrix clones
+
+- [x] Profile the exact hosted-timeout path and identify the repeated sparse
+      Laplacian clone in `cfd-2d` pressure correction.
+- [x] Borrow the immutable cached CSR operator in place; keep initial assembly,
+      right-hand-side construction, solver selection, tolerances, and output
+      semantics unchanged.
+- [x] Run the exact value-semantic regression through locked `cargo nextest`:
+      `microventuri_35um_case_produces_converged_informative_2d_result` passes
+      in 16.785 s under run
+      `5c15ba54-0b90-47a8-ab4c-f0eaf7b55d6c`.
+- [ ] Run the provider focused gate and publish the exact source head for
+      hosted verification. Do not change the committed test budget or
+      workload. Both exact hosted-timeout scenarios pass locally; hosted
+      confirmation remains the closure gate.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS [patch] — done 2026-08-17
 
 - [x] Wire `cfd-1d` resistance-model tests into the module graph and correct

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -21,7 +21,8 @@
       failed before checkout on codeload 503/429, so the fontconfig fix has not
       yet executed hosted. Atlas `bb505e5` adds `libfontconfig1-dev` to that
       shared workflow; this branch pins the exact fix. The source-correctness
-      head also defines NaN propagation for the hemolysis wrapper. New
+      head also defines NaN propagation and signed-zero canonicalization for
+      the hemolysis wrapper. New
       exact-head CI and Pages runs `32044597678` and `32044597852` are queued.
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,7 +14,12 @@
 - [ ] Run the provider focused gate and publish the exact source head for
       hosted verification. Do not change the committed test budget or
       workload. Both exact hosted-timeout scenarios pass locally; hosted
-      confirmation remains the closure gate.
+      confirmation remains the closure gate. At head `521d9f76`, CI run
+      `32043011439` failed before checkout because the pinned Rust-toolchain
+      action download returned 503/429 (`95425551229`); this is infrastructure
+      evidence, not a Rust or test failure. Pages run `32043011748` also failed
+      before checkout on `actions/configure-pages` 429/502
+      (`95425552255`); both failed jobs were rerun asynchronously.
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
       docs/book` and `mdbook build docs/book` pass.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -23,7 +23,16 @@
       shared workflow; this branch pins the exact fix. The source-correctness
       head also defines NaN propagation and signed-zero canonicalization for
       the hemolysis wrapper. New
-      exact-head CI and Pages runs `32044597678` and `32044597852` are queued.
+      exact-head CI and Pages runs `32046463302` and `32046464094` are queued
+      for source head `c86dc33f`. The preceding exact head `02c2ae80` reached
+      the hosted numerical-fidelity suite: 13/14 tests passed, while
+      `cfd-validation::benchmark_validation::test_benchmark_run_integration`
+      hit the unchanged 30-second budget at 30.003 s.
+- [x] Flatten the backward-facing-step stencil's contiguous Leto storage and
+      hoist invariant scalar terms in `c86dc33f`, preserving update order and
+      value semantics. Local format and diff gates pass; local locked Nextest
+      remains blocked before compilation by the shared Atlas overlay/lock
+      mismatch, so hosted exact-head verification is required.
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
       docs/book` and `mdbook build docs/book` pass.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -24,7 +24,10 @@
 - [ ] Verify the Cargo example gate against Apollo's merged default
       `ed6d6905afda394a9e12570543159ab1b262589e`, which contains provider fix
       `81583aab8b3eb48c96d138e3980e2c554d9d83fa`; the peer-dirty local overlay
-      remains at `c87a1abe` and is not modified.
+      remains at `c87a1abe` and is not modified. The current local
+      `cargo check --locked --examples` stops before compilation on the shared
+      overlay/lock mismatch; hosted exact-head package verification remains
+      the reproducible closure gate.
 
 ## ATLAS-ORPHAN-MODULES-096-CFDRS [patch] — done 2026-08-17
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -34,6 +34,15 @@
       overlay/lock mismatch; hosted exact-head package verification remains
       the reproducible closure gate.
 
+## ATLAS-CFDRS-HEMOLYSIS-107 [fix] — Remove silent model-error fallback
+
+- [x] Pre-validate the documented non-positive input behavior before the
+      provider call and remove `unwrap_or(0.0)` from `giersiepen_hi`.
+- [x] Preserve the existing negative-input and analytical reference tests.
+- [ ] Run the focused locked Nextest and hosted exact-head provider gate;
+      local compilation is currently blocked by the shared overlay/lock
+      mismatch, not by a source diagnostic.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS [patch] — done 2026-08-17
 
 - [x] Wire `cfd-1d` resistance-model tests into the module graph and correct

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,13 +14,14 @@
 - [ ] Run the provider focused gate and publish the exact source head for
       hosted verification. Do not change the committed test budget or
       workload. Both exact hosted-timeout scenarios pass locally; hosted
-      confirmation remains the closure gate. At head `90798ca7`, Rust run
-      `32043533301` failed before checkout on Atlas action-download 503/429
-      (`95426903063`), while the figure rerun passed (`95427953989`). Pages
-      run `32043533628` reached the package build and failed because the shared
-      workflow lacked `fontconfig.pc` for `yeslogic-fontconfig-sys`. Atlas
-      `bb505e5` adds `libfontconfig1-dev` to that shared workflow; this branch
-      pins the exact fix and requires a new exact-head run.
+      confirmation remains the closure gate. At head `57722595`, the
+      preceding Rust run `32043533301` failed before checkout on Atlas
+      action-download 503/429 (`95426903063`), while the figure rerun passed
+      (`95427953989`). Retry Pages job `95428903018` in run `32044071732` still
+      failed before checkout on codeload 503/429, so the fontconfig fix has not
+      yet executed hosted. Atlas `bb505e5` adds `libfontconfig1-dev` to that
+      shared workflow; this branch pins the exact fix. Figure rerun
+      `95428996925` passes and the Rust retry remains in progress.
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
       docs/book` and `mdbook build docs/book` pass.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -15,6 +15,12 @@
       hosted verification. Do not change the committed test budget or
       workload. Both exact hosted-timeout scenarios pass locally; hosted
       confirmation remains the closure gate.
+- [x] Retag every book diagram, equation, and command fence explicitly and
+      mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
+      docs/book` and `mdbook build docs/book` pass.
+- [ ] Re-run the Cargo example gate after Apollo merges
+      `81583aab8b3eb48c96d138e3980e2c554d9d83fa`; the current provider head
+      `c87a1abe` fails on the missing public `apollo_fft::PlanScratch` export.
 
 ## ATLAS-ORPHAN-MODULES-096-CFDRS [patch] — done 2026-08-17
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,12 +14,13 @@
 - [ ] Run the provider focused gate and publish the exact source head for
       hosted verification. Do not change the committed test budget or
       workload. Both exact hosted-timeout scenarios pass locally; hosted
-      confirmation remains the closure gate. At head `521d9f76`, CI run
-      `32043011439` failed before checkout because the pinned Rust-toolchain
-      action download returned 503/429 (`95425551229`); this is infrastructure
-      evidence, not a Rust or test failure. Pages run `32043011748` also failed
-      before checkout on `actions/configure-pages` 429/502
-      (`95425552255`); both failed jobs were rerun asynchronously.
+      confirmation remains the closure gate. At head `90798ca7`, Rust run
+      `32043533301` failed before checkout on Atlas action-download 503/429
+      (`95426903063`), while the figure rerun passed (`95427953989`). Pages
+      run `32043533628` reached the package build and failed because the shared
+      workflow lacked `fontconfig.pc` for `yeslogic-fontconfig-sys`. Atlas
+      `bb505e5` adds `libfontconfig1-dev` to that shared workflow; this branch
+      pins the exact fix and requires a new exact-head run.
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
       docs/book` and `mdbook build docs/book` pass.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -18,9 +18,13 @@
 - [x] Retag every book diagram, equation, and command fence explicitly and
       mark workspace-context API excerpts as `rust,ignore`; local `mdbook test
       docs/book` and `mdbook build docs/book` pass.
-- [ ] Re-run the Cargo example gate after Apollo merges
-      `81583aab8b3eb48c96d138e3980e2c554d9d83fa`; the current provider head
-      `c87a1abe` fails on the missing public `apollo_fft::PlanScratch` export.
+- [x] Enable the Pages caller's shared `mdbook-test` gate with
+      `cargo-package: cfd-validation`; hosted exact-head verification remains
+      pending after the caller change.
+- [ ] Verify the Cargo example gate against Apollo's merged default
+      `ed6d6905afda394a9e12570543159ab1b262589e`, which contains provider fix
+      `81583aab8b3eb48c96d138e3980e2c554d9d83fa`; the peer-dirty local overlay
+      remains at `c87a1abe` and is not modified.
 
 ## ATLAS-ORPHAN-MODULES-096-CFDRS [patch] — done 2026-08-17
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -41,6 +41,8 @@
 - [x] Pre-validate the documented non-positive input behavior before the
       provider call and remove `unwrap_or(0.0)` from `giersiepen_hi`.
 - [x] Preserve the existing negative-input and analytical reference tests.
+- [x] Define and test NaN propagation explicitly; positive infinity continues
+      through the provider's IEEE-754 arithmetic.
 - [ ] Run the focused locked Nextest and hosted exact-head provider gate;
       local compilation is currently blocked by the shared overlay/lock
       mismatch, not by a source diagnostic.

--- a/backlog.md
+++ b/backlog.md
@@ -96,9 +96,10 @@ closure check.
 documented negative-input behavior before calling the cfd-core model and uses
 an invariant-checked `expect` for the provider result. A provider invariant
 violation can no longer be silently converted into a zero hemolysis
-index. NaN inputs now propagate as NaN explicitly, with value-semantic
-regressions alongside the negative-input and reference-value tests. The
-existing behavioral oracle remains unchanged for valid and negative inputs.
+index. NaN inputs now propagate as NaN explicitly and signed zero is
+canonicalized to positive zero, with value-semantic regressions alongside the
+negative-input and reference-value tests. The existing behavioral oracle
+remains unchanged for valid and negative inputs.
 `cargo fmt --all -- --check` passes; the focused locked Nextest command is
 currently blocked before compilation by the shared Atlas overlay/lock mismatch
 recorded above. Hosted exact-head verification is required before closure.

--- a/backlog.md
+++ b/backlog.md
@@ -86,6 +86,18 @@ is a lock/overlay environment residual, not evidence of a missing Apollo
 `PlanScratch` export; the hosted exact-head package gate is the reproducible
 closure check.
 
+## ATLAS-CFDRS-HEMOLYSIS-107 [fix] — Remove silent model-error fallback (in progress 2026-08-17)
+
+`crates/cfd-1d/src/physics/hemolysis/models.rs:25-35` now handles the
+documented negative-input behavior before calling the cfd-core model and uses
+an invariant-checked `expect` for the provider result. A future provider
+validation error can no longer be silently converted into a zero hemolysis
+index. The existing value-semantic negative-input and reference-value tests
+remain the behavioral oracle. `cargo fmt --all -- --check` passes; the focused
+locked Nextest command is currently blocked before compilation by the shared
+Atlas overlay/lock mismatch recorded above. Hosted exact-head verification is
+required before closure.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS — Close unreachable source modules [patch] — done 2026-08-17
 
 **Owner:** Atlas session; source merged as `54dcea3c`.

--- a/backlog.md
+++ b/backlog.md
@@ -58,7 +58,7 @@ The Pages caller now enables the shared `mdbook-test` gate and builds
 `cfd-validation` before testing; hosted confirmation is part of the exact-head
 closure below.
 
-At exact head `57722595`, the preceding hosted Rust job `95426903063` in run
+At exact head `6ede137a`, the preceding hosted Rust job `95426903063` in run
 `32043533301` failed before checkout while downloading the pinned Atlas
 reusable action: GitHub returned 503 and then 429. The figure job passed after
 the failed-job rerun (`95427953989`). Pages job `95428903018` in run
@@ -66,8 +66,9 @@ the failed-job rerun (`95427953989`). Pages job `95428903018` in run
 codeload 503/429, so the fontconfig fix has not yet executed on hosted
 infrastructure. Atlas commit `bb505e5` adds the required
 `libfontconfig1-dev` install to the shared book workflow; this branch pins
-that exact shared-workflow commit. Figure rerun `95428996925` passes and the
-Rust retry remains in progress.
+that exact shared-workflow commit. The source-correctness head also defines
+NaN propagation for the hemolysis wrapper and adds value-semantic regressions.
+New exact-head CI and Pages runs `32044597678` and `32044597852` are queued.
 
 ## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — hosted closure pending 2026-08-17
 

--- a/backlog.md
+++ b/backlog.md
@@ -58,6 +58,14 @@ The Pages caller now enables the shared `mdbook-test` gate and builds
 `cfd-validation` before testing; hosted confirmation is part of the exact-head
 closure below.
 
+At exact pre-runtime-fix head `02c2ae80`, hosted CI run `32044765872` completed
+format, check, ordinary tests, and 13/14 numerical-fidelity tests, but
+`cfd-validation::benchmark_validation::test_benchmark_run_integration` hit the
+committed 30-second Nextest timeout at 30.003 s. The source fix at `c86dc33f`
+borrows contiguous Leto matrix storage once and hoists invariant stencil terms;
+it preserves the finite-difference update order and the test budget. New exact
+head CI run `32046463302` and Pages run `32046464094` are queued.
+
 At exact head `6ede137a`, the preceding hosted Rust job `95426903063` in run
 `32043533301` failed before checkout while downloading the pinned Atlas
 reusable action: GitHub returned 503 and then 429. The figure job passed after

--- a/backlog.md
+++ b/backlog.md
@@ -51,19 +51,25 @@ Book verification is now deterministic: all diagrams, equations, and shell
 commands use explicit non-Rust fences, and workspace-context API excerpts use
 `rust,ignore` with links to their canonical source files. `mdbook test
 docs/book` and `mdbook build docs/book` both pass locally. The separate Cargo
-example gate remains blocked by the upstream Apollo public-bound change below;
-no downstream compatibility trait is added.
+example gate cannot resolve against the peer-dirty local Apollo overlay; the
+merged Apollo default and hosted exact-head package gate are the closure path.
+No downstream compatibility trait is added.
+The Pages caller now enables the shared `mdbook-test` gate and builds
+`cfd-validation` before testing; hosted confirmation is part of the exact-head
+closure below.
 
-## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — blocked upstream 2026-08-17
+## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — hosted closure pending 2026-08-17
 
 `cargo check --offline --examples` reaches `cfd-3d` and fails because
 `crates/cfd-3d/src/spectral/fourier.rs` imports `apollo_fft::PlanScratch`, but
-the exact Apollo provider at `c87a1abe` does not re-export that public bound.
-Apollo already has the provider-owned fix on remote head
-`81583aab8b3eb48c96d138e3980e2c554d9d83fa` (`feat(apollo-fft): Expose plan
-scratch bound`), which makes `plan_scratch` public and re-exports the trait.
-The CFDrs consumer must advance only after that upstream change merges; a
-local adapter or private-module import would violate provider ownership.
+the peer-dirty local Apollo overlay at `c87a1abe` does not re-export that
+public bound. The provider-owned fix `81583aab8b3eb48c96d138e3980e2c554d9d83fa`
+is merged in Apollo's default at `ed6d6905afda394a9e12570543159ab1b262589e`
+(`feat(apollo-fft): Expose plan scratch bound`), which makes `plan_scratch`
+public and re-exports the trait. The CFDrs hosted exact-head gate must now
+verify the package/example build against that merged Apollo default; the
+peer-dirty local overlay is not modified, and no local adapter or private
+module import is added.
 
 ## ATLAS-ORPHAN-MODULES-096-CFDRS — Close unreachable source modules [patch] — done 2026-08-17
 

--- a/backlog.md
+++ b/backlog.md
@@ -47,6 +47,24 @@ hosted baseline had timed out at 30.005--30.007 s, so these are not controlled
 cross-machine speedup claims; provider hosted confirmation at the exact
 post-change head remains pending.
 
+Book verification is now deterministic: all diagrams, equations, and shell
+commands use explicit non-Rust fences, and workspace-context API excerpts use
+`rust,ignore` with links to their canonical source files. `mdbook test
+docs/book` and `mdbook build docs/book` both pass locally. The separate Cargo
+example gate remains blocked by the upstream Apollo public-bound change below;
+no downstream compatibility trait is added.
+
+## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — blocked upstream 2026-08-17
+
+`cargo check --offline --examples` reaches `cfd-3d` and fails because
+`crates/cfd-3d/src/spectral/fourier.rs` imports `apollo_fft::PlanScratch`, but
+the exact Apollo provider at `c87a1abe` does not re-export that public bound.
+Apollo already has the provider-owned fix on remote head
+`81583aab8b3eb48c96d138e3980e2c554d9d83fa` (`feat(apollo-fft): Expose plan
+scratch bound`), which makes `plan_scratch` public and re-exports the trait.
+The CFDrs consumer must advance only after that upstream change merges; a
+local adapter or private-module import would violate provider ownership.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS — Close unreachable source modules [patch] — done 2026-08-17
 
 **Owner:** Atlas session; source merged as `54dcea3c`.

--- a/backlog.md
+++ b/backlog.md
@@ -58,13 +58,15 @@ The Pages caller now enables the shared `mdbook-test` gate and builds
 `cfd-validation` before testing; hosted confirmation is part of the exact-head
 closure below.
 
-At exact head `521d9f76`, hosted CI run `32043011439` failed before checkout
-while downloading the pinned `dtolnay/rust-toolchain` action: GitHub returned
-503 and then 429 after the runner's three retries (job `95425551229`). The
-book run `32043011748` independently failed before checkout while downloading
-`actions/configure-pages` with 429/502 responses (job `95425552255`). These are
-infrastructure failures with no source or test execution. Both failed jobs
-were rerun asynchronously.
+At exact head `90798ca7`, hosted Rust job `95426903063` in run
+`32043533301` failed before checkout while downloading the pinned Atlas
+reusable action: GitHub returned 503 and then 429. The figure job passed after
+the failed-job rerun (`95427953989`). Pages job `95426905897` in run
+`32043533628` reached the package build and exposed a missing hosted system
+dependency: `yeslogic-fontconfig-sys` could not find `fontconfig.pc`. Atlas
+commit `bb505e5` adds the required `libfontconfig1-dev` install to the shared
+book workflow; this branch pins that exact shared-workflow commit. The source
+and book gates remain open until the new exact-head run completes.
 
 ## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — hosted closure pending 2026-08-17
 

--- a/backlog.md
+++ b/backlog.md
@@ -71,6 +71,13 @@ verify the package/example build against that merged Apollo default; the
 peer-dirty local overlay is not modified, and no local adapter or private
 module import is added.
 
+The fresh local command `cargo check --locked --examples` now stops before
+compilation because the shared Atlas development overlay patches peer-local
+first-party trees that are not represented by this standalone lockfile. This
+is a lock/overlay environment residual, not evidence of a missing Apollo
+`PlanScratch` export; the hosted exact-head package gate is the reproducible
+closure check.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS — Close unreachable source modules [patch] — done 2026-08-17
 
 **Owner:** Atlas session; source merged as `54dcea3c`.

--- a/backlog.md
+++ b/backlog.md
@@ -58,15 +58,16 @@ The Pages caller now enables the shared `mdbook-test` gate and builds
 `cfd-validation` before testing; hosted confirmation is part of the exact-head
 closure below.
 
-At exact head `90798ca7`, hosted Rust job `95426903063` in run
+At exact head `57722595`, the preceding hosted Rust job `95426903063` in run
 `32043533301` failed before checkout while downloading the pinned Atlas
 reusable action: GitHub returned 503 and then 429. The figure job passed after
-the failed-job rerun (`95427953989`). Pages job `95426905897` in run
-`32043533628` reached the package build and exposed a missing hosted system
-dependency: `yeslogic-fontconfig-sys` could not find `fontconfig.pc`. Atlas
-commit `bb505e5` adds the required `libfontconfig1-dev` install to the shared
-book workflow; this branch pins that exact shared-workflow commit. The source
-and book gates remain open until the new exact-head run completes.
+the failed-job rerun (`95427953989`). Pages job `95428903018` in run
+`32044071732` still failed before checkout on `actions/configure-pages`
+codeload 503/429, so the fontconfig fix has not yet executed on hosted
+infrastructure. Atlas commit `bb505e5` adds the required
+`libfontconfig1-dev` install to the shared book workflow; this branch pins
+that exact shared-workflow commit. Figure rerun `95428996925` passes and the
+Rust retry remains in progress.
 
 ## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — hosted closure pending 2026-08-17
 

--- a/backlog.md
+++ b/backlog.md
@@ -29,6 +29,24 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # CFDrs Backlog
 
+## ATLAS-CFDRS-PRESSURE-CACHE-102 [perf] — Remove repeated pressure-matrix clones (in progress 2026-08-17)
+
+**Owner:** Atlas session; scope is the provider-owned cfd-2d pressure
+correction path. **Acceptance:** preserve the pressure operator and output
+values while eliminating the cached-CSR clone on each SIMPLE correction;
+prove the exact 35 µm validation case under the unchanged nextest budget;
+then pass the provider hosted gate at the exact source head.
+
+The implementation now borrows the immutable cached Laplacian in place. The
+initial assembly still stores one cache copy; subsequent corrections reuse the
+same sparse topology and values while rebuilding only the right-hand side and
+solution. Exact local Nextest run `5c15ba54-0b90-47a8-ab4c-f0eaf7b55d6c`
+passes `microventuri_35um_case_produces_converged_informative_2d_result` in
+16.785 s. The exact trifurcation case also passes locally in 16.903 s. The
+hosted baseline had timed out at 30.005--30.007 s, so these are not controlled
+cross-machine speedup claims; provider hosted confirmation at the exact
+post-change head remains pending.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS — Close unreachable source modules [patch] — done 2026-08-17
 
 **Owner:** Atlas session; source merged as `54dcea3c`.

--- a/backlog.md
+++ b/backlog.md
@@ -93,13 +93,14 @@ closure check.
 
 `crates/cfd-1d/src/physics/hemolysis/models.rs:25-35` now handles the
 documented negative-input behavior before calling the cfd-core model and uses
-an invariant-checked `expect` for the provider result. A future provider
-validation error can no longer be silently converted into a zero hemolysis
-index. The existing value-semantic negative-input and reference-value tests
-remain the behavioral oracle. `cargo fmt --all -- --check` passes; the focused
-locked Nextest command is currently blocked before compilation by the shared
-Atlas overlay/lock mismatch recorded above. Hosted exact-head verification is
-required before closure.
+an invariant-checked `expect` for the provider result. A provider invariant
+violation can no longer be silently converted into a zero hemolysis
+index. NaN inputs now propagate as NaN explicitly, with value-semantic
+regressions alongside the negative-input and reference-value tests. The
+existing behavioral oracle remains unchanged for valid and negative inputs.
+`cargo fmt --all -- --check` passes; the focused locked Nextest command is
+currently blocked before compilation by the shared Atlas overlay/lock mismatch
+recorded above. Hosted exact-head verification is required before closure.
 
 ## ATLAS-ORPHAN-MODULES-096-CFDRS — Close unreachable source modules [patch] — done 2026-08-17
 

--- a/backlog.md
+++ b/backlog.md
@@ -58,6 +58,14 @@ The Pages caller now enables the shared `mdbook-test` gate and builds
 `cfd-validation` before testing; hosted confirmation is part of the exact-head
 closure below.
 
+At exact head `521d9f76`, hosted CI run `32043011439` failed before checkout
+while downloading the pinned `dtolnay/rust-toolchain` action: GitHub returned
+503 and then 429 after the runner's three retries (job `95425551229`). The
+book run `32043011748` independently failed before checkout while downloading
+`actions/configure-pages` with 429/502 responses (job `95425552255`). These are
+infrastructure failures with no source or test execution. Both failed jobs
+were rerun asynchronously.
+
 ## ATLAS-CFDRS-APOLLO-PLAN-SCRATCH-104 [arch] — hosted closure pending 2026-08-17
 
 `cargo check --offline --examples` reaches `cfd-3d` and fails because

--- a/crates/cfd-1d/src/physics/hemolysis/mod.rs
+++ b/crates/cfd-1d/src/physics/hemolysis/mod.rs
@@ -114,6 +114,18 @@ mod tests {
     }
 
     #[test]
+    fn giersiepen_signed_zero_is_canonical_zero() {
+        assert_eq!(
+            giersiepen_hi(shear(-0.0), duration(1.0)).to_bits(),
+            0.0_f64.to_bits()
+        );
+        assert_eq!(
+            giersiepen_hi(shear(1.0), duration(-0.0)).to_bits(),
+            0.0_f64.to_bits()
+        );
+    }
+
+    #[test]
     fn giersiepen_reference_value_at_100pa_1s() {
         // HI = 3.62e-5 × 1^0.765 × 100^1.991
         let expected =

--- a/crates/cfd-1d/src/physics/hemolysis/mod.rs
+++ b/crates/cfd-1d/src/physics/hemolysis/mod.rs
@@ -108,6 +108,12 @@ mod tests {
     }
 
     #[test]
+    fn giersiepen_nan_inputs_propagate_nan() {
+        assert!(giersiepen_hi(shear(f64::NAN), duration(1.0)).is_nan());
+        assert!(giersiepen_hi(shear(1.0), duration(f64::NAN)).is_nan());
+    }
+
+    #[test]
     fn giersiepen_reference_value_at_100pa_1s() {
         // HI = 3.62e-5 × 1^0.765 × 100^1.991
         let expected =

--- a/crates/cfd-1d/src/physics/hemolysis/models.rs
+++ b/crates/cfd-1d/src/physics/hemolysis/models.rs
@@ -5,7 +5,7 @@ use aequitas::systems::si::quantities::{Pressure, Time};
 /// Thin wrapper delegating to [`cfd_core::physics::hemolysis::HemolysisModel::giersiepen_millifluidic`]
 /// so that the single source of truth for all model constants lives in cfd-core.
 /// Returns `0.0` for non-positive inputs (no damage when shear or time is
-/// zero or negative) and `0.0` on conversion error (never expected in practice).
+/// zero or negative).
 ///
 /// # Arguments
 ///
@@ -23,9 +23,15 @@ use aequitas::systems::si::quantities::{Pressure, Time};
 #[inline]
 #[must_use]
 pub fn giersiepen_hi(shear: Pressure, duration: Time) -> f64 {
+    let shear_pa = shear.into_base();
+    let duration_s = duration.into_base();
+    if shear_pa < 0.0 || duration_s < 0.0 {
+        return 0.0;
+    }
+
     cfd_core::physics::hemolysis::HemolysisModel::giersiepen_millifluidic()
-        .damage_index(shear.into_base(), duration.into_base())
-        .unwrap_or(0.0)
+        .damage_index(shear_pa, duration_s)
+        .expect("invariant: non-negative shear and duration satisfy the hemolysis model")
 }
 
 /// Amplify a baseline Giersiepen HI by the local cavitation potential.

--- a/crates/cfd-1d/src/physics/hemolysis/models.rs
+++ b/crates/cfd-1d/src/physics/hemolysis/models.rs
@@ -4,8 +4,9 @@ use aequitas::systems::si::quantities::{Pressure, Time};
 ///
 /// Thin wrapper delegating to [`cfd_core::physics::hemolysis::HemolysisModel::giersiepen_millifluidic`]
 /// so that the single source of truth for all model constants lives in cfd-core.
-/// Returns `0.0` for non-positive finite inputs. NaN inputs propagate as NaN;
-/// positive infinity follows the IEEE-754 arithmetic of the provider model.
+/// Returns `0.0` for negative or zero inputs, including negative infinity.
+/// NaN inputs propagate as NaN; positive infinity follows the IEEE-754
+/// arithmetic of the provider model.
 ///
 /// # Arguments
 ///
@@ -27,6 +28,9 @@ pub fn giersiepen_hi(shear: Pressure, duration: Time) -> f64 {
     let duration_s = duration.into_base();
     if shear_pa.is_nan() || duration_s.is_nan() {
         return f64::NAN;
+    }
+    if shear_pa == 0.0 || duration_s == 0.0 {
+        return 0.0;
     }
     if shear_pa < 0.0 || duration_s < 0.0 {
         return 0.0;

--- a/crates/cfd-1d/src/physics/hemolysis/models.rs
+++ b/crates/cfd-1d/src/physics/hemolysis/models.rs
@@ -4,8 +4,8 @@ use aequitas::systems::si::quantities::{Pressure, Time};
 ///
 /// Thin wrapper delegating to [`cfd_core::physics::hemolysis::HemolysisModel::giersiepen_millifluidic`]
 /// so that the single source of truth for all model constants lives in cfd-core.
-/// Returns `0.0` for non-positive inputs (no damage when shear or time is
-/// zero or negative).
+/// Returns `0.0` for non-positive finite inputs. NaN inputs propagate as NaN;
+/// positive infinity follows the IEEE-754 arithmetic of the provider model.
 ///
 /// # Arguments
 ///
@@ -25,6 +25,9 @@ use aequitas::systems::si::quantities::{Pressure, Time};
 pub fn giersiepen_hi(shear: Pressure, duration: Time) -> f64 {
     let shear_pa = shear.into_base();
     let duration_s = duration.into_base();
+    if shear_pa.is_nan() || duration_s.is_nan() {
+        return f64::NAN;
+    }
     if shear_pa < 0.0 || duration_s < 0.0 {
         return 0.0;
     }

--- a/crates/cfd-2d/src/pressure_velocity/correction.rs
+++ b/crates/cfd-2d/src/pressure_velocity/correction.rs
@@ -270,13 +270,7 @@ impl<T: CfdScalar + Copy + Debug + FloatElement + LetoScalar> PressureCorrection
                     .is_some_and(|cached| cached == dirichlet_sides)
         });
 
-        let matrix = if matrix_cache_valid {
-            self._laplacian_cache
-                .borrow()
-                .as_ref()
-                .expect("invariant: pressure matrix cache validity was established above")
-                .clone()
-        } else {
+        if !matrix_cache_valid {
             let mut builder = self.take_matrix_builder(system_size, system_size);
             let dx2_inv = scalar::one::<T>() / (dx * dx);
             let dy2_inv = scalar::one::<T>() / (dy * dy);
@@ -346,8 +340,7 @@ impl<T: CfdScalar + Copy + Debug + FloatElement + LetoScalar> PressureCorrection
             *self._laplacian_cache.borrow_mut() = Some(matrix.clone());
             *self._face_matrix_mask.borrow_mut() = Some(mask.to_vec());
             *self._face_matrix_dirichlet.borrow_mut() = Some(dirichlet_sides);
-            matrix
-        };
+        }
 
         for i in 1..nx - 1 {
             for j in 1..ny - 1 {
@@ -374,18 +367,28 @@ impl<T: CfdScalar + Copy + Debug + FloatElement + LetoScalar> PressureCorrection
             ._solution_cache
             .borrow_mut()
             .take()
-            .filter(|vector| vector.shape()[0] == matrix.nrows())
-            .unwrap_or_else(|| Array1::from_elem([matrix.nrows()], scalar::zero::<T>()));
+            .filter(|vector| vector.shape()[0] == system_size)
+            .unwrap_or_else(|| Array1::from_elem([system_size], scalar::zero::<T>()));
         p_correction_vec.fill(scalar::zero::<T>());
-        self.dispatch_solve(&matrix, &rhs, &mut p_correction_vec)?;
+        {
+            // The topology is immutable after the first assembly. Borrowing it
+            // in place avoids cloning every pressure matrix on the hot path;
+            // the prior clone copied all sparse values for every SIMPLE
+            // correction even though only the right-hand side changes.
+            let matrix_cache = self._laplacian_cache.borrow();
+            let matrix = matrix_cache
+                .as_ref()
+                .expect("invariant: pressure matrix is cached after assembly");
+            self.dispatch_solve(matrix, &rhs, &mut p_correction_vec)?;
 
-        self.scatter_correction(
-            &p_correction_vec,
-            reference_idx,
-            &map_index,
-            boundary_conditions,
-            output_correction,
-        )?;
+            self.scatter_correction(
+                &p_correction_vec,
+                reference_idx,
+                &map_index,
+                boundary_conditions,
+                output_correction,
+            )?;
+        }
 
         *self._rhs_cache.borrow_mut() = Some(rhs);
         *self._solution_cache.borrow_mut() = Some(p_correction_vec);

--- a/crates/cfd-validation/src/benchmarks/step.rs
+++ b/crates/cfd-validation/src/benchmarks/step.rs
@@ -76,6 +76,20 @@ impl<T: RealField + Copy + FloatElement> Benchmark<T> for BackwardFacingStep<T> 
         let nu = self.inlet_velocity * self.step_height / reynolds; // Kinematic viscosity
         let min_spacing = scalar::min(dx, dy);
         let dt = <T as FloatElement>::from_f64(0.01) * min_spacing * min_spacing / nu; // CFL condition
+        let dx_squared = dx * dx;
+        let dy_squared = dy * dy;
+        let two = <T as FloatElement>::from_f64(2.0);
+        let relaxation = <T as FloatElement>::from_f64(0.7);
+
+        // `zeros` constructs a C-contiguous Array2. Borrowing its dense storage
+        // once keeps the stencil hot loop on flat slices instead of recomputing
+        // a two-dimensional layout offset for every neighbor access.
+        let u_data = u
+            .as_slice_mut()
+            .expect("invariant: zero-initialized velocity field is contiguous");
+        let v_data = v
+            .as_slice_mut()
+            .expect("invariant: zero-initialized velocity field is contiguous");
 
         // Iterative solver for demonstration
         let mut convergence = Vec::new();
@@ -88,40 +102,31 @@ impl<T: RealField + Copy + FloatElement> Benchmark<T> for BackwardFacingStep<T> 
             // Note: DMatrix indexing is (row, col) = (j, i) where j is y-direction, i is x-direction
             for j in 1..ny - 1 {
                 for i in 1..nx - 1 {
-                    let u_old = u[(j, i)];
+                    let index = j * nx + i;
+                    let u_old = u_data[index];
 
                     // Gauss-Seidel update for momentum equation with proper physics
                     // Solves the steady incompressible Navier-Stokes momentum equation
-                    let viscous_term = (u[(j, i + 1)]
-                        - <T as FloatElement>::from_f64(2.0) * u[(j, i)]
-                        + u[(j, i - 1)])
-                        / (dx * dx)
-                        + (u[(j + 1, i)] - <T as FloatElement>::from_f64(2.0) * u[(j, i)]
-                            + u[(j - 1, i)])
-                            / (dy * dy);
+                    let viscous_term = (u_data[index + 1] - two * u_old + u_data[index - 1])
+                        / dx_squared
+                        + (u_data[index + nx] - two * u_old + u_data[index - nx]) / dy_squared;
 
-                    let convective_u =
-                        (u[(j, i + 1)] - u[(j, i - 1)]) / (<T as FloatElement>::from_f64(2.0) * dx);
-                    let convective_v =
-                        (u[(j + 1, i)] - u[(j - 1, i)]) / (<T as FloatElement>::from_f64(2.0) * dy);
+                    let convective_u = (u_data[index + 1] - u_data[index - 1]) / (two * dx);
+                    let convective_v = (u_data[index + nx] - u_data[index - nx]) / (two * dy);
 
                     let u_update = u_old
                         + dt * (nu * viscous_term
                             - u_old * convective_u
-                            - v[(j, i)] * convective_v);
-                    u[(j, i)] = u_old + <T as FloatElement>::from_f64(0.7) * (u_update - u_old);
+                            - v_data[index] * convective_v);
+                    u_data[index] = u_old + relaxation * (u_update - u_old);
 
                     // Update v-velocity similarly
-                    let viscous_term_v = (v[(j, i + 1)]
-                        - <T as FloatElement>::from_f64(2.0) * v[(j, i)]
-                        + v[(j, i - 1)])
-                        / (dx * dx)
-                        + (v[(j + 1, i)] - <T as FloatElement>::from_f64(2.0) * v[(j, i)]
-                            + v[(j - 1, i)])
-                            / (dy * dy);
-                    let v_update = v[(j, i)] + dt * nu * viscous_term_v;
-                    v[(j, i)] =
-                        v[(j, i)] + <T as FloatElement>::from_f64(0.7) * (v_update - v[(j, i)]);
+                    let v_old = v_data[index];
+                    let viscous_term_v = (v_data[index + 1] - two * v_old + v_data[index - 1])
+                        / dx_squared
+                        + (v_data[index + nx] - two * v_old + v_data[index - nx]) / dy_squared;
+                    let v_update = v_old + dt * nu * viscous_term_v;
+                    v_data[index] = v_old + relaxation * (v_update - v_old);
 
                     let residual = scalar::abs(u_update - u_old);
                     if residual > local_max_residual {

--- a/crates/cfd-validation/src/matrix.rs
+++ b/crates/cfd-validation/src/matrix.rs
@@ -74,6 +74,18 @@ impl<T> DMatrix<T> {
     {
         self.data.clone_from(&other.data);
     }
+
+    /// Return the logical row-major elements when the matrix is C-contiguous.
+    #[inline]
+    pub fn as_slice(&self) -> Option<&[T]> {
+        self.data.as_slice()
+    }
+
+    /// Return mutable logical row-major elements when the matrix is C-contiguous.
+    #[inline]
+    pub fn as_slice_mut(&mut self) -> Option<&mut [T]> {
+        self.data.as_slice_mut()
+    }
 }
 
 impl<T> Index<(usize, usize)> for DMatrix<T> {

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -8,7 +8,7 @@ consistent zero-copy, zero-cost-abstraction design.
 
 ## Architecture at a Glance
 
-```
+```text
                 +-----------------------------------------------------+
                 |  cfd-validation  |  cfd-optim  |  cfd-python       |
                 |  benchmarks, planning, Python bindings            |
@@ -51,7 +51,7 @@ consistent zero-copy, zero-cost-abstraction design.
 
 ## Getting Started
 
-```
+```console
 cargo run --example cavity_validation                  # lid-driven cavity, Re ~ 100
 cargo run --example pipe_flow_validation               # Hagen-Poiseuille 1-D benchmark
 cargo run --example mesh_3d_integration                # structured 16 x 4 mesh + CSG
@@ -64,6 +64,12 @@ member, so the run form is `cargo run -p cfd-validation
 --example richardson_convergence`.  See the `**Run**:` line on
 each example's `docs/book/examples/<name>.md` page for the
 canonical invocation.
+
+API excerpts in this book are marked `rust,ignore` when they require the
+workspace's Cargo dependency graph or a runtime fixture. Their canonical
+implementations are the linked Rust source files; the package and example
+targets remain the compilation gate. Untyped fences are explicitly `text` or
+`console` so diagrams, equations, and commands cannot be misread as doctests.
 
 ## Chapters
 

--- a/docs/book/biomedical_flows.md
+++ b/docs/book/biomedical_flows.md
@@ -22,7 +22,7 @@ Microfluidic screens are serpentine or bifurcation arrays designed for
 mixing, separation, or hemolysis screening.  CFDrs handles them as a chain
 of bifurcations:
 
-```rust
+```rust,ignore
 use cfd_schematics::serpentine::SerpentineBuilder;
 
 let chip = SerpentineBuilder::new()
@@ -42,7 +42,7 @@ bifurcation chain and reports branches with shear stress above an FDA-style
 threshold.  The API is intentionally minimal so that custom geometries can
 plug in:
 
-```rust
+```rust,ignore
 let report = cfd_1d::screening::shear_violations(&state, &geometries)?;
 for branch in report.violations {
     eprintln!("branch {}: peak shear {} Pa (limit 9.0)", branch.id, branch.peak);

--- a/docs/book/cavitation.md
+++ b/docs/book/cavitation.md
@@ -8,7 +8,7 @@
 Cavitation is modeled as a **phase transition** whose rate depends on local
 pressure-vs-vapor-pressure:
 
-```rust
+```rust,ignore
 pub trait Cavitation {
     fn inception_pressure<F: FloatElement>(&self) -> F;
     fn collapse_rate<F: FloatElement>(&self, p: F) -> F;
@@ -21,7 +21,9 @@ flows.
 
 Damage accumulation is integrated per timestep as
 
-    damage += (inception_indicator) · (collapse_rate · dt)
+```text
+damage += (inception_indicator) · (collapse_rate · dt)
+```
 
 and reported through the [`cfd-3d::posterior::damage`] hook.  Outputs are
 dimensionally consistent (kg/m²/s) so that downstream fatigue models can

--- a/docs/book/crate_1d_flows.md
+++ b/docs/book/crate_1d_flows.md
@@ -26,4 +26,4 @@ cargo run -p cfd-1d --example tpms_blood_1d
 cargo run -p cfd-1d --example cavitation_venturi_analysis
 cargo run -p cfd-1d --example medical_millifluidic_screening
 cargo run -p cfd-1d --example hemolysis_serpentine_analysis
-```
+```text

--- a/docs/book/crate_3d_flows.md
+++ b/docs/book/crate_3d_flows.md
@@ -20,4 +20,4 @@ cargo run -p cfd-3d --example spectral_poisson_3d
 cargo run -p cfd-3d --example bifurcation_3d_blood
 cargo run -p cfd-3d --example venturi_3d_cavitation
 cargo run -p cfd-3d --example serpentine_3d_dean
-```
+```text

--- a/docs/book/crate_optim.md
+++ b/docs/book/crate_optim.md
@@ -17,4 +17,4 @@ for CFD geometries.  Key examples demonstrate the Latin-hypercube sampler
 ```bash
 cargo run -p cfd-optim --example cell_sep_audit
 cargo run -p cfd-optim --example milestone12_validation
-```
+```text

--- a/docs/book/crate_validation.md
+++ b/docs/book/crate_validation.md
@@ -19,4 +19,4 @@ Run all three with:
 cargo run -p cfd-validation --example comprehensive_validation_suite
 cargo run -p cfd-validation --example richardson_convergence
 cargo run -p cfd-validation --example blood_poiseuille_2d
-```
+```text

--- a/docs/book/examples/adaptive_time_stepping_demo.md
+++ b/docs/book/examples/adaptive_time_stepping_demo.md
@@ -22,7 +22,7 @@ y(t) = exp(−2t)), showing accuracy and efficiency tradeoffs.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::schemes::time::{
     AdaptationStrategy, AdaptiveController, AdaptiveTimeIntegrator, StateVector,
 };
@@ -42,13 +42,13 @@ demonstrate_combined_adaptation(&y0, t_final)?;
 ## Physics Background
 
 For explicit schemes, **CFL condition** bounds the time step:
-```
+```text
 CFL = |u| · Δt / Δx ≤ CFL_max
 ```
 CFL > 1 causes the numerical domain of dependence to exceed the physical one,
 leading to instability. **Richardson extrapolation** estimates the local
 truncation error by comparing a full step with two half-steps:
-```
+```text
 ε ≈ |y_full − y_half| / (2^p − 1)
 ```
 where p is the scheme order.

--- a/docs/book/examples/bifurcation_2d_blood_validation.md
+++ b/docs/book/examples/bifurcation_2d_blood_validation.md
@@ -21,7 +21,7 @@ solved on a staggered grid via the `BifurcationSolver2D` / SIMPLE path.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::solvers::bifurcation_flow::{BifurcationGeometry, BifurcationSolver2D};
 use cfd_2d::solvers::ns_fvm::{BloodModel, SIMPLEConfig};
 use cfd_core::physics::fluid::blood::{CarreauYasudaBlood, CassonBlood};

--- a/docs/book/examples/bifurcation_schematic.md
+++ b/docs/book/examples/bifurcation_schematic.md
@@ -28,7 +28,7 @@ Two-phase schematic-driven bifurcation simulation: design with `cfd-schematics` 
 
 ```bash
 cargo run -p cfd-2d --example bifurcation_schematic
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/blood_flow_1d_validation.md
+++ b/docs/book/examples/blood_flow_1d_validation.md
@@ -23,7 +23,7 @@ a different rheology or network model:
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_1d::domain::channel::Channel;
 
 // Casson model: √τ = √τ_y + √(μ_∞ · γ̇)

--- a/docs/book/examples/blood_poiseuille_2d.md
+++ b/docs/book/examples/blood_poiseuille_2d.md
@@ -24,7 +24,7 @@ analytical Poiseuille solution for the same pressure gradient.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::solvers::{BloodModel, PoiseuilleConfig, PoiseuilleFlow2D};
 use cfd_core::error::Result;
 use cfd_core::physics::fluid::blood::CassonBlood;

--- a/docs/book/examples/blood_rheology_models.md
+++ b/docs/book/examples/blood_rheology_models.md
@@ -24,7 +24,7 @@ Five blood-viscosity models compared over the full physiological shear-rate rang
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 // Millifluidic channel: D = 1 mm, L = 30 mm, Q = 1 mL/min
 // For each model, apparent viscosity at γ̇_w = 8V/D feeds Hagen-Poiseuille:
 //   ΔP = 128 μ_app L Q / (π D⁴)

--- a/docs/book/examples/blood_venturi.md
+++ b/docs/book/examples/blood_venturi.md
@@ -31,7 +31,7 @@
 
 ```bash
 cargo run -p cfd-2d --example blood_venturi
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/cavity_validation.md
+++ b/docs/book/examples/cavity_validation.md
@@ -23,7 +23,7 @@ for lid-driven cavity flow at Re = 100.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::grid::StructuredGrid2D;
 use cfd_2d::physics::vorticity_stream::{VorticityStreamConfig, VorticityStreamSolver};
 

--- a/docs/book/examples/cfd_demo.md
+++ b/docs/book/examples/cfd_demo.md
@@ -22,7 +22,7 @@ Baseline sanity check covering four primitives of the CFDrs stack:
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_core::physics::fluid_dynamics::{FlowField, FlowOperations};
 
 let flow_field = FlowField::<f64>::new(32, 32, 32);

--- a/docs/book/examples/comprehensive_validation_suite.md
+++ b/docs/book/examples/comprehensive_validation_suite.md
@@ -28,7 +28,7 @@ end of the run.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_core::error::Result;
 use cfd_core::physics::fluid::blood::CassonBlood;
 use cfd_validation::benchmarks::{

--- a/docs/book/examples/csg_cfd_simulation.md
+++ b/docs/book/examples/csg_cfd_simulation.md
@@ -24,7 +24,7 @@ in a single end-to-end pipeline using the `cfd-schematics` → `gaia` → `cfd-1
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_schematics::venturi_rect;
 use cfd_mesh::application::pipeline::{BlueprintMeshPipeline, PipelineConfig};
 use cfd_1d::{evaluate_venturi_screening, VenturiScreeningInput};
@@ -47,7 +47,7 @@ let screening = evaluate_venturi_screening(VenturiScreeningInput {
 
 ## Architecture
 
-```
+```text
 cfd-schematics (parametric blueprint)
   └─ gaia (mesh generation)
        └─ cfd-1d (screening / reduced-order model)

--- a/docs/book/examples/csg_operations.md
+++ b/docs/book/examples/csg_operations.md
@@ -23,7 +23,7 @@ full topology validation and STL export to `outputs/csg/`.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_mesh::application::csg::boolean::{csg_boolean, BooleanOp};
 use cfd_mesh::{Cube, IndexedMesh};
 use cfd_mesh::domain::geometry::primitives::{Cylinder, PrimitiveMesh};
@@ -40,7 +40,7 @@ let result = csg_boolean(&cube, &cyl, BooleanOp::Difference)?;
 
 ```bash
 CSG_TRACE=1 cargo run --example csg_operations --features csg
-```
+```text
 
 Enables seam-repair trace output for investigating watertightness failures
 after boolean operations.

--- a/docs/book/examples/csg_primitives_demo.md
+++ b/docs/book/examples/csg_primitives_demo.md
@@ -24,7 +24,7 @@ and outward-normal orientation — no boolean operations, pure primitive baselin
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_mesh::{Cube, IndexedMesh, analyze_normals};
 use cfd_mesh::application::watertight::check::check_watertight;
 use cfd_mesh::domain::geometry::primitives::{Cone, Cylinder, PrimitiveMesh, UvSphere};

--- a/docs/book/examples/enhanced_cfd_demo.md
+++ b/docs/book/examples/enhanced_cfd_demo.md
@@ -23,7 +23,7 @@ with LES turbulence, WENO5/7 reconstruction, and immersed-boundary geometry.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::physics::turbulence::{MilesLES, SigmaModel, VremanModel};
 use cfd_math::high_order::weno::WenoReconstruction;
 use cfd_math::time_stepping::RungeKuttaChebyshev;
@@ -33,7 +33,7 @@ let sigma  = SigmaModel::new();   // σ-model (Nicoud et al. 2011)
 let miles  = MilesLES::new();     // MILES: monotone implicit LES
 
 let weno = WenoReconstruction::weno5(); // 5th-order shock-capturing
-let rk_cheb = RungeKuttaChebyshev::new(stages=10); // stable for stiff diffusion
+let rk_cheb = RungeKuttaChebyshev::new(10); // stable for stiff diffusion
 ```
 
 ## Physics Background

--- a/docs/book/examples/fem_3d_stokes.md
+++ b/docs/book/examples/fem_3d_stokes.md
@@ -23,7 +23,7 @@ using P1/P1 stabilised tetrahedral finite elements.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_3d::fem::{FemConfig, FemSolver, StokesFlowProblem};
 use cfd_core::physics::fluid::ConstantPropertyFluid;
 
@@ -40,7 +40,7 @@ let solution = FemSolver::solve(&problem, &FemConfig::default())?;
 
 The **Stokes equations** are the zero-inertia limit of Navier-Stokes:
 
-```
+```text
 −∇p + μ ∇²u = 0,   ∇·u = 0
 ```
 

--- a/docs/book/examples/geometry_integration_demo.md
+++ b/docs/book/examples/geometry_integration_demo.md
@@ -20,7 +20,7 @@ Uses `AnalysisOverlay` for typed CFD field visualization (no raw `cfd_1d::domain
 
 ```bash
 cargo run -p cfd-1d --example geometry_integration_demo
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/gpu_detection.md
+++ b/docs/book/examples/gpu_detection.md
@@ -22,7 +22,7 @@ using the unified `ComputeDispatcher` backed by `hephaestus-wgpu`.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_core::compute::backend::ComputeCapability;
 use cfd_core::compute::dispatch::ComputeDispatcher;
 use cfd_core::compute::traits::ComputeBackend;

--- a/docs/book/examples/hemolysis_serpentine_analysis.md
+++ b/docs/book/examples/hemolysis_serpentine_analysis.md
@@ -16,7 +16,7 @@ Full-pipeline hemolysis analysis in a serpentine millifluidic channel. Quantifie
 
 ```text
 D = C · τ^α · t^β
-```
+```console
 where τ = wall shear stress, t = channel residence time (L/v̄).
 
 ## Pipeline

--- a/docs/book/examples/matrix_free_demo.md
+++ b/docs/book/examples/matrix_free_demo.md
@@ -24,7 +24,7 @@ storing the coefficient matrix.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_math::linear_solver::{
     ConjugateGradient, IterativeSolverConfig, LaplacianOperator2D, LinearOperator,
 };

--- a/docs/book/examples/medical_millifluidic_screening.md
+++ b/docs/book/examples/medical_millifluidic_screening.md
@@ -24,7 +24,7 @@ Comprehensive medical-grade millifluidic CFD screening in a 96-well-plate footpr
 
 ```bash
 cargo run -p cfd-1d --example medical_millifluidic_screening
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/milestone12_ga.md
+++ b/docs/book/examples/milestone12_ga.md
@@ -16,7 +16,7 @@ Genetic algorithm track for in-place Dean–serpentine refinement of Option 2 ve
 
 ```text
 De = Re · √(D_h / 2R_c)
-```
+```console
 
 GA score rewards designs that co-localize Dean vortex focusing with venturi cavitation at bend apices.
 

--- a/docs/book/examples/milestone12_option1.md
+++ b/docs/book/examples/milestone12_option1.md
@@ -22,7 +22,7 @@ Selective Acoustic Residence/Separation track. Exploits the **Zweifach–Fung ef
 
 ```bash
 cargo run -p cfd-optim --example milestone12_option1
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/milestone12_option2.md
+++ b/docs/book/examples/milestone12_option2.md
@@ -17,7 +17,7 @@ Selective Venturi Hydrodynamic Cavitation track. Centers on Rayleigh–Plesset b
 Bernoulli cavitation number:
 ```text
 σ = (p∞ − pᵥ) / (½ρv²)
-```
+```console
 When σ < 1, static pressure drops below vapour pressure (pᵥ ≈ 6.3 kPa at 37 °C), nucleating microbubbles.
 
 ## Design Constraints

--- a/docs/book/examples/pipe_flow_validation.md
+++ b/docs/book/examples/pipe_flow_validation.md
@@ -22,7 +22,7 @@ Hagen-Poiseuille solution (Batchelor 1967 §4.2).
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_3d::fem::{StokesFlowProblem, StokesFlowSolution};
 use cfd_3d::FemConfig;
 use cfd_core::prelude::{BoundaryCondition, ConstantPropertyFluid};
@@ -38,7 +38,7 @@ let solution  = StokesFlowProblem::solve(&problem, &FemConfig::default())?;
 
 **Hagen-Poiseuille** (laminar, fully developed, circular pipe):
 
-```
+```text
 v_z(r) = −(dp/dz) · R² / (4μ) · (1 − (r/R)²)
 Q       = π R⁴ (−dp/dz) / (8μ)
 ```

--- a/docs/book/examples/richardson_convergence.md
+++ b/docs/book/examples/richardson_convergence.md
@@ -24,7 +24,7 @@ the extrapolated exact solution, and the Grid Convergence Index (GCI).
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_core::error::Result;
 use cfd_validation::benchmarks::{Benchmark, BenchmarkConfig, LidDrivenCavity};
 
@@ -37,7 +37,7 @@ let f = |n: usize| -> Result<f64> {
     Ok(result.values[0])
 };
 
-let (f1, f2, f3) = (f(64)?, f(32)?, f(16)?;
+let (f1, f2, f3) = (f(64)?, f(32)?, f(16)?);
 let r = 2.0;
 let p = ((f3 - f2) / (f2 - f1)).abs().ln() / r.ln();
 let f_rich = f1 + (f1 - f2) / (r.powf(p) - 1.0);

--- a/docs/book/examples/schematic_demo_integration.md
+++ b/docs/book/examples/schematic_demo_integration.md
@@ -14,7 +14,7 @@ Demonstrates the integration bridge between `cfd-schematics` and `cfd-1d`: defin
 
 ## Pattern
 
-```rust
+```rust,ignore
 // 1. Define with cfd-schematics types
 let blueprint = NetworkBlueprint { nodes, channels };
 
@@ -30,7 +30,7 @@ let solution = NetworkSolver::solve(problem)?;
 
 ```bash
 cargo run -p cfd-1d --example schematic_demo_integration
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/serpentine_mixing_schematic.md
+++ b/docs/book/examples/serpentine_mixing_schematic.md
@@ -16,7 +16,7 @@ Schematic visualization of serpentine mixer geometry with flow analysis overlays
 
 ```bash
 cargo run -p cfd-2d --example serpentine_mixing_schematic
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/serpentine_venturi_1d_vs_2d.md
+++ b/docs/book/examples/serpentine_venturi_1d_vs_2d.md
@@ -29,7 +29,7 @@ Prints a channel-by-channel table: flow rates, pressure drops, wall shear stress
 
 ```text
 De = Re · √(D_h / 2R_c)
-```
+```console
 
 Secondary Dean vortices pre-focus cells toward the centreline — ideal for cavitation-enhanced CTC lysis in SDT.
 

--- a/docs/book/examples/simd_performance_benchmark.md
+++ b/docs/book/examples/simd_performance_benchmark.md
@@ -23,7 +23,7 @@ flux kernels using `cfd-math::simd::CfdSimdOps` backed by `hermes`.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_math::simd::cfd::CfdSimdOps;
 use std::time::Instant;
 

--- a/docs/book/examples/spectral_3d_poisson.md
+++ b/docs/book/examples/spectral_3d_poisson.md
@@ -22,7 +22,7 @@ spectral Poisson solver, and compares against the analytical solution.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_3d::spectral::{PoissonBoundaryCondition, PoissonSolver};
 use leto::Array1;
 use std::f64::consts::PI;

--- a/docs/book/examples/spectral_performance.md
+++ b/docs/book/examples/spectral_performance.md
@@ -25,7 +25,7 @@ delegates plan reuse to `apollo-fft`.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_3d::spectral::{FourierTransform, SpectralDerivative};
 use leto::Array1;
 

--- a/docs/book/examples/spectral_poisson_3d_crate.md
+++ b/docs/book/examples/spectral_poisson_3d_crate.md
@@ -25,7 +25,7 @@ as the polynomial-mode count `N` increases through `{4, 6, 8, 10, 12}`.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_3d::spectral::poisson::PoissonBoundaryCondition;
 use cfd_3d::spectral::solver::PoissonProblem;
 use cfd_3d::spectral::{SpectralConfig, SpectralSolver};

--- a/docs/book/examples/tpms_blood_1d.md
+++ b/docs/book/examples/tpms_blood_1d.md
@@ -22,7 +22,7 @@ Models blood flow through a millifluidic network whose topology derives from a T
 
 ```bash
 cargo run -p cfd-1d --example tpms_blood_1d
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/examples/tpms_blood_2d.md
+++ b/docs/book/examples/tpms_blood_2d.md
@@ -16,7 +16,7 @@
 
 ```text
 y_wall(x) = amplitude · (1 + cos(2π·x/λ)) / 2
-```
+```console
 
 Cells inside the wall region are masked as solid; the SIMPLE solver enforces zero velocity there.
 

--- a/docs/book/examples/turbulence_models_demo.md
+++ b/docs/book/examples/turbulence_models_demo.md
@@ -22,7 +22,7 @@ showing how eddy viscosity and closure behaviour differ.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::physics::turbulence::{
     KEpsilonModel, KOmegaSSTModel, SpalartAllmaras, TurbulenceModel,
 };

--- a/docs/book/examples/turbulence_validation_demo.md
+++ b/docs/book/examples/turbulence_validation_demo.md
@@ -23,7 +23,7 @@ Spalart-Allmaras via `run_turbulence_validation::<f64>()`.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::physics::turbulence::run_turbulence_validation;
 
 // Runs all four validation passes in sequence

--- a/docs/book/examples/turbulent_channel_flow.md
+++ b/docs/book/examples/turbulent_channel_flow.md
@@ -22,7 +22,7 @@ validated against DNS data of Moser, Kim & Mansour (1999) at Re_τ = 395.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_2d::physics::turbulence::{KOmegaSSTModel, TurbulenceModel};
 
 // Re_τ = u_τ · h / ν = 395  (DNS benchmark)
@@ -40,7 +40,7 @@ println!("Model: {}", sst_model.name());
 The **k-ω SST** (Shear Stress Transport) model blends the k-ω formulation in
 the near-wall region with the k-ε model in the free stream:
 
-```
+```text
 Dk/Dt  = P_k − β*kω + ∇·[(ν + σ_k νt) ∇k]
 Dω/Dt  = γ P_k/νt − β' ω² + ∇·[(ν + σ_ω νt) ∇ω] + CDkω
 ```

--- a/docs/book/examples/venturi_cavitation.md
+++ b/docs/book/examples/venturi_cavitation.md
@@ -23,7 +23,7 @@ showing differential inception thresholds driven by membrane mechanics.
 
 ## Key Code Snippet
 
-```rust
+```rust,ignore
 use cfd_1d::{evaluate_venturi_screening, VenturiScreeningInput};
 use cfd_core::physics::cavitation::{
     SelectiveCavitationInput, SelectiveCavitationPopulation, CellMechanicalState,

--- a/docs/book/examples/venturi_schematic.md
+++ b/docs/book/examples/venturi_schematic.md
@@ -27,7 +27,7 @@ Two-phase schematic-driven Venturi simulation: design with `cfd-schematics`, sim
 
 ```bash
 cargo run -p cfd-2d --example venturi_schematic
-```
+```text
 
 ## Part Reference
 

--- a/docs/book/foundations.md
+++ b/docs/book/foundations.md
@@ -36,7 +36,7 @@ contracts — boundary conditions, time-stepping, state vectors — live in
 `BoundaryConditionSet<T>` collection. Solver crates consume these contracts
 through their grid- or mesh-specific setup paths.
 
-```rust
+```rust,ignore
 use cfd_core::physics::boundary::{BoundaryCondition, BoundaryConditionSet};
 use leto::geometry::Vector3;
 
@@ -52,7 +52,7 @@ boundaries
 
 ## The CFDrs Simulation Lifecycle
 
-```
+```text
 +------------+   +-----------+   +----------+   +----------+
 | Geometry   |-->| Mesh/Grid |-->| Boundary |-->| Initial  |
 | (CSG)      |   |           |   | wiring   |   | state    |

--- a/docs/book/geometry_and_meshing.md
+++ b/docs/book/geometry_and_meshing.md
@@ -26,7 +26,7 @@ The root CSG examples construct `cfd-mesh` primitives through
 components, Euler characteristic, and normal orientation. Boolean composition
 uses one operation enum:
 
-```rust
+```rust,ignore
 use cfd_mesh::application::csg::boolean::{csg_boolean, BooleanOp};
 
 let union = csg_boolean(BooleanOp::Union, &left, &right)?;

--- a/docs/book/governing_equations.md
+++ b/docs/book/governing_equations.md
@@ -17,7 +17,7 @@ The continuity and momentum equations for a constant-density fluid:
 ∇·u = 0
 
 ∂u/∂t + (u·∇)u = -∇(p/ρ) + ν ∇²u + f/ρ
-```
+```text
 
 where **u** is velocity, *p* pressure, *ρ* density, *ν* kinematic viscosity,
 and **f** body forces.  CFDrs resolves the incompressibility constraint through
@@ -40,7 +40,7 @@ Blood and polymer flows use the generalised Newtonian model:
 
 ```text
 τ = μ_eff(γ̇) · γ̇
-```
+```text
 
 `cfd-core` provides the rheology dispatch:
 
@@ -68,7 +68,7 @@ crate:
 Boundary conditions live in `cfd-core::physics::boundary` and are consumed
 by every discretisation layer through a single `BoundaryCondition<T>` enum:
 
-```rust
+```rust,ignore
 use cfd_core::physics::boundary::{BoundaryCondition, BoundaryConditionSet};
 
 let bc = BoundaryConditionSet::<f64>::new()

--- a/docs/book/matrix_free_operators.md
+++ b/docs/book/matrix_free_operators.md
@@ -10,7 +10,7 @@ linear operator is a trait, and the solver allocates only the action
 function `A·x`.  Matrix-free applications decouple memory footprint from
 discretization size.
 
-```rust
+```rust,ignore
 pub trait LinearOp<F: FloatElement> {
     fn apply(&self, x: &NdArray<F, Ix3>, y: &mut NdArray<F, Ix3>);
 }
@@ -25,7 +25,7 @@ three discretizations (Stencil, FEM, Spectral).
 the same convergence target at the same iteration count regardless of
 which discretization backs them.
 
-```rust
+```rust,ignore
 let krylov = BiCgStab::<f64>::new();
 let solution = krylov.solve(&op, &rhs, &preconditioner, 1e-6, 5000)?;
 ```

--- a/docs/book/numerics_and_solvers.md
+++ b/docs/book/numerics_and_solvers.md
@@ -34,7 +34,7 @@ The Krylov solver APIs (BiCGSTAB, GMRES, IDR(s)) are documented in the [Matrix-F
 
 ## Time Integration
 
-```rust
+```rust,ignore
 pub trait Integrator<F: FloatElement> {
     fn step(&mut self, x: &mut NdArray<F, Ix3>, dt: F);
 }
@@ -50,7 +50,7 @@ explicit Adams-Bashforth pair is the default for incompressible time-stepping.
 
 ## Adaptive Time-Stepping
 
-```rust
+```rust,ignore
 let stepping = AdaptiveStepping::builder()
     .cfl_max(0.5)
     .atol_field(1e-6)

--- a/docs/book/pressure_velocity.md
+++ b/docs/book/pressure_velocity.md
@@ -20,7 +20,7 @@ SIMPLE alternates momentum and pressure-correction sweeps until convergence:
 2. Solve pressure-correction equation: ∇·(1/A · ∇p') = ∇·u*
 3. Correct: p ← p + p', u ← u* − (1/A)·∇p'
 4. Repeat until ‖∇·u‖ < ε
-```
+```text
 
 ```rust
 use cfd_core::solver::{SimpleSolver, SolverConfig};
@@ -34,7 +34,7 @@ let state = solver.solve(&mesh, &boundary_conditions, &initial_conditions)?;
 PIMPLE extends SIMPLE with outer corrector loops, enabling large Courant
 numbers in transient simulations:
 
-```rust
+```rust,ignore
 use cfd_core::solver::{PimpleSolver, PimpleConfig};
 
 let pimple = PimpleSolver::new(PimpleConfig {
@@ -49,7 +49,7 @@ let pimple = PimpleSolver::new(PimpleConfig {
 SIMPLEC modifies the momentum under-relaxation to improve convergence
 for mildly non-linear problems:
 
-```rust
+```rust,ignore
 use cfd_core::solver::{SimplecSolver};
 ```
 
@@ -65,7 +65,7 @@ For hyperbolic-dominated flows:
 | 4th-order Runge-Kutta | 4th | ~2.8 |
 | Low-storage RK4 | 4th | ~2.8 |
 
-```rust
+```rust,ignore
 use cfd_math::time_stepping::runge_kutta::RK4;
 
 let rk4 = RK4::new(dt);
@@ -86,7 +86,7 @@ For diffusion-dominated and stiff problems:
 `cfd-math` monitors the spectral radius and adjusts `dt` to maintain the
 target CFL number:
 
-```rust
+```rust,ignore
 use cfd_math::time_stepping::AdaptiveTimeStepper;
 
 let ts = AdaptiveTimeStepper::new()

--- a/docs/book/schematic_integration_2d.md
+++ b/docs/book/schematic_integration_2d.md
@@ -17,7 +17,7 @@ Phase 1 — Design (cfd-schematics)
 
 Phase 2 — Simulation (cfd-2d or cfd-1d)
    Blueprint → network solve → AnalysisOverlay PNG
-```
+```console
 
 | Example | Crate | Description |
 |---------|-------|-------------|

--- a/docs/book/turbulence_multiphase.md
+++ b/docs/book/turbulence_multiphase.md
@@ -14,7 +14,7 @@ This chapter documents the integration contracts used to combine them.
 
 `cfd-3d` integrates the canonical closures through a single trait:
 
-```rust
+```rust,ignore
 pub trait TurbulenceModel<T: NumericElement> {
     fn turbulent_viscosity(
         &self,
@@ -53,7 +53,7 @@ For multiphase (e.g. liquid + gas), CFDrs uses a **volume-of-fluid**
 style coupling: each cell carries a phase-volume fraction `α ∈ [0, 1]`,
 and mixture properties are computed by a weighted sum:
 
-```rust
+```rust,ignore
 let rho_mix = rho_l * (1.0 - alpha) + rho_g * alpha;
 let mu_mix  = mu_l  * (1.0 - alpha) + mu_g  * alpha;
 ```
@@ -70,7 +70,7 @@ For details on phase transition models, Rayleigh–Plesset closures, and damage 
 
 All three regimes compose through the same `Integrate` trait:
 
-```rust
+```rust,ignore
 pub trait Integrate {
     fn step<F: FloatElement>(&mut self) -> Result<(), CfdError>;
 }

--- a/docs/book/validation.md
+++ b/docs/book/validation.md
@@ -24,7 +24,7 @@ Richardson extrapolation establishes the **observed order of accuracy**:
 
 ```text
 φ_exact ≈ φ_fine + (φ_fine - φ_coarse) / (r^p - 1)
-```
+```text
 
 where *r* is the mesh refinement ratio and *p* the expected order.
 
@@ -47,7 +47,7 @@ Re = 100, 400, 1000, 3200.
 CFDrs reproduces the Ghia *u*-velocity profile along the vertical centreline
 to within 0.5% for Re ≤ 1000:
 
-```rust
+```rust,ignore
 cargo run -p cfd-suite --example cavity_validation
 ```
 
@@ -57,7 +57,7 @@ For a circular pipe of radius *R* and pressure gradient dP/dx:
 
 ```text
 u(r) = (1/(4μ)) · (-dP/dx) · (R² - r²)
-```
+```console
 
 ```rust
 cargo run -p cfd-suite --example pipe_flow_validation
@@ -68,7 +68,7 @@ cargo run -p cfd-suite --example pipe_flow_validation
 CFDrs includes the FDA nozzle haemolysis model and hemolysis
 (Giersiepen-Wurzinger) as validated metrics:
 
-```rust
+```rust,ignore
 cargo run -p cfd-suite --example blood_flow_1d_validation
 cargo run -p cfd-1d --example fda_shear_limit_screening
 ```

--- a/docs/book/vascular_bifurcations.md
+++ b/docs/book/vascular_bifurcations.md
@@ -8,7 +8,7 @@
 The vascular bifurcation is the keystone of CFDrs's biomedical flow
 support.  It is generated as a CSG composition:
 
-```rust
+```rust,ignore
 use cfd_schematics::bifurcation::BifurcationBuilder;
 use leto::Point3;
 
@@ -27,7 +27,7 @@ parent / child branch.
 
 ### Rheology Choices
 
-```rust
+```rust,ignore
 use cfd_1d::blood_rheology::Rheology;
 
 let rheo = Rheology::carreau {          // μ_0, μ_∞, λ, n

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -64,6 +64,20 @@ hosted exact-head verification remain pending. The separate
 `cross_fidelity_trifurcation_dominance` 3D case also passes locally in 16.903 s;
 the broad package and hosted exact-head gates remain the closure evidence.
 
+## CFDrs book and example gate — Apollo public-bound dependency
+
+The book's executable-test failure was caused by untyped diagrams, equations,
+commands, and non-self-contained workspace API excerpts. Those blocks now have
+explicit fence languages; `mdbook test docs/book` and `mdbook build docs/book`
+pass locally. This does not substitute for compiling the linked examples.
+
+The linked Cargo example gate is currently blocked at `cfd-3d`: its spectral
+consumer names the public `apollo_fft::PlanScratch` bound, while the integrated
+Apollo head `c87a1abe` does not expose it. Apollo remote head
+`81583aab8b3eb48c96d138e3980e2c554d9d83fa` contains the provider-owned
+re-export and public module change. CFDrs remains unadvanced until that
+upstream head is merged; no compatibility shim is permitted.
+
 ## Unreachable source-module closure — CFDrs (2026-08-17)
 
 - Closed at merged provider default `54dcea3c`, source head `b455a416`.

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -45,6 +45,25 @@ slice and is not represented as a successful gate.
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Gap Audit: CFDrs
 
+## Pressure-correction sparse-matrix clone — CFDRS-PERF-102 (local implementation closed 2026-08-17)
+
+The high-contraction 2D SIMPLEC/PIMPLE path cloned its cached sparse pressure
+Laplacian on every pressure correction. The matrix topology and values are
+immutable for a fixed grid and boundary mask; only the right-hand side and
+solution change. The provider now borrows the cached CSR matrix in place after
+the first assembly, deleting the repeated sparse allocation/copy without
+changing the operator, linear solver, tolerance, or validation acceptance.
+
+The exact value-semantic regression
+`microventuri_35um_case_produces_converged_informative_2d_result` passes in
+16.785 s under locked `cargo nextest`, run
+`5c15ba54-0b90-47a8-ab4c-f0eaf7b55d6c`; the 30-second committed budget and test
+workload are unchanged. This is not a controlled cross-machine speedup claim:
+the hosted pre-change baseline timed out at 30.005 s. Provider focused and
+hosted exact-head verification remain pending. The separate
+`cross_fidelity_trifurcation_dominance` 3D case also passes locally in 16.903 s;
+the broad package and hosted exact-head gates remain the closure evidence.
+
 ## Unreachable source-module closure — CFDrs (2026-08-17)
 
 - Closed at merged provider default `54dcea3c`, source head `b455a416`.


### PR DESCRIPTION
## Outcome\nBorrow the immutable cached pressure CSR matrix after first assembly instead of cloning it for every SIMPLE correction. Only the RHS and solution remain per-iteration state.\n\n## Verification\n- cargo fmt --all --manifest-path ... -- --check\n- locked cargo check -p cfd-validation\n- exact 35 µm nextest: 16.785 s, run 5c15ba54-0b90-47a8-ab4c-f0eaf7b55d6c\n- exact trifurcation nextest: 16.903 s, run 913a79da-d89d-4440-a12e-52c575483be6\n- no test workload, assertion, or timeout change\n\n## Tracking\nSee acklog.md, CHECKLIST.md, and gap_audit.md for evidence limits and residuals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved pressure-correction solve efficiency by reusing assembled matrix data without changing solver results.

- **Bug Fixes**
  - Improved hemolysis calculations for negative, zero, NaN, infinite, and signed-zero inputs.
  - Corrected a documentation example syntax issue.

- **Documentation**
  - Clarified example commands, equations, and code samples throughout the user guide.
  - Updated code examples to render consistently and avoid misleading doctest behavior.

- **Quality Improvements**
  - Expanded automated validation for documentation, examples, and package builds.
  - Added regression coverage for hemolysis edge cases and pressure-correction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->