### PR TITLE
build(cfd-3d): Migrate to apollo-fft 0.27 — drop _typed suffix [ATLAS-APOLLO-API-050]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aequitas"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/aequitas#5114cd12b6d7769628f2ebff83e26f9c5e19caed"
+source = "git+https://github.com/ryancinsight/aequitas#c74b662c9204d7ea18c1f56829f77ded753803ca"
 dependencies = [
  "eunomia",
  "serde",
@@ -116,7 +116,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "apollo-fft"
 version = "0.27.0"
-source = "git+https://github.com/ryancinsight/apollo#ed6d6905afda394a9e12570543159ab1b262589e"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -138,7 +138,7 @@ dependencies = [
 [[package]]
 name = "apollo-fft-macros"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/apollo#ed6d6905afda394a9e12570543159ab1b262589e"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "apollo-leto-interop"
 version = "0.18.0"
-source = "git+https://github.com/ryancinsight/apollo#ed6d6905afda394a9e12570543159ab1b262589e"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "leto",
 ]
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "apollo-nufft"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/apollo#ed6d6905afda394a9e12570543159ab1b262589e"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "athena-core"
 version = "0.1.1"
-source = "git+https://github.com/ryancinsight/athena#bd9346f6c34384b15f89dc9bcc571872799fbf98"
+source = "git+https://github.com/ryancinsight/athena#f6608bef656e301a68132d45f7af6dae1ca03a30"
 dependencies = [
  "eunomia",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "athena-leto"
 version = "0.1.1"
-source = "git+https://github.com/ryancinsight/athena#bd9346f6c34384b15f89dc9bcc571872799fbf98"
+source = "git+https://github.com/ryancinsight/athena#f6608bef656e301a68132d45f7af6dae1ca03a30"
 dependencies = [
  "athena-core",
  "eunomia",
@@ -374,9 +374,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "coeus-autograd"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "coeus-core"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "coeus-leto"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-core",
  "leto",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "coeus-nn"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "coeus-ops"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "coeus-optim"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "coeus-sparse"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "coeus-tensor"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#32d7f4e87d6cb13865db214d9401ce2975c81808"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -888,7 +888,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "consus-compression"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#e8f6b228f012d859fe39c73296e5bffa1e4a1180"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "byteorder",
  "consus-core",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "consus-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#1e061b0b8472e8b049359c64f4763a22525e1e4c"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "byteorder",
  "smallvec",
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "consus-hdf5"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#e8f6b228f012d859fe39c73296e5bffa1e4a1180"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "byteorder",
  "consus-compression",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "consus-io"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#1e061b0b8472e8b049359c64f4763a22525e1e4c"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "consus-core",
 ]
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "eunomia"
 version = "0.8.0"
-source = "git+https://github.com/ryancinsight/eunomia#88c685f2a733df73f753f2351b2e4d2ede8ff478"
+source = "git+https://github.com/ryancinsight/eunomia#bab4f9f87cd19291dbfbf0645449a7177c2762ea"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -1419,8 +1419,9 @@ dependencies = [
 [[package]]
 name = "gaia-mesh"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/gaia#10afa2b77b0fbc6e8d2bc359679445404a7b8ed5"
+source = "git+https://github.com/ryancinsight/gaia#9595668433c0db9627e7c20d1c992c17457cc21b"
 dependencies = [
+ "aequitas",
  "anyhow",
  "eunomia",
  "geometry-predicates",
@@ -1574,7 +1575,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hephaestus-core"
 version = "0.19.0"
-source = "git+https://github.com/ryancinsight/hephaestus#dc7b72c678b6f16fa56b350c21466ce7dbdde7ac"
+source = "git+https://github.com/ryancinsight/hephaestus#607ce3feb2e0ed1d907d3e0172e23377851e71d8"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1587,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "hephaestus-wgpu"
 version = "0.19.0"
-source = "git+https://github.com/ryancinsight/hephaestus#dc7b72c678b6f16fa56b350c21466ce7dbdde7ac"
+source = "git+https://github.com/ryancinsight/hephaestus#607ce3feb2e0ed1d907d3e0172e23377851e71d8"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1607,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#08ac3d91cc22bad12078fff83e29c9b0e743e7c6"
+source = "git+https://github.com/ryancinsight/hermes.git#525f4a4ae2aba0745e8b039c827741df7c1606dc"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1621,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-core"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#08ac3d91cc22bad12078fff83e29c9b0e743e7c6"
+source = "git+https://github.com/ryancinsight/hermes.git#525f4a4ae2aba0745e8b039c827741df7c1606dc"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1633,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-intrinsics"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#08ac3d91cc22bad12078fff83e29c9b0e743e7c6"
+source = "git+https://github.com/ryancinsight/hermes.git#525f4a4ae2aba0745e8b039c827741df7c1606dc"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1642,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-macros"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#08ac3d91cc22bad12078fff83e29c9b0e743e7c6"
+source = "git+https://github.com/ryancinsight/hermes.git#525f4a4ae2aba0745e8b039c827741df7c1606dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1652,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-types"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#08ac3d91cc22bad12078fff83e29c9b0e743e7c6"
+source = "git+https://github.com/ryancinsight/hermes.git#525f4a4ae2aba0745e8b039c827741df7c1606dc"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1667,7 +1668,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "hyperion"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/hyperion#86e89450974f9787beae6d0af263b46ee4a10996"
+source = "git+https://github.com/ryancinsight/hyperion#fd752c7fcd638c476a24a5b58228afa380e06535"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1725,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "iris-viz"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/iris#7b492157b878dd8f70898411dfc84046d2f4bf6f"
+source = "git+https://github.com/ryancinsight/iris#c10b328dbaa87099c57a6475076eee85f9c0bb20"
 
 [[package]]
 name = "is-terminal"
@@ -1795,7 +1796,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leto"
 version = "0.42.0"
-source = "git+https://github.com/ryancinsight/leto.git#2beb4f17c35c88c0eade4bd337f161c0cc2cf48f"
+source = "git+https://github.com/ryancinsight/leto.git#1402668167777860b3834c0cdf2a2c41a6686a8d"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1807,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "leto-ops"
 version = "0.42.0"
-source = "git+https://github.com/ryancinsight/leto.git#2beb4f17c35c88c0eade4bd337f161c0cc2cf48f"
+source = "git+https://github.com/ryancinsight/leto.git#1402668167777860b3834c0cdf2a2c41a6686a8d"
 dependencies = [
  "eunomia",
  "hermes-simd",
@@ -1842,9 +1843,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -1911,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "melinoe"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/melinoe.git#b521113c1b9530e509c8c868980a6f05e6d16335"
+source = "git+https://github.com/ryancinsight/melinoe.git#689f5621ce881c2e55674a1a0144d4e476e62ec2"
 
 [[package]]
 name = "memchr"
@@ -1932,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-arena"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
@@ -1943,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "mnemosyne-memory-core",
 ]
@@ -1951,12 +1952,12 @@ dependencies = [
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1966,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-heap"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "libc",
  "melinoe",
@@ -1981,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-local"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1996,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
@@ -2011,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory-core"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "loom",
 ]
@@ -2019,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#5ca0461a548ecb7b633c87846d7dd34e2c666136"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#ea0839bbb52ced140f86e83b7899b7ec51903f0c"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -2081,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "moirai-gpu"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#9ec4b029f78baa0d003667aee0c0d123503ba6ad"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "mnemosyne-memory-core",
  "moirai-core",
@@ -2511,9 +2512,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -2638,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "proteus"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/proteus#0003266c40224f77c82a368dfe6a3364f734318c"
+source = "git+https://github.com/ryancinsight/proteus#996b82279261a6a968420d68c74fb184b1337665"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -2953,7 +2954,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "ritk-image"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/ritk#d4d74b5bdede7e5c90fe9387285f3165a9b3a58f"
+source = "git+https://github.com/ryancinsight/ritk#b91bcee6f4058f69298ef6b330c36094ba1eb929"
 dependencies = [
  "anyhow",
  "coeus-autograd",
@@ -2970,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "ritk-spatial"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#d4d74b5bdede7e5c90fe9387285f3165a9b3a58f"
+source = "git+https://github.com/ryancinsight/ritk#b91bcee6f4058f69298ef6b330c36094ba1eb929"
 dependencies = [
  "leto",
  "serde",
@@ -2980,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "ritk-vtk"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#d4d74b5bdede7e5c90fe9387285f3165a9b3a58f"
+source = "git+https://github.com/ryancinsight/ritk#b91bcee6f4058f69298ef6b330c36094ba1eb929"
 dependencies = [
  "anyhow",
  "coeus-core",
@@ -2996,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "ritk-wgpu-compat"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#d4d74b5bdede7e5c90fe9387285f3165a9b3a58f"
+source = "git+https://github.com/ryancinsight/ritk#b91bcee6f4058f69298ef6b330c36094ba1eb929"
 
 [[package]]
 name = "rkyv"
@@ -3296,7 +3297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3305,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "themis-topology"
 version = "0.10.1"
-source = "git+https://github.com/ryancinsight/themis#f61173bc8c3ecd28fcdea7b35a0b1aed841f79a0"
+source = "git+https://github.com/ryancinsight/themis#d0fcce7aced31b3554fc33a9c20e40b37531e359"
 dependencies = [
  "melinoe",
 ]
@@ -3495,7 +3496,7 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 [[package]]
 name = "tyche-core"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/tyche#63d06940faa4aeccc7b779b238b564b07cc101f5"
+source = "git+https://github.com/ryancinsight/tyche#5eeaba952ed8abd2b072cf87e7628b7415bea03b"
 dependencies = [
  "eunomia",
 ]
@@ -3538,9 +3539,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apollo-fft"
-version = "0.26.0"
+version = "0.27.0"
 source = "git+https://github.com/ryancinsight/apollo#ed6d6905afda394a9e12570543159ab1b262589e"
 dependencies = [
  "apollo-fft-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ cfd-math = { path = "crates/cfd-math" }
 cfd-io = { path = "crates/cfd-io" }
 # Editable working copies live at the atlas root under repos/{gaia,apollo,consus};
 cfd-mesh = { version = "0.4.0", git = "https://github.com/ryancinsight/gaia", package = "gaia-mesh" }
-apollo-fft = { version = "0.26.0", git = "https://github.com/ryancinsight/apollo" }
+apollo-fft = { version = "0.27.0", git = "https://github.com/ryancinsight/apollo" }
 apollo-nufft = { version = "0.7.0", git = "https://github.com/ryancinsight/apollo" }
 leto = { version = "0.42.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }
 leto-ops = { version = "0.42.0", git = "https://github.com/ryancinsight/leto.git", default-features = false, features = ["std"] }

--- a/crates/cfd-3d/src/atlas_array.rs
+++ b/crates/cfd-3d/src/atlas_array.rs
@@ -4,8 +4,8 @@
 //! Leto transform surfaces directly.
 
 use apollo_fft::{
-    fft_1d_array_typed as apollo_fft_1d_array, fft_3d_array_typed as apollo_fft_3d_array,
-    ifft_3d_array_typed as apollo_ifft_3d_array, Complex64,
+    fft_1d_array as apollo_fft_1d_array, fft_3d_array as apollo_fft_3d_array,
+    ifft_3d_array as apollo_ifft_3d_array, Complex64,
 };
 use apollo_nufft::nufft_type2_3d as apollo_nufft_type2_3d;
 use apollo_nufft::{nufft_type1_3d as apollo_nufft_type1_3d, UniformGrid3D};

--- a/crates/cfd-3d/src/spectral/fourier.rs
+++ b/crates/cfd-3d/src/spectral/fourier.rs
@@ -21,7 +21,7 @@
 
 use crate::atlas_array::values;
 use apollo_fft::{
-    fft_1d_array_typed, ifft_1d_array_typed, PlanCacheProvider, PlanScratch, RealFftData,
+    fft_1d_array, ifft_1d_array, PlanCacheProvider, PlanScratch, RealFftData,
 };
 use cfd_core::error::Result;
 use core::ops::Neg;
@@ -102,7 +102,7 @@ where
         ensure_length(u.size(), self.n, "FourierTransform::forward")?;
 
         let scale = scalar_from_usize::<T>(self.n);
-        let spectrum = fft_1d_array_typed::<T>(u);
+        let spectrum = fft_1d_array::<T>(u);
         let normalized = values(&spectrum)
             .into_iter()
             .map(|value| Complex::new(value.re / scale, value.im / scale))
@@ -123,7 +123,7 @@ where
                 invalid_configuration(format!("FourierTransform::inverse input shape: {error}"))
             })?;
 
-        let spatial = ifft_1d_array_typed::<T>(&spectrum);
+        let spatial = ifft_1d_array::<T>(&spectrum);
         let recovered = values(&spatial)
             .into_iter()
             .map(|value| value * scale)

--- a/crates/cfd-3d/src/spectral/fourier.rs
+++ b/crates/cfd-3d/src/spectral/fourier.rs
@@ -20,9 +20,7 @@
 //! before transforming to physical space.
 
 use crate::atlas_array::values;
-use apollo_fft::{
-    fft_1d_array, ifft_1d_array, PlanCacheProvider, PlanScratch, RealFftData,
-};
+use apollo_fft::{fft_1d_array, ifft_1d_array, PlanCacheProvider, PlanScratch, RealFftData};
 use cfd_core::error::Result;
 use core::ops::Neg;
 use eunomia::{Complex, FloatElement, NumericElement};

--- a/crates/cfd-core/src/compute/gpu/field_ops/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/field_ops/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 use super::GpuFieldOps;
 use crate::compute::gpu::GpuContext;
 use crate::error::Error;

--- a/crates/cfd-core/src/compute/gpu/kernels/advection/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/advection/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 use super::{AdvectionConfig, GpuAdvectionKernel};
 use crate::compute::gpu::GpuContext;
 use crate::error::Error;

--- a/crates/cfd-core/src/compute/gpu/kernels/advection/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/advection/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{AdvectionConfig, GpuAdvectionKernel};

--- a/crates/cfd-core/src/compute/gpu/kernels/advection/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/advection/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{AdvectionConfig, GpuAdvectionKernel};
 use crate::compute::gpu::GpuContext;

--- a/crates/cfd-core/src/compute/gpu/kernels/diffusion/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/diffusion/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{DiffusionConfig, GpuDiffusionKernel};

--- a/crates/cfd-core/src/compute/gpu/kernels/diffusion/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/diffusion/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 use super::{DiffusionConfig, GpuDiffusionKernel};
 use crate::compute::gpu::GpuContext;
 use crate::error::Error;

--- a/crates/cfd-core/src/compute/gpu/kernels/diffusion/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/diffusion/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{DiffusionConfig, GpuDiffusionKernel};
 use crate::compute::gpu::GpuContext;

--- a/crates/cfd-core/src/compute/gpu/kernels/laplacian/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/laplacian/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 //! Tests for the 2D Laplacian GPU kernel.
 
 use super::kernel::Laplacian2DKernel;

--- a/crates/cfd-core/src/compute/gpu/kernels/pressure/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/pressure/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{GpuPressureKernel, PressureConfig};

--- a/crates/cfd-core/src/compute/gpu/kernels/pressure/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/pressure/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{GpuPressureKernel, PressureConfig};
 use crate::compute::gpu::GpuContext;

--- a/crates/cfd-core/src/compute/gpu/kernels/pressure/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/pressure/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 use super::{GpuPressureKernel, PressureConfig};
 use crate::compute::gpu::GpuContext;
 use crate::error::Error;

--- a/crates/cfd-core/src/compute/gpu/kernels/velocity/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/velocity/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 use super::{GpuVelocityKernel, VelocityConfig};
 use crate::compute::gpu::GpuContext;
 use crate::error::Error;

--- a/crates/cfd-core/src/compute/gpu/kernels/velocity/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/velocity/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{GpuVelocityKernel, VelocityConfig};

--- a/crates/cfd-core/src/compute/gpu/kernels/velocity/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/kernels/velocity/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::{GpuVelocityKernel, VelocityConfig};
 use crate::compute::gpu::GpuContext;

--- a/crates/cfd-core/src/compute/gpu/turbulence_compute/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/turbulence_compute/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 use super::*;
 use crate::error::Error;
 

--- a/crates/cfd-core/src/compute/gpu/turbulence_compute/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/turbulence_compute/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::*;

--- a/crates/cfd-core/src/compute/gpu/turbulence_compute/tests.rs
+++ b/crates/cfd-core/src/compute/gpu/turbulence_compute/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 #![allow(clippy::print_stderr)]
 use super::*;
 use crate::error::Error;

--- a/crates/cfd-core/src/compute/gpu/validation_tests.rs
+++ b/crates/cfd-core/src/compute/gpu/validation_tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stderr)]
 //! GPU kernel validation tests
 //! Verifies GPU implementations match CPU results within numerical tolerance
 

--- a/crates/cfd-core/src/compute/tests.rs
+++ b/crates/cfd-core/src/compute/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::float_cmp)]
 //! Tests for compute backend
 

--- a/crates/cfd-core/src/compute/tests.rs
+++ b/crates/cfd-core/src/compute/tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 //! Tests for compute backend
 
 use super::*;

--- a/crates/cfd-core/tests/backend_validation.rs
+++ b/crates/cfd-core/tests/backend_validation.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::float_cmp)]
 //! Validation tests for backend abstraction pattern
 //!
 //! Validates the backend abstraction implementation against performance and correctness


### PR DESCRIPTION
Consumer half of ATLAS-APOLLO-API-050. Removes _typed suffix from fft/ifft array functions, bumps workspace dep to 0.27.0.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `apollo-fft` dependency from version 0.26.0 to 0.27.0 and removes the `_typed` suffix from FFT and IFFT array function calls throughout the codebase. The changes include renaming `fft_1d_array_typed` to `fft_1d_array`, `ifft_1d_array_typed` to `ifft_1d_array`, `fft_3d_array_typed` to `fft_3d_array`, and `ifft_3d_array_typed` to `ifft_3d_array` to align with the updated API in the new version of the library.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `crates/cfd-3d/src/atlas_array.rs` |
| 3 | `crates/cfd-3d/src/spectral/fourier.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the Apollo FFT integration to version 0.27.0.
  * Improved compatibility with the updated FFT integration while preserving existing array-processing behavior.
  * Maintained Fourier transform normalization and error handling for consistent results.
  * Preserved existing wrapper behavior and overall processing workflows.
  * Improved validation of GPU-related operations without changing their expected functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->