### PR TITLE
build(CFDrs): Restore standalone Cargo.lock form (ADR-0044)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aequitas"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/aequitas#3168a41df9771741eb598f9d7dc95daf8cec1253"
 dependencies = [
  "eunomia",
  "serde",
@@ -115,6 +116,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "apollo-fft"
 version = "0.27.0"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -136,6 +138,7 @@ dependencies = [
 [[package]]
 name = "apollo-fft-macros"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -145,6 +148,7 @@ dependencies = [
 [[package]]
 name = "apollo-leto-interop"
 version = "0.18.0"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "leto",
 ]
@@ -152,6 +156,7 @@ dependencies = [
 [[package]]
 name = "apollo-nufft"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/apollo#d585e0f5c6f6e45e5e551a5ec3ca29f41af5afab"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -183,6 +188,7 @@ dependencies = [
 [[package]]
 name = "athena-core"
 version = "0.1.1"
+source = "git+https://github.com/ryancinsight/athena#f6608bef656e301a68132d45f7af6dae1ca03a30"
 dependencies = [
  "eunomia",
 ]
@@ -190,6 +196,7 @@ dependencies = [
 [[package]]
 name = "athena-leto"
 version = "0.1.1"
+source = "git+https://github.com/ryancinsight/athena#f6608bef656e301a68132d45f7af6dae1ca03a30"
 dependencies = [
  "athena-core",
  "eunomia",
@@ -759,6 +766,7 @@ dependencies = [
 [[package]]
 name = "coeus-autograd"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -773,6 +781,7 @@ dependencies = [
 [[package]]
 name = "coeus-core"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -787,6 +796,7 @@ dependencies = [
 [[package]]
 name = "coeus-leto"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-core",
  "leto",
@@ -796,6 +806,7 @@ dependencies = [
 [[package]]
 name = "coeus-nn"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -809,6 +820,7 @@ dependencies = [
 [[package]]
 name = "coeus-ops"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -826,6 +838,7 @@ dependencies = [
 [[package]]
 name = "coeus-optim"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -839,6 +852,7 @@ dependencies = [
 [[package]]
 name = "coeus-sparse"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -849,6 +863,7 @@ dependencies = [
 [[package]]
 name = "coeus-tensor"
 version = "0.10.0"
+source = "git+https://github.com/ryancinsight/Coeus.git#79f05dfd8cc63d132bbce4cbe275a385098dcd82"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -873,6 +888,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "consus-compression"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "byteorder",
  "consus-core",
@@ -881,6 +897,7 @@ dependencies = [
 [[package]]
 name = "consus-core"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "byteorder",
  "smallvec",
@@ -890,6 +907,7 @@ dependencies = [
 [[package]]
 name = "consus-hdf5"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "byteorder",
  "consus-compression",
@@ -900,6 +918,7 @@ dependencies = [
 [[package]]
 name = "consus-io"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/consus.git#34b25075f1dfb89052bf08017fd7d85b8acacec4"
 dependencies = [
  "consus-core",
 ]
@@ -1177,6 +1196,7 @@ dependencies = [
 [[package]]
 name = "eunomia"
 version = "0.8.0"
+source = "git+https://github.com/ryancinsight/eunomia#bab4f9f87cd19291dbfbf0645449a7177c2762ea"
 dependencies = [
  "bytemuck",
  "libm",
@@ -1399,6 +1419,7 @@ dependencies = [
 [[package]]
 name = "gaia-mesh"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/gaia#4980732cce0f5a022a67e2c5bdaf2efb894bbf42"
 dependencies = [
  "aequitas",
  "anyhow",
@@ -1554,6 +1575,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hephaestus-core"
 version = "0.19.0"
+source = "git+https://github.com/ryancinsight/hephaestus#607ce3feb2e0ed1d907d3e0172e23377851e71d8"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1566,6 +1588,7 @@ dependencies = [
 [[package]]
 name = "hephaestus-wgpu"
 version = "0.19.0"
+source = "git+https://github.com/ryancinsight/hephaestus#607ce3feb2e0ed1d907d3e0172e23377851e71d8"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1585,6 +1608,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/hermes.git#ef40f43d775ef2c266c09c02703d26497f52bb44"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1598,6 +1622,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-core"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/hermes.git#ef40f43d775ef2c266c09c02703d26497f52bb44"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1609,6 +1634,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-intrinsics"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/hermes.git#ef40f43d775ef2c266c09c02703d26497f52bb44"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1617,6 +1643,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-macros"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/hermes.git#ef40f43d775ef2c266c09c02703d26497f52bb44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1626,6 +1653,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-types"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/hermes.git#ef40f43d775ef2c266c09c02703d26497f52bb44"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1640,6 +1668,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "hyperion"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/hyperion#fd752c7fcd638c476a24a5b58228afa380e06535"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1697,6 +1726,7 @@ dependencies = [
 [[package]]
 name = "iris-viz"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/iris#f8630a1367f0a72a282b25ed1f73092c17f85ba9"
 
 [[package]]
 name = "is-terminal"
@@ -1766,6 +1796,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leto"
 version = "0.42.0"
+source = "git+https://github.com/ryancinsight/leto.git#1402668167777860b3834c0cdf2a2c41a6686a8d"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1777,6 +1808,7 @@ dependencies = [
 [[package]]
 name = "leto-ops"
 version = "0.42.0"
+source = "git+https://github.com/ryancinsight/leto.git#1402668167777860b3834c0cdf2a2c41a6686a8d"
 dependencies = [
  "eunomia",
  "hermes-simd",
@@ -1880,6 +1912,7 @@ dependencies = [
 [[package]]
 name = "melinoe"
 version = "0.9.0"
+source = "git+https://github.com/ryancinsight/melinoe.git#689f5621ce881c2e55674a1a0144d4e476e62ec2"
 
 [[package]]
 name = "memchr"
@@ -1900,6 +1933,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-arena"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "eunomia",
  "mnemosyne-backend",
@@ -1910,6 +1944,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "mnemosyne-memory-core",
 ]
@@ -1917,10 +1952,12 @@ dependencies = [
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.3.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1930,6 +1967,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-heap"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "libc",
  "melinoe",
@@ -1944,6 +1982,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-local"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1958,6 +1997,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory"
 version = "0.7.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
@@ -1972,6 +2012,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory-core"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "loom",
 ]
@@ -1979,6 +2020,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#2977a84593b67af7715bade2bce4249591d49546"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -1988,6 +2030,7 @@ dependencies = [
 [[package]]
 name = "moirai-async"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "futures",
  "libc",
@@ -2003,6 +2046,7 @@ dependencies = [
 [[package]]
 name = "moirai-async-macros"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2012,6 +2056,7 @@ dependencies = [
 [[package]]
 name = "moirai-core"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "bytemuck",
  "libc",
@@ -2023,6 +2068,7 @@ dependencies = [
 [[package]]
 name = "moirai-executor"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2036,6 +2082,7 @@ dependencies = [
 [[package]]
 name = "moirai-gpu"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "mnemosyne-memory-core",
  "moirai-core",
@@ -2046,6 +2093,7 @@ dependencies = [
 [[package]]
 name = "moirai-iter"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "futures",
  "libc",
@@ -2061,6 +2109,7 @@ dependencies = [
 [[package]]
 name = "moirai-pal"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "js-sys",
  "libc",
@@ -2075,6 +2124,7 @@ dependencies = [
 [[package]]
 name = "moirai-parallel"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "melinoe",
  "moirai-core",
@@ -2085,6 +2135,7 @@ dependencies = [
 [[package]]
 name = "moirai-runtime"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2102,6 +2153,7 @@ dependencies = [
 [[package]]
 name = "moirai-scheduler"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "mnemosyne-memory",
  "moirai-core",
@@ -2113,6 +2165,7 @@ dependencies = [
 [[package]]
 name = "moirai-sync"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "libc",
  "moirai-core",
@@ -2122,6 +2175,7 @@ dependencies = [
 [[package]]
 name = "moirai-transport"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 dependencies = [
  "bytemuck",
  "moirai-core",
@@ -2132,6 +2186,7 @@ dependencies = [
 [[package]]
 name = "moirai-utils"
 version = "0.5.0"
+source = "git+https://github.com/ryancinsight/Moirai#3d5d4c661552ca206c454704f1d5f3ed147d2adc"
 
 [[package]]
 name = "munge"
@@ -2584,6 +2639,7 @@ dependencies = [
 [[package]]
 name = "proteus"
 version = "0.1.0"
+source = "git+https://github.com/ryancinsight/proteus#f612c9981547d56021db3a1be7f75631fd78ff4c"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -2898,6 +2954,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "ritk-image"
 version = "0.4.0"
+source = "git+https://github.com/ryancinsight/ritk#c58ad548e95a75c22cf27d17f8ad8f279654ff7e"
 dependencies = [
  "anyhow",
  "coeus-autograd",
@@ -2914,6 +2971,7 @@ dependencies = [
 [[package]]
 name = "ritk-spatial"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/ritk#c58ad548e95a75c22cf27d17f8ad8f279654ff7e"
 dependencies = [
  "leto",
  "serde",
@@ -2923,6 +2981,7 @@ dependencies = [
 [[package]]
 name = "ritk-vtk"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/ritk#c58ad548e95a75c22cf27d17f8ad8f279654ff7e"
 dependencies = [
  "anyhow",
  "coeus-core",
@@ -2938,6 +2997,7 @@ dependencies = [
 [[package]]
 name = "ritk-wgpu-compat"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/ritk#c58ad548e95a75c22cf27d17f8ad8f279654ff7e"
 
 [[package]]
 name = "rkyv"
@@ -3246,6 +3306,7 @@ dependencies = [
 [[package]]
 name = "themis-topology"
 version = "0.10.1"
+source = "git+https://github.com/ryancinsight/themis#d0fcce7aced31b3554fc33a9c20e40b37531e359"
 dependencies = [
  "melinoe",
 ]
@@ -3435,6 +3496,7 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 [[package]]
 name = "tyche-core"
 version = "0.2.0"
+source = "git+https://github.com/ryancinsight/tyche#5eeaba952ed8abd2b072cf87e7628b7415bea03b"
 dependencies = [
  "eunomia",
 ]
@@ -4153,63 +4215,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "asclepius"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "asclepius-coeus"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "ritk-core"
-version = "0.10.0"
-
-[[patch.unused]]
-name = "ritk-dicom"
-version = "0.2.0"
-
-[[patch.unused]]
-name = "ritk-io"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "ritk-registration"
-version = "0.54.0"
-
-[[patch.unused]]
-name = "apollo-sht"
-version = "0.7.0"
-
-[[patch.unused]]
-name = "hephaestus-cuda"
-version = "0.19.0"
-
-[[patch.unused]]
-name = "hephaestus-metal"
-version = "0.19.0"
-
-[[patch.unused]]
-name = "hephaestus-rocm"
-version = "0.19.0"
-
-[[patch.unused]]
-name = "horae"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "consus-npy"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "consus-onnx"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "consus-zarr"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "moirai-http"
-version = "0.5.0"


### PR DESCRIPTION
The committed Cargo.lock was in overlay-stripped form: ritk, themis, and tyche git source lines were missing. Regenerated outside the Atlas overlay per tlas-lock-form.py regenerate.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR restores the `Cargo.lock` file to its standalone form by adding back git source lines for dependencies that were previously stripped in an overlay configuration. The changes regenerate the lock file outside the Atlas overlay environment, adding explicit git repository URLs and commit hashes for numerous dependencies (such as `ritk`, `themis`, `tyche`, `apollo`, `coeus`, `moirai`, and many others) while also removing the `[[patch.unused]]` sections at the end of the file. This ensures the lock file properly references the git sources for all external dependencies per ADR-0044.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->