### PR TITLE
fix(cfd-1d): Integrate bounded JFNK recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 > Mirror reference: atlas-meta backlog.md / checklist.md / gap_audit.md + repos/ritk/{CHANGELOG.md, checklist.md, gap_audit.md} (same six canonical + three disallowed compounds in the same one-page rubric form).
 # Changelog
 
+- **cfd-1d/cfd-math**: Integrate the retained bounded-amplitude JFNK recovery
+  into the nonlinear network solver. Recovery work is derived from the
+  configured iteration budget, and residual callback failures remain typed
+  through the new checked JFNK entry point.
+
 - **cfd-2d**: The Newtonian pressure-correction default remains its existing
   calibrated SOR split; `SIMPLEConfig` now permits a validated consumer-owned
   override. The backward-facing-step benchmark selects `1.7` together with

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -124,6 +124,18 @@
       local compilation is currently blocked by the shared overlay/lock
       mismatch, not by a source diagnostic.
 
+## ATLAS-CFDRS-JFNK-OPEN-033 [fix] — Integrate bounded Newton-Krylov recovery
+
+- [x] Declare `newton_fallback.rs` in the `cfd-1d` solver graph and invoke it
+      once after the existing bounded-amplitude stagnation detector.
+- [x] Derive the Newton/Krylov recovery limits from `SolverConfig.max_iterations`
+      and route residual callback failures through a fallible JFNK API.
+- [x] Add value-semantic coverage for checked JFNK error propagation and the
+      finite recovery-budget invariant.
+- [ ] Run the locked `cfd-1d`/`cfd-math` Nextest filters and the hosted exact-head
+      Rust and book-figure gates; the local Atlas overlay currently blocks Cargo
+      resolution before compilation.
+
 ## ATLAS-ORPHAN-MODULES-096-CFDRS [patch] — done 2026-08-17
 
 - [x] Wire `cfd-1d` resistance-model tests into the module graph and correct

--- a/backlog.md
+++ b/backlog.md
@@ -231,6 +231,21 @@ CI run `32033808279` passes its Rust workspace and book-figure gates at source
 head `b455a416`; the pushed PM head `5b95fe3a` passes the same gates in run
 `32036370369`. External `recurseml/analysis` remains report-only.
 
+## ATLAS-CFDRS-JFNK-OPEN-033 — Integrate bounded Newton-Krylov recovery [fix] — in progress
+
+**Owner:** Atlas session; scope is `cfd-1d` nonlinear network recovery and the
+provider-owned `cfd-math` JFNK callback seam. **Acceptance:** the retained
+`newton_fallback.rs` source is reachable from `NetworkSolver`; bounded-amplitude
+stagnation invokes one finite-budget JFNK trajectory; assembly and linear-solver
+failures remain typed; and the exact provider hosted gates pass at the final
+source head. No tolerance relaxation, compatibility shim, or test-workload
+change is permitted.
+
+The source integration and value-semantic unit coverage are implemented. Local
+format and diff checks pass. Locked Cargo verification is currently blocked
+before compilation by the shared Atlas overlay/lock mismatch; hosted exact-head
+verification is the remaining closure gate.
+
 ## ATLAS-CFDRS-CONFORMANCE-101 — Close current ratchet regressions [patch] — done 2026-08-17
 
 **Owner:** Atlas session; closed at provider source head `e9c84bf6`.

--- a/crates/cfd-1d/src/solver/core/mod.rs
+++ b/crates/cfd-1d/src/solver/core/mod.rs
@@ -10,6 +10,7 @@ mod geometry;
 mod linear_system;
 mod matrix_assembly;
 mod network_solver;
+mod newton_fallback;
 mod problem;
 mod solver_detection;
 mod state;

--- a/crates/cfd-1d/src/solver/core/network_solver.rs
+++ b/crates/cfd-1d/src/solver/core/network_solver.rs
@@ -9,6 +9,7 @@ use eunomia::{FloatElement, NumericElement};
 
 use super::vector_bridge::{array_l2_norm, copy_array};
 use super::{
+    newton_fallback::{jfnk_fallback, FallbackBudget},
     workspace, ConvergenceChecker, LinearSolverMethod, LinearSystemSolver, MatrixAssembler,
     NetworkProblem, PrimarySolveDiagnostics, PrimarySolveError, SolveFailureReason, SolverConfig,
 };
@@ -281,6 +282,9 @@ impl<T: CfdScalar, F: FluidTrait<T> + Clone> NetworkSolver<T, F> {
 
         let mut selected_method: Option<LinearSolverMethod> = None;
         let mut adaptive_solver: Option<LinearSystemSolver<T>> = None;
+        let fallback_budget = FallbackBudget::for_max_iterations(self.config.max_iterations);
+        let mut solution_change_history = Vec::with_capacity(fallback_budget.stall_window);
+        let mut fallback_attempted = false;
 
         for iter in 0..self.config.max_iterations {
             diagnostics.picard_iterations = iter + 1;
@@ -384,6 +388,9 @@ impl<T: CfdScalar, F: FluidTrait<T> + Clone> NetworkSolver<T, F> {
                     }),
                 ));
             }
+            if let Some(change) = Self::diagnostic_f64(solution_change_norm) {
+                solution_change_history.push(change);
+            }
             network.residuals.push(residual_norm);
 
             let converged = self
@@ -445,6 +452,67 @@ impl<T: CfdScalar, F: FluidTrait<T> + Clone> NetworkSolver<T, F> {
                     .iter()
                     .map(|flow_rate| flow_rate.into_base()),
             );
+
+            if !fallback_attempted
+                && iter + 1 < self.config.max_iterations
+                && iter + 1 >= fallback_budget.warmup_iterations
+                && fallback_budget.is_stalling(&solution_change_history)
+            {
+                fallback_attempted = true;
+                diagnostics.fallback_used = true;
+                let Some(linear_method) = selected_method else {
+                    return Err(PrimarySolveError::new(
+                        SolveFailureReason::LinearSolverFailure,
+                        diagnostics,
+                        Error::InvalidConfiguration(
+                            "JFNK fallback requires a selected linear solver method".to_string(),
+                        ),
+                    ));
+                };
+                let fallback_solution = jfnk_fallback(
+                    &self.assembler,
+                    &network,
+                    workspace.dirichlet_values.clone(),
+                    workspace.neumann_sources.clone(),
+                    linear_method,
+                    self.config.tolerance,
+                    &fallback_budget,
+                    &workspace.last_solution,
+                )
+                .map_err(|source| {
+                    let reason = match &source {
+                        Error::Convergence(_) => SolveFailureReason::MaxIterationsExceeded,
+                        Error::Numerical(_) => SolveFailureReason::NonFiniteResidual,
+                        _ => SolveFailureReason::LinearSolverFailure,
+                    };
+                    PrimarySolveError::new(reason, diagnostics.clone(), source)
+                })?;
+                if !Self::vector_is_finite(&fallback_solution) {
+                    return Err(PrimarySolveError::new(
+                        SolveFailureReason::NonFiniteResidual,
+                        diagnostics,
+                        Error::Numerical(NumericalErrorKind::InvalidValue {
+                            value: "non-finite JFNK fallback solution".to_string(),
+                        }),
+                    ));
+                }
+                self.update_network_solution(&mut network, &fallback_solution)
+                    .map_err(|source| {
+                        PrimarySolveError::new(
+                            SolveFailureReason::MatrixAssemblyInvalid,
+                            diagnostics.clone(),
+                            source,
+                        )
+                    })?;
+                workspace.last_solution = fallback_solution;
+                last_flow_rates.clear();
+                last_flow_rates.extend(
+                    network
+                        .flow_rates
+                        .iter()
+                        .map(|flow_rate| flow_rate.into_base()),
+                );
+            }
         }
 
         Err(PrimarySolveError::new(

--- a/crates/cfd-1d/src/solver/core/newton_fallback.rs
+++ b/crates/cfd-1d/src/solver/core/newton_fallback.rs
@@ -56,15 +56,15 @@
 
 use cfd_core::error::{ConvergenceErrorKind, Error, Result};
 use cfd_math::nonlinear_solver::{JfnkConfig, JfnkSolver};
-use eunomia::{FloatElement, NumericElement};
+use eunomia::FloatElement;
 use leto::Array1;
 
 use super::linear_system::{LinearSolverMethod, LinearSystemSolver};
 use super::matrix_assembly::MatrixAssembler;
 use super::workspace::SolverWorkspace;
-use super::Network;
-use cfd_core::CfdScalar;
+use crate::domain::network::Network;
 use cfd_core::physics::fluid::FluidTrait;
+use cfd_core::CfdScalar;
 
 /// Configuration for the JFNK fallback.
 ///
@@ -96,10 +96,8 @@ pub(super) struct FallbackBudget {
 
 impl Default for FallbackBudget {
     fn default() -> Self {
-        // With the canonical `SolverConfig { max_iterations = 10000 }`,
-        // warmup 200 + newton 30 × krylov 50 = 200 + 1500 = 1700 ≪ 10000.
-        // The active test budget roughly halves because each JvP does one
-        // extra F-eval, but the production Picard budget is not raised.
+        // These values are the recovery defaults. `for_max_iterations` derives
+        // the active Newton/Krylov limits from the caller's outer budget.
         Self {
             warmup_iterations: 200,
             stall_window: 64,
@@ -111,6 +109,29 @@ impl Default for FallbackBudget {
 }
 
 impl FallbackBudget {
+    /// Derive a recovery budget that fits inside the configured outer budget.
+    ///
+    /// The warm-up and the bounded Newton/Krylov work are counted as one
+    /// recovery trajectory. This prevents the fallback from silently turning
+    /// a finite solver budget into an unbounded second attempt.
+    pub(super) fn for_max_iterations(max_iterations: usize) -> Self {
+        let defaults = Self::default();
+        let warmup_iterations = defaults
+            .warmup_iterations
+            .min(max_iterations.saturating_sub(1));
+        let remaining = max_iterations.saturating_sub(warmup_iterations).max(1);
+        let max_krylov_iterations = defaults.max_krylov_iterations.min(remaining);
+        let max_newton_iterations = (remaining / max_krylov_iterations)
+            .max(1)
+            .min(defaults.max_newton_iterations);
+        Self {
+            warmup_iterations,
+            max_krylov_iterations,
+            max_newton_iterations,
+            ..defaults
+        }
+    }
+
     /// Stagnation detector: bounded fixed-amplitude cycle on
     /// `solution_change_norm`.
     ///
@@ -171,11 +192,12 @@ where
     F: FluidTrait<T> + Clone,
 {
     let n = network_snapshot.node_count();
-    debug_assert_eq!(
-        warm_solution.shape()[0],
-        n,
-        "JFNK warm-start vector length must match network node count"
-    );
+    if warm_solution.shape()[0] != n {
+        return Err(Error::InvalidConfiguration(format!(
+            "JFNK warm-start length {} does not match network node count {n}",
+            warm_solution.shape()[0]
+        )));
+    }
 
     // Pre-allocated workspace and solver reused across all F-evaluations.
     // The boundary-condition classification is constant once the outer
@@ -194,22 +216,17 @@ where
     // loop: (1) refresh edge flow rates from `x`, (2) assemble the conductance
     // Laplacian, (3) solve `A x = b` for `x_next = G(x)`. Returning
     // `x_next − x` gives the Newton residual of the fixed-point map.
-    let picard_residual = |x: &Array1<T>| -> Array1<T> {
+    let picard_residual = |x: &Array1<T>| -> Result<Array1<T>> {
         let mut net = network_snapshot.clone();
-        net.update_from_solution(x)
-            .expect("invariant: network update_from_solution must succeed on JFNK F-eval");
-        let matrix = assembler
-            .assemble_into(&net, &mut workspace)
-            .expect("invariant: assemble_into must succeed on JFNK F-eval");
+        net.update_from_solution(x)?;
+        let matrix = assembler.assemble_into(&net, &mut workspace)?;
         let mut x_init = x.clone();
-        let g_x = inner_solver
-            .solve_with_initial_guess(&matrix, &workspace.rhs, &mut x_init)
-            .expect("invariant: linear solve must succeed on JFNK F-eval");
+        let g_x = inner_solver.solve_with_initial_guess(&matrix, &workspace.rhs, &mut x_init)?;
         let mut f = g_x.clone();
         for i in 0..n {
             f[[i]] = g_x[[i]] - x[[i]];
         }
-        f
+        Ok(f)
     };
 
     // atol := tolerance. Newton's `‖F‖ < atol` is structurally equivalent
@@ -227,7 +244,7 @@ where
         eta_max: <T as FloatElement>::from_f64(0.9),
     };
     let jfnk = JfnkSolver::new(jfnk_config);
-    let (solution, convergence) = jfnk.solve(picard_residual, warm_solution.clone())?;
+    let (solution, convergence) = jfnk.solve_checked(picard_residual, warm_solution.clone())?;
     if !convergence.converged {
         return Err(Error::Convergence(
             ConvergenceErrorKind::MaxIterationsExceeded {
@@ -241,6 +258,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aequitas::systems::si::quantities::{HydraulicResistance, Pressure};
+    use cfd_core::physics::fluid::database::water_20c;
+    use crate::domain::network::{Network, NetworkBuilder};
 
     /// Empty-history slice is not stalled — fallback should not start.
     #[test]
@@ -255,6 +275,21 @@ mod tests {
         let budget = FallbackBudget::default();
         let shorter: Vec<f64> = (0..budget.stall_window - 1).map(|_| 1.0).collect();
         assert!(!budget.is_stalling(&shorter));
+    }
+
+    /// The derived recovery work stays within the caller's finite iteration
+    /// budget, including the bounded Krylov work per Newton step.
+    #[test]
+    fn derived_budget_is_bounded() {
+        for max_iterations in [1, 64, 200, 1_000, 10_000] {
+            let budget = FallbackBudget::for_max_iterations(max_iterations);
+            assert!(budget.warmup_iterations < max_iterations || max_iterations == 0);
+            assert!(
+                budget.warmup_iterations
+                    + budget.max_newton_iterations * budget.max_krylov_iterations
+                    <= max_iterations.max(1)
+            );
+        }
     }
 
     /// Bounded fixed-amplitude cycle is the canonical stalled trajectory.
@@ -311,5 +346,68 @@ mod tests {
         cycle[1] = 0.0;
         // All NaN/0 sample → no usable history, not stalled.
         assert!(!budget.is_stalling(&cycle));
+    }
+
+    /// A real two-node linear network exercises the full residual callback,
+    /// matrix assembly, linear solve, and JFNK convergence contract.
+    #[test]
+    fn linear_network_fallback_recovers_pressure_solution() {
+        let fluid = water_20c::<f64>().expect("water properties are valid");
+        let mut builder = NetworkBuilder::new();
+        let inlet = builder.add_inlet("inlet".into());
+        let outlet = builder.add_outlet("outlet".into());
+        builder.connect_with_pipe(inlet, outlet, "pipe".into());
+        let mut graph = builder.build().expect("network graph is valid");
+        let edge = graph
+            .edge_indices()
+            .next()
+            .expect("network contains the pipe edge");
+        graph[edge].resistance = HydraulicResistance::from_base(2.0);
+
+        let mut network = Network::new(graph, fluid);
+        network.set_pressure(inlet, Pressure::from_base(10.0));
+        network.set_pressure(outlet, Pressure::from_base(0.0));
+
+        let n = network.node_count();
+        let mut workspace = SolverWorkspace::new(n);
+        MatrixAssembler::classify_boundary_conditions_into(
+            &network,
+            &mut workspace.dirichlet_values,
+            &mut workspace.neumann_sources,
+        )
+        .expect("boundary conditions are valid");
+        let assembler = MatrixAssembler::new();
+        let matrix = assembler
+            .assemble_into(&network, &mut workspace)
+            .expect("network matrix is valid");
+        let mut warm_solution = Array1::from_elem([n], 0.0);
+        let initial_solution = LinearSystemSolver::new()
+            .with_method(LinearSolverMethod::ConjugateGradient)
+            .with_tolerance(1.0e-10)
+            .with_max_iterations(20)
+            .solve_with_initial_guess(&matrix, &workspace.rhs, &mut warm_solution)
+            .expect("linear warm start is valid");
+        let budget = FallbackBudget {
+            warmup_iterations: 1,
+            stall_window: 1,
+            stall_ratio: 10.0,
+            max_newton_iterations: 10,
+            max_krylov_iterations: 10,
+        };
+
+        let solution = jfnk_fallback(
+            &assembler,
+            &network,
+            workspace.dirichlet_values,
+            workspace.neumann_sources,
+            LinearSolverMethod::ConjugateGradient,
+            1.0e-10,
+            &budget,
+            &initial_solution,
+        )
+        .expect("JFNK recovers the linear network root");
+
+        assert!((solution[inlet.index()] - 10.0).abs() < 1.0e-8);
+        assert!(solution[outlet.index()].abs() < 1.0e-8);
     }
 }

--- a/crates/cfd-1d/src/solver/core/newton_fallback.rs
+++ b/crates/cfd-1d/src/solver/core/newton_fallback.rs
@@ -258,9 +258,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::network::{Network, NetworkBuilder};
     use aequitas::systems::si::quantities::{HydraulicResistance, Pressure};
     use cfd_core::physics::fluid::database::water_20c;
-    use crate::domain::network::{Network, NetworkBuilder};
 
     /// Empty-history slice is not stalled — fallback should not start.
     #[test]

--- a/crates/cfd-1d/src/solver/core/newton_fallback.rs
+++ b/crates/cfd-1d/src/solver/core/newton_fallback.rs
@@ -126,8 +126,8 @@ impl FallbackBudget {
             .min(defaults.max_newton_iterations);
         Self {
             warmup_iterations,
-            max_krylov_iterations,
             max_newton_iterations,
+            max_krylov_iterations,
             ..defaults
         }
     }

--- a/crates/cfd-1d/src/solver/core/status.rs
+++ b/crates/cfd-1d/src/solver/core/status.rs
@@ -51,6 +51,9 @@ pub struct PrimarySolveDiagnostics {
     pub last_solution_change_norm: Option<f64>,
     /// True when the network was solved as a static linear system.
     pub matrix_treated_as_linear_static: bool,
+    /// True when the bounded JFNK recovery trajectory was attempted.
+    #[serde(default)]
+    pub fallback_used: bool,
     /// True when `cfd-optim` had to degrade geometry-dependent coefficients for recovery.
     pub degraded_geometry_for_recovery: bool,
     /// Human-readable failure detail from the underlying solver/model error.

--- a/crates/cfd-math/src/nonlinear_solver/jfnk.rs
+++ b/crates/cfd-math/src/nonlinear_solver/jfnk.rs
@@ -118,14 +118,14 @@ pub struct JfnkConvergence<T: Copy> {
 struct JvpOperator<'a, T, F>
 where
     T: RealField + Copy + FloatElement,
-    F: Fn(&Array1<T>) -> Result<Array1<T>>,
+    F: FnMut(&Array1<T>) -> Result<Array1<T>>,
 {
     /// Current Newton point $x_k$ (pivot)
     x_pivot: &'a Array1<T>,
     /// $F(x_k)$ — pre-computed residual at pivot
     f_pivot: &'a Array1<T>,
     /// The nonlinear function $F$
-    func: &'a F,
+    func: &'a mut F,
     /// Finite-difference perturbation size $\varepsilon$
     eps: T,
 }
@@ -133,7 +133,7 @@ where
 impl<T, F> JvpOperator<'_, T, F>
 where
     T: RealField + Copy + FloatElement + Scalar,
-    F: Fn(&Array1<T>) -> Result<Array1<T>>,
+    F: FnMut(&Array1<T>) -> Result<Array1<T>>,
 {
     /// Compute $J(x) v \approx [F(x + \varepsilon v) - F(x)] / \varepsilon$.
     ///
@@ -141,7 +141,7 @@ where
     ///
     /// Uses the caller-pre-computed `eps` which already encodes
     /// $\varepsilon = \sqrt{\varepsilon_{\rm mach}} (1 + \|x\|) / \|v\|$.
-    fn apply_jvp(&self, v: &Array1<T>) -> Result<Array1<T>> {
+    fn apply_jvp(&mut self, v: &Array1<T>) -> Result<Array1<T>> {
         // Perturbed point: x + ε v
         let x_pert = add_scaled(self.x_pivot, v, self.eps);
         // Finite difference: [F(x + ε v) - F(x)] / ε
@@ -197,6 +197,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
     /// finite-difference Jacobian-vector product, and every model-residual
     /// evaluation. This keeps domain and linear-solver failures typed instead
     /// of converting them into a panic inside a recovery path.
+    /// The callback may mutate reusable workspace state between evaluations.
     ///
     /// # Errors
     ///
@@ -204,11 +205,11 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
     /// solve.
     pub fn solve_checked<F>(
         &self,
-        func: F,
+        mut func: F,
         mut x: Array1<T>,
     ) -> Result<(Array1<T>, JfnkConvergence<T>)>
     where
-        F: Fn(&Array1<T>) -> Result<Array1<T>>,
+        F: FnMut(&Array1<T>) -> Result<Array1<T>>,
     {
         let n = x.shape()[0];
         let mut f = func(&x)?;
@@ -263,14 +264,14 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
 
             // Solve J(x) δx = -F(x) via matrix-free GMRES
             let rhs = neg(&f);
-            let delta_x = self.gmres_matrix_free(&func, &x, &f, &rhs, inner_tol, n)?;
+            let delta_x = self.gmres_matrix_free(&mut func, &x, &f, &rhs, inner_tol, n)?;
 
             // Model residual estimate: ‖F(xₖ) + J(xₖ)δxₖ‖ (via JvP)
             let eps = Self::compute_eps(&x, &delta_x);
-            let jop = JvpOperator {
+            let mut jop = JvpOperator {
                 x_pivot: &x,
                 f_pivot: &f,
-                func: &func,
+                func: &mut func,
                 eps,
             };
             let j_delta = jop.apply_jvp(&delta_x)?;
@@ -308,7 +309,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
     /// The residual sequence is non-increasing: ‖r_{k+1}‖ ≤ ‖r_k‖.
     fn gmres_matrix_free<F>(
         &self,
-        func: &F,
+        func: &mut F,
         x: &Array1<T>,
         f_x: &Array1<T>,
         b: &Array1<T>,
@@ -316,7 +317,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
         n: usize,
     ) -> Result<Array1<T>>
     where
-        F: Fn(&Array1<T>) -> Result<Array1<T>>,
+        F: FnMut(&Array1<T>) -> Result<Array1<T>>,
     {
         let restart = self.config.krylov_restart.min(n);
         let max_iter = self.config.max_krylov_iterations;
@@ -359,10 +360,10 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                 // Arnoldi: compute w = J(x) · vⱼ
                 let vj = &v_basis[j];
                 let eps = Self::compute_eps(x, vj);
-                let jop = JvpOperator {
+                let mut jop = JvpOperator {
                     x_pivot: x,
                     f_pivot: f_x,
-                    func,
+                    func: &mut *func,
                     eps,
                 };
                 let mut w = jop.apply_jvp(vj)?;
@@ -407,10 +408,10 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                     }
                     let fwd = {
                         let eps = Self::compute_eps(x, &delta);
-                        let jop = JvpOperator {
+                        let mut jop = JvpOperator {
                             x_pivot: x,
                             f_pivot: f_x,
-                            func,
+                            func: &mut *func,
                             eps,
                         };
                         jop.apply_jvp(&delta)?
@@ -432,10 +433,10 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                     }
                     let fwd = {
                         let eps = Self::compute_eps(x, &delta);
-                        let jop = JvpOperator {
+                        let mut jop = JvpOperator {
                             x_pivot: x,
                             f_pivot: f_x,
-                            func,
+                            func: &mut *func,
                             eps,
                         };
                         jop.apply_jvp(&delta)?
@@ -622,6 +623,26 @@ mod tests {
             }
             other => panic!("unexpected JFNK checked result: {other:?}"),
         }
+    }
+
+    /// A checked residual may mutate reusable state between evaluations.
+    #[test]
+    fn test_checked_residual_accepts_mutable_callback() {
+        let solver = JfnkSolver::new(JfnkConfig::<f64>::default());
+        let mut calls = 0;
+        let (solution, convergence) = solver
+            .solve_checked(
+                |x| {
+                    calls += 1;
+                    Ok(vec(vec![x[0] - 1.0]))
+                },
+                vec(vec![1.0]),
+            )
+            .expect("initial root should converge");
+
+        assert_eq!(solution, vec(vec![1.0]));
+        assert!(convergence.converged);
+        assert_eq!(calls, 1);
     }
 
     /// Verify EW forcing term stays in [eta_min, eta_max].

--- a/crates/cfd-math/src/nonlinear_solver/jfnk.rs
+++ b/crates/cfd-math/src/nonlinear_solver/jfnk.rs
@@ -118,7 +118,7 @@ pub struct JfnkConvergence<T: Copy> {
 struct JvpOperator<'a, T, F>
 where
     T: RealField + Copy + FloatElement,
-    F: Fn(&Array1<T>) -> Array1<T>,
+    F: Fn(&Array1<T>) -> Result<Array1<T>>,
 {
     /// Current Newton point $x_k$ (pivot)
     x_pivot: &'a Array1<T>,
@@ -133,7 +133,7 @@ where
 impl<T, F> JvpOperator<'_, T, F>
 where
     T: RealField + Copy + FloatElement + Scalar,
-    F: Fn(&Array1<T>) -> Array1<T>,
+    F: Fn(&Array1<T>) -> Result<Array1<T>>,
 {
     /// Compute $J(x) v \approx [F(x + \varepsilon v) - F(x)] / \varepsilon$.
     ///
@@ -141,12 +141,12 @@ where
     ///
     /// Uses the caller-pre-computed `eps` which already encodes
     /// $\varepsilon = \sqrt{\varepsilon_{\rm mach}} (1 + \|x\|) / \|v\|$.
-    fn apply_jvp(&self, v: &Array1<T>) -> Array1<T> {
+    fn apply_jvp(&self, v: &Array1<T>) -> Result<Array1<T>> {
         // Perturbed point: x + ε v
         let x_pert = add_scaled(self.x_pivot, v, self.eps);
         // Finite difference: [F(x + ε v) - F(x)] / ε
-        let f_pert = (self.func)(&x_pert);
-        scale(&sub(&f_pert, self.f_pivot), T::ONE / self.eps)
+        let f_pert = (self.func)(&x_pert)?;
+        Ok(scale(&sub(&f_pert, self.f_pivot), T::ONE / self.eps))
     }
 }
 
@@ -181,15 +181,37 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
         }
     }
 
-    /// Solve $F(x) = 0$ with initial guess $x_0$ using JFNK.
+    /// Solve an infallible $F(x) = 0$ problem with initial guess $x_0$ using JFNK.
     ///
     /// Returns the solution and convergence diagnostics.
-    pub fn solve<F>(&self, func: F, mut x: Array1<T>) -> Result<(Array1<T>, JfnkConvergence<T>)>
+    pub fn solve<F>(&self, func: F, x: Array1<T>) -> Result<(Array1<T>, JfnkConvergence<T>)>
     where
         F: Fn(&Array1<T>) -> Array1<T>,
     {
+        self.solve_checked(|value| Ok(func(value)), x)
+    }
+
+    /// Solve a fallible $F(x) = 0$ problem with initial guess $x_0$ using JFNK.
+    ///
+    /// The callback's error is propagated from the initial residual, every
+    /// finite-difference Jacobian-vector product, and every model-residual
+    /// evaluation. This keeps domain and linear-solver failures typed instead
+    /// of converting them into a panic inside a recovery path.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by `func` or by the inner Krylov
+    /// solve.
+    pub fn solve_checked<F>(
+        &self,
+        func: F,
+        mut x: Array1<T>,
+    ) -> Result<(Array1<T>, JfnkConvergence<T>)>
+    where
+        F: Fn(&Array1<T>) -> Result<Array1<T>>,
+    {
         let n = x.shape()[0];
-        let mut f = func(&x);
+        let mut f = func(&x)?;
         let norm0 = norm(&f);
 
         if norm0 < self.config.atol {
@@ -251,13 +273,13 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                 func: &func,
                 eps,
             };
-            let j_delta = jop.apply_jvp(&delta_x);
+            let j_delta = jop.apply_jvp(&delta_x)?;
             prev_model_residual = norm(&add(&f, &j_delta));
             prev_norm = norm_f;
 
             // Update: x ← x + δx
             x = add(&x, &delta_x);
-            f = func(&x);
+            f = func(&x)?;
 
             history.push(norm(&f));
         }
@@ -294,7 +316,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
         n: usize,
     ) -> Result<Array1<T>>
     where
-        F: Fn(&Array1<T>) -> Array1<T>,
+        F: Fn(&Array1<T>) -> Result<Array1<T>>,
     {
         let restart = self.config.krylov_restart.min(n);
         let max_iter = self.config.max_krylov_iterations;
@@ -343,7 +365,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                     func,
                     eps,
                 };
-                let mut w = jop.apply_jvp(vj);
+                let mut w = jop.apply_jvp(vj)?;
 
                 // Modified Gram-Schmidt orthogonalization
                 for i in 0..=j {
@@ -391,7 +413,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                             func,
                             eps,
                         };
-                        jop.apply_jvp(&delta)
+                        jop.apply_jvp(&delta)?
                     };
                     r = sub(b, &fwd);
                     inner_converged = true;
@@ -416,7 +438,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
                             func,
                             eps,
                         };
-                        jop.apply_jvp(&delta)
+                        jop.apply_jvp(&delta)?
                     };
                     r = sub(b, &fwd);
                 }
@@ -467,6 +489,7 @@ impl<T: RealField + Copy + FloatElement + Scalar + std::fmt::Debug> JfnkSolver<T
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cfd_core::error::Error;
     use eunomia::assert_relative_eq;
     use leto::Array2;
 
@@ -576,6 +599,29 @@ mod tests {
         let (_, conv) = solver.solve(func, x0).expect("expected value");
         assert!(conv.converged);
         assert_eq!(conv.newton_iterations, 0);
+    }
+
+    /// A fallible residual callback must preserve its typed failure at the
+    /// initial evaluation instead of converting it into a panic or a fake
+    /// residual vector.
+    #[test]
+    fn test_checked_residual_propagates_domain_error() {
+        let solver = JfnkSolver::new(JfnkConfig::<f64>::default());
+        let result = solver.solve_checked(
+            |_| {
+                Err(Error::InvalidConfiguration(
+                    "synthetic residual failure".to_string(),
+                ))
+            },
+            vec(vec![0.0]),
+        );
+
+        match result {
+            Err(Error::InvalidConfiguration(message)) => {
+                assert_eq!(message, "synthetic residual failure");
+            }
+            other => panic!("unexpected JFNK checked result: {other:?}"),
+        }
     }
 
     /// Verify EW forcing term stays in [eta_min, eta_max].

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -166,6 +166,20 @@ Apollo head `c87a1abe` does not expose it. Apollo remote head
 re-export and public module change. CFDrs remains unadvanced until that
 upstream head is merged; no compatibility shim is permitted.
 
+## Bounded Newton-Krylov recovery integration — CFDrs (2026-08-19)
+
+- `crates/cfd-1d/src/solver/core/newton_fallback.rs` is now declared in the
+  solver module graph and is called once when the existing bounded-amplitude
+  stagnation detector classifies the Picard trajectory as stalled.
+- The recovery budget derives its warm-up and Newton/Krylov limits from
+  `SolverConfig.max_iterations`, so the fallback does not create a second
+  unbounded solver attempt. `cfd-math::JfnkSolver::solve_checked` propagates
+  residual callback failures as typed errors instead of panicking.
+- Static source reachability, package formatting, and diff checks are clean.
+  Locked local Cargo verification is blocked before compilation by the shared
+  Atlas overlay/lock mismatch; provider hosted exact-head Rust and book-figure
+  gates remain open until the source branch is checked.
+
 ## Unreachable source-module closure — CFDrs (2026-08-17)
 
 - Closed at merged provider default `54dcea3c`, source head `b455a416`.


### PR DESCRIPTION
## Outcome\n- wires the retained cfd-1d JFNK fallback into NetworkSolver after bounded-amplitude stagnation\n- derives recovery work from SolverConfig.max_iterations\n- adds fallible cfd-math JFNK callback propagation and value-semantic coverage\n\n## Verification\n- cargo fmt -p cfd-math -p cfd-1d -- --check\n- git diff --check\n- locked Cargo verification is blocked before compilation by the shared Atlas overlay/lock mismatch; hosted exact-head gates remain required\n\nRefs: ATLAS-CFDRS-JFNK-OPEN-033

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR integrates a bounded Jacobian-Free Newton-Krylov (JFNK) recovery mechanism into the `cfd-1d` nonlinear network solver to handle stalled Anderson-accelerated Picard iterations. When the Picard solver detects bounded-amplitude stagnation (non-decaying oscillations), it triggers a JFNK fallback that can converge quadratically where Picard fails. The recovery budget is derived from `SolverConfig.max_iterations` to prevent unbounded retries, and the `cfd-math` JFNK solver now supports fallible residual callbacks that propagate domain and linear-solver errors as typed failures instead of panics.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-1d/src/solver/core/network_solver.rs` |
| 2 | `crates/cfd-1d/src/solver/core/newton_fallback.rs` |
| 3 | `crates/cfd-math/src/nonlinear_solver/jfnk.rs` |
| 4 | `crates/cfd-1d/src/solver/core/status.rs` |
| 5 | `crates/cfd-1d/src/solver/core/mod.rs` |
| 6 | `CHANGELOG.md` |
| 7 | `CHECKLIST.md` |
| 8 | `backlog.md` |
| 9 | `gap_audit.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded Newton–Krylov recovery for nonlinear network solver stagnation.
  - Recovery limits now adapt to the configured iteration budget.
  - Solver diagnostics indicate when recovery was attempted.
  - Added typed error propagation for residual and linear-solver failures.

- **Bug Fixes**
  - Invalid recovery configurations now return clear errors instead of triggering assertions.
  - Fallback solutions are validated before updating solver state.

- **Documentation**
  - Updated changelog, checklist, backlog, and gap-audit records.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->