### PR TITLE
fix(clippy): Replace unwrap() with expect() in test code; fix doc-markdown

### DIFF
--- a/crates/cfd-core/src/abstractions/state.rs
+++ b/crates/cfd-core/src/abstractions/state.rs
@@ -239,8 +239,12 @@ mod tests {
         state.add_scalar_field(FieldVariable::Pressure, 3);
         state.add_vector_field(FieldVariable::Velocity, 2);
 
-        state.scalar_field_mut(FieldVariable::Pressure).expect("pressure field registered")[1] = 5.0;
-        state.vector_field_mut(FieldVariable::Velocity).expect("velocity field registered")[0] = Vector3::new(1.0, 2.0, 3.0);
+        state
+            .scalar_field_mut(FieldVariable::Pressure)
+            .expect("pressure field registered")[1] = 5.0;
+        state
+            .vector_field_mut(FieldVariable::Velocity)
+            .expect("velocity field registered")[0] = Vector3::new(1.0, 2.0, 3.0);
         state.set_time(2.0);
         state.increment_iteration();
 
@@ -257,7 +261,9 @@ mod tests {
             &[0.0, 0.0, 0.0]
         );
         assert_eq!(
-            state.vector_field(FieldVariable::Velocity).expect("velocity field registered"),
+            state
+                .vector_field(FieldVariable::Velocity)
+                .expect("velocity field registered"),
             &[Vector3::zeros(), Vector3::zeros()]
         );
     }
@@ -266,10 +272,14 @@ mod tests {
     fn field_data_scalar_round_trips_as_leto_array() {
         let mut state = FieldState::<f64>::new();
         state.add_scalar_field(FieldVariable::Pressure, 2);
-        state.scalar_field_mut(FieldVariable::Pressure).expect("pressure field registered")[0] = 4.0;
+        state
+            .scalar_field_mut(FieldVariable::Pressure)
+            .expect("pressure field registered")[0] = 4.0;
 
-        let encoded = serde_json::to_string(&state.fields[&FieldVariable::Pressure]).expect("serde_json serialization");
-        let decoded: FieldData<f64> = serde_json::from_str(&encoded).expect("serde_json deserialization");
+        let encoded = serde_json::to_string(&state.fields[&FieldVariable::Pressure])
+            .expect("serde_json serialization");
+        let decoded: FieldData<f64> =
+            serde_json::from_str(&encoded).expect("serde_json deserialization");
 
         match decoded {
             FieldData::Scalar(values) => {

--- a/crates/cfd-core/src/abstractions/state.rs
+++ b/crates/cfd-core/src/abstractions/state.rs
@@ -239,8 +239,8 @@ mod tests {
         state.add_scalar_field(FieldVariable::Pressure, 3);
         state.add_vector_field(FieldVariable::Velocity, 2);
 
-        state.scalar_field_mut(FieldVariable::Pressure).unwrap()[1] = 5.0;
-        state.vector_field_mut(FieldVariable::Velocity).unwrap()[0] = Vector3::new(1.0, 2.0, 3.0);
+        state.scalar_field_mut(FieldVariable::Pressure).expect("pressure field registered")[1] = 5.0;
+        state.vector_field_mut(FieldVariable::Velocity).expect("velocity field registered")[0] = Vector3::new(1.0, 2.0, 3.0);
         state.set_time(2.0);
         state.increment_iteration();
 
@@ -251,13 +251,13 @@ mod tests {
         assert_eq!(
             state
                 .scalar_field(FieldVariable::Pressure)
-                .unwrap()
+                .expect("pressure field registered")
                 .storage()
                 .as_slice(),
             &[0.0, 0.0, 0.0]
         );
         assert_eq!(
-            state.vector_field(FieldVariable::Velocity).unwrap(),
+            state.vector_field(FieldVariable::Velocity).expect("velocity field registered"),
             &[Vector3::zeros(), Vector3::zeros()]
         );
     }
@@ -266,10 +266,10 @@ mod tests {
     fn field_data_scalar_round_trips_as_leto_array() {
         let mut state = FieldState::<f64>::new();
         state.add_scalar_field(FieldVariable::Pressure, 2);
-        state.scalar_field_mut(FieldVariable::Pressure).unwrap()[0] = 4.0;
+        state.scalar_field_mut(FieldVariable::Pressure).expect("pressure field registered")[0] = 4.0;
 
-        let encoded = serde_json::to_string(&state.fields[&FieldVariable::Pressure]).unwrap();
-        let decoded: FieldData<f64> = serde_json::from_str(&encoded).unwrap();
+        let encoded = serde_json::to_string(&state.fields[&FieldVariable::Pressure]).expect("serde_json serialization");
+        let decoded: FieldData<f64> = serde_json::from_str(&encoded).expect("serde_json deserialization");
 
         match decoded {
             FieldData::Scalar(values) => {

--- a/crates/cfd-core/src/compute/gpu/field_ops/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/field_ops/tests.rs
@@ -90,7 +90,7 @@ fn arithmetic_rejects_mismatched_lengths() {
 
     let add_operand_error = operations
         .add_fields(&[1.0, 2.0], &[3.0], &mut two_values)
-        .unwrap_err();
+        .expect_err("expected error for invalid input");
     assert!(matches!(
         add_operand_error,
         Error::DimensionMismatch {
@@ -101,7 +101,7 @@ fn arithmetic_rejects_mismatched_lengths() {
 
     let add_output_error = operations
         .add_fields(&[1.0, 2.0], &[3.0, 4.0], &mut one_value)
-        .unwrap_err();
+        .expect_err("expected error for invalid input");
     assert!(matches!(
         add_output_error,
         Error::DimensionMismatch {
@@ -112,7 +112,7 @@ fn arithmetic_rejects_mismatched_lengths() {
 
     let multiply_output_error = operations
         .multiply_field(&[1.0, 2.0], 3.0, &mut one_value)
-        .unwrap_err();
+        .expect_err("expected error for invalid input");
     assert!(matches!(
         multiply_output_error,
         Error::DimensionMismatch {
@@ -131,7 +131,7 @@ fn laplacian_rejects_invalid_contracts() {
     let mut output = [0.0; 4];
     let input_error = operations
         .laplacian_2d(&[1.0; 3], 2, 2, meters(1.0), meters(1.0), &mut output)
-        .unwrap_err();
+        .expect_err("expected error for invalid input");
     assert!(matches!(
         input_error,
         Error::DimensionMismatch {
@@ -143,7 +143,7 @@ fn laplacian_rejects_invalid_contracts() {
     let mut short_output = [0.0; 3];
     let output_error = operations
         .laplacian_2d(&[1.0; 4], 2, 2, meters(1.0), meters(1.0), &mut short_output)
-        .unwrap_err();
+        .expect_err("expected error for invalid input");
     assert!(matches!(
         output_error,
         Error::DimensionMismatch {
@@ -154,6 +154,6 @@ fn laplacian_rejects_invalid_contracts() {
 
     let spacing_error = operations
         .laplacian_2d(&[1.0; 4], 2, 2, meters(0.0), meters(1.0), &mut output)
-        .unwrap_err();
+        .expect_err("expected error for invalid input");
     assert!(matches!(spacing_error, Error::InvalidConfiguration(_)));
 }

--- a/crates/cfd-io/tests/checkpoint_roundtrip.rs
+++ b/crates/cfd-io/tests/checkpoint_roundtrip.rs
@@ -1,4 +1,4 @@
-//! Bit-exact roundtrip tests for CheckpointManager
+//! Bit-exact roundtrip tests for [`CheckpointManager`]
 
 use cfd_io::checkpoint::{Checkpoint, CheckpointManager, CheckpointMetadata, CompressionStrategy};
 use leto::Array2;
@@ -18,8 +18,8 @@ fn assert_array_eq(left: &Array2<f64>, right: &Array2<f64>) {
 
 #[test]
 fn checkpoint_roundtrip_no_compression() {
-    let dir = tempdir().unwrap();
-    let manager = CheckpointManager::new(dir.path()).unwrap();
+    let dir = tempdir().expect("tmpdir creation");
+    let manager = CheckpointManager::new(dir.path()).expect("CheckpointManager creation");
 
     let ny = 10;
     let nx = 10;
@@ -31,8 +31,8 @@ fn checkpoint_roundtrip_no_compression() {
 
     let checkpoint = Checkpoint::new(metadata, u.clone(), v.clone(), p.clone());
 
-    let path = manager.save(&checkpoint).unwrap();
-    let loaded = manager.load(&path).unwrap();
+    let path = manager.save(&checkpoint).expect("checkpoint save");
+    let loaded = manager.load(&path).expect("checkpoint load");
 
     assert_eq!(loaded.metadata.iteration, 100);
     assert_eq!(loaded.metadata.time.to_bits(), 1.234f64.to_bits());
@@ -44,8 +44,8 @@ fn checkpoint_roundtrip_no_compression() {
 
 #[test]
 fn checkpoint_roundtrip_zstd() {
-    let dir = tempdir().unwrap();
-    let mut manager = CheckpointManager::new(dir.path()).unwrap();
+    let dir = tempdir().expect("tmpdir creation");
+    let mut manager = CheckpointManager::new(dir.path()).expect("CheckpointManager creation");
     manager.set_compression(CompressionStrategy::Zstd(3));
 
     let ny = 5;
@@ -58,8 +58,8 @@ fn checkpoint_roundtrip_zstd() {
 
     let checkpoint = Checkpoint::new(metadata, u.clone(), v.clone(), p.clone());
 
-    let path = manager.save(&checkpoint).unwrap();
-    let loaded = manager.load(&path).unwrap();
+    let path = manager.save(&checkpoint).expect("checkpoint save");
+    let loaded = manager.load(&path).expect("checkpoint load");
 
     assert_eq!(loaded.metadata.iteration, 200);
     assert_eq!(loaded.metadata.time.to_bits(), E.to_bits());
@@ -92,17 +92,17 @@ proptest::proptest! {
             (1.0, 1.0),
         );
 
-        let u = Array2::from_shape_vec([ny, nx], u_data.clone()).unwrap();
-        let v = Array2::from_shape_vec([ny, nx], v_data.clone()).unwrap();
-        let p = Array2::from_shape_vec([ny, nx], p_data.clone()).unwrap();
+        let u = Array2::from_shape_vec([ny, nx], u_data.clone()).expect("u array shape");
+        let v = Array2::from_shape_vec([ny, nx], v_data.clone()).expect("v array shape");
+        let p = Array2::from_shape_vec([ny, nx], p_data.clone()).expect("p array shape");
 
         let checkpoint = Checkpoint::new(metadata, u.clone(), v.clone(), p.clone());
 
-        let dir = tempdir().unwrap();
-        let manager = CheckpointManager::new(dir.path()).unwrap();
+        let dir = tempdir().expect("tmpdir creation");
+        let manager = CheckpointManager::new(dir.path()).expect("CheckpointManager creation");
 
-        let path = manager.save(&checkpoint).unwrap();
-        let loaded = manager.load(&path).unwrap();
+        let path = manager.save(&checkpoint).expect("checkpoint save");
+        let loaded = manager.load(&path).expect("checkpoint load");
 
         prop_assert_eq!(loaded.metadata.iteration, iteration);
         prop_assert_eq!(loaded.metadata.time.to_bits(), time.to_bits());


### PR DESCRIPTION
Fixes the Clippy gate that was failing since ci(CFDrs)#3f2b2172 started running Clippy. Three test files used bare .unwrap()/.unwrap_err() which are denied by workspace-level unwrap_used=deny. Also fixes doc-markdown for CheckpointManager.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes Clippy warnings by replacing bare `unwrap()` and `unwrap_err()` calls with descriptive `expect()` and `expect_err()` messages in test code across three files. It also corrects a doc-markdown lint issue by properly formatting the `CheckpointManager` reference in documentation. These changes ensure compliance with the workspace-level `unwrap_used=deny` lint rule that was enforced after a recent CI update.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-io/tests/checkpoint_roundtrip.rs` |
| 2 | `crates/cfd-core/src/abstractions/state.rs` |
| 3 | `crates/cfd-core/src/compute/gpu/field_ops/tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test failure messages across state, GPU field-operation, and checkpoint roundtrip tests.
  * Added clearer context when invalid inputs, serialization, compression, or checkpoint operations fail.
  * Updated checkpoint test documentation with a linked reference for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->