### PR TITLE
feat(cfd-2d): Adopt Harmonia relaxation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "criterion",
  "eunomia",
  "gaia-mesh",
+ "harmonia",
  "iris-viz",
  "leto",
  "leto-ops",
@@ -1536,6 +1537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "harmonia"
+version = "0.1.0"
+source = "git+https://github.com/ryancinsight/harmonia#3d6682fc1b43d283d5f97fd5d16ec5ce1fcdb7cb"
+dependencies = [
+ "athena-core",
+ "eunomia",
+ "horae",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1675,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "horae"
+version = "0.1.0"
+source = "git+https://github.com/ryancinsight/horae#0df563a69693418b267f337fa4bc9dfb7c1aeb1b"
+dependencies = [
+ "aequitas",
+ "eunomia",
+]
 
 [[package]]
 name = "hyperion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,9 @@ hephaestus-wgpu = { version = "0.19.0", git = "https://github.com/ryancinsight/h
 # athena-leto = Leto CPU backend). Used by cfd-math/linear_solver/krylov.rs.
 athena-core = { version = "0.1.0", git = "https://github.com/ryancinsight/athena" }
 athena-leto = { version = "0.1.0", git = "https://github.com/ryancinsight/athena" }
+# harmonia: provider-owned transactional relaxation policies used by the
+# coupled resistance iteration in cfd-2d.
+harmonia = { version = "0.1.0", git = "https://github.com/ryancinsight/harmonia", default-features = false, features = ["std"] }
 # coeus: Atlas tensor/autodiff/NN/optimizer stack. coeus-optim's least-squares
 # (Levenberg-Marquardt) solver calibrates turbulence model constants against
 # DNS reference profiles in cfd-2d/physics/turbulence/constants_validation.

--- a/crates/cfd-2d/Cargo.toml
+++ b/crates/cfd-2d/Cargo.toml
@@ -20,6 +20,7 @@ cfd-math.workspace = true
 cfd-mesh.workspace = true
 cfd-io.workspace = true
 cfd-1d.workspace = true
+harmonia.workspace = true
 cfd-schematics = { path = "../cfd-schematics" }
 petgraph.workspace = true
 thiserror.workspace = true

--- a/crates/cfd-2d/src/network/coupled.rs
+++ b/crates/cfd-2d/src/network/coupled.rs
@@ -15,6 +15,7 @@ use cfd_schematics::geometry::metadata::{
     BranchBoundaryMetadata, BranchBoundarySpecification, JunctionFamily, JunctionGeometryMetadata,
 };
 use eunomia::{FloatElement, NumericElement};
+use harmonia::{AitkenRelaxation, Relaxation};
 use leto::{Array1, Storage, StorageMut};
 use moirai::{map_collect_mut_with, Adaptive};
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -65,99 +66,82 @@ where
     T: CfdScalar + Copy + FloatElement + eunomia::RealField,
 {
     anderson: AndersonAccelerator<T>,
-    previous_residual: Option<Array1<T>>,
-    previous_relaxation: Option<Array1<T>>,
-    relaxation_floor: T,
-    relaxation_ceiling: T,
-    residual_drop_tolerance: T,
+    relaxation: AitkenRelaxation<T>,
 }
 
 impl<T> CoupledResistanceMixer<T>
 where
     T: CfdScalar + Copy + FloatElement + eunomia::RealField + std::fmt::Debug,
 {
-    fn new(history_depth: usize) -> Self {
-        Self {
+    fn new(history_depth: usize) -> CfdResult<Self> {
+        let relaxation = AitkenRelaxation::new(
+            <T as FloatElement>::from_f64(COUPLING_AITKEN_RELAXATION_MIN),
+            <T as FloatElement>::from_f64(COUPLING_AITKEN_RELAXATION_MAX),
+            <T as FloatElement>::from_f64(COUPLING_AITKEN_DROP_TOLERANCE),
+        )
+        .map_err(|error| {
+            Error::InvalidInput(format!(
+                "Network2DSolver coupled solve rejected Aitken configuration: {error}"
+            ))
+        })?;
+
+        Ok(Self {
             anderson: AndersonAccelerator::new(AndersonConfig::<T> {
                 history_depth,
                 relaxation: scalar::one(),
                 drop_tolerance: <T as FloatElement>::from_f64(COUPLING_AITKEN_DROP_TOLERANCE),
                 method: AndersonMethod::QR,
             }),
-            previous_residual: None,
-            previous_relaxation: None,
-            relaxation_floor: <T as FloatElement>::from_f64(COUPLING_AITKEN_RELAXATION_MIN),
-            relaxation_ceiling: <T as FloatElement>::from_f64(COUPLING_AITKEN_RELAXATION_MAX),
-            residual_drop_tolerance: <T as FloatElement>::from_f64(COUPLING_AITKEN_DROP_TOLERANCE),
-        }
+            relaxation,
+        })
     }
 
-    fn mix(&mut self, current: &Array1<T>, target: &Array1<T>) -> Array1<T> {
-        if vector_len(current) != vector_len(target)
-            || !vector_is_finite(current)
-            || !vector_is_finite(target)
-        {
-            self.reset();
-            return target.clone();
+    fn mix(&mut self, current: &Array1<T>, target: &Array1<T>) -> CfdResult<Array1<T>> {
+        if vector_len(current) != vector_len(target) {
+            return Err(Error::InvalidInput(format!(
+                "Network2DSolver coupled solve resistance dimensions differ: current {}, target {}",
+                vector_len(current),
+                vector_len(target)
+            )));
         }
 
-        let aitken_candidate = self.vector_aitken_candidate(current, target);
-        if !vector_is_finite(&aitken_candidate) {
-            self.reset();
-            return target.clone();
-        }
-
+        let aitken_candidate = self.aitken_candidate(current, target)?;
         let anderson_candidate = self.anderson.compute_next(current, &aitken_candidate);
         if vector_is_finite(&anderson_candidate) {
-            anderson_candidate
+            Ok(anderson_candidate)
         } else {
-            self.anderson.reset();
-            aitken_candidate
+            Err(Error::InvalidInput(
+                "Network2DSolver coupled solve Anderson mixing produced a non-finite resistance state"
+                    .to_string(),
+            ))
         }
     }
 
-    fn reset(&mut self) {
-        self.previous_residual = None;
-        self.previous_relaxation = None;
-        self.anderson.reset();
-    }
-
-    fn vector_aitken_candidate(&mut self, current: &Array1<T>, target: &Array1<T>) -> Array1<T> {
-        let residual = vector_sub(target, current);
-        let mut relaxation = Array1::from_elem([vector_len(&residual)], scalar::one());
-
-        if let (Some(previous_residual), Some(previous_relaxation)) =
-            (&self.previous_residual, &self.previous_relaxation)
-        {
-            if vector_len(previous_residual) == vector_len(&residual)
-                && vector_len(previous_relaxation) == vector_len(&residual)
-            {
-                let residual_delta = vector_sub(&residual, previous_residual);
-                for i in 0..vector_len(&residual) {
-                    let previous_factor = previous_relaxation[[i]];
-                    let delta = residual_delta[[i]];
-                    relaxation[[i]] = if <T as NumericElement>::is_finite(delta)
-                        && <T as NumericElement>::abs(delta) > self.residual_drop_tolerance
-                        && <T as NumericElement>::is_finite(previous_factor)
-                    {
-                        let raw = -previous_factor * previous_residual[[i]] / delta;
-                        clamp_relaxation(raw, self.relaxation_floor, self.relaxation_ceiling)
-                    } else {
-                        clamp_relaxation(
-                            previous_factor,
-                            self.relaxation_floor,
-                            self.relaxation_ceiling,
-                        )
-                    };
-                }
-            } else {
-                self.reset();
-            }
+    fn aitken_candidate(
+        &mut self,
+        current: &Array1<T>,
+        target: &Array1<T>,
+    ) -> CfdResult<Array1<T>> {
+        let mut aitken_candidate = current.clone();
+        self.relaxation
+            .update_pair(
+                vector_slice_mut(&mut aitken_candidate),
+                vector_slice(target),
+                &mut [],
+                &[],
+            )
+            .map_err(|error| {
+                Error::InvalidInput(format!(
+                    "Network2DSolver coupled solve relaxation failed: {error}"
+                ))
+            })?;
+        if !vector_is_finite(&aitken_candidate) {
+            return Err(Error::InvalidInput(
+                "Network2DSolver coupled solve relaxation produced a non-finite resistance state"
+                    .to_string(),
+            ));
         }
-
-        self.previous_residual = Some(residual.clone());
-        self.previous_relaxation = Some(relaxation.clone());
-        vector_add_component_scaled(current, &residual, &relaxation)
+        Ok(aitken_candidate)
     }
 }
 
@@ -265,7 +249,7 @@ where
             max_iterations: 500,
             require_flow_convergence: true,
         });
-        let mut coupling_mixer = CoupledResistanceMixer::<T>::new(COUPLING_ANDERSON_DEPTH);
+        let mut coupling_mixer = CoupledResistanceMixer::<T>::new(COUPLING_ANDERSON_DEPTH)?;
         let channel_coupling_weights = build_channel_coupling_weights::<T>(&self.blueprint);
         let convergence_threshold_pct = <T as FloatElement>::from_f64(
             tolerance.max(COUPLING_CONVERGENCE_FLOOR_RELATIVE) * 100.0,
@@ -494,12 +478,13 @@ where
         ));
     }
 
-    let mut next_linear = coupling_mixer.mix(&current_linear, &weighted_target);
+    let mut next_linear = coupling_mixer.mix(&current_linear, &weighted_target)?;
     clamp_vector_to_floor(&mut next_linear, min_linear_resistance);
     if !vector_is_finite(&next_linear) {
-        coupling_mixer.reset();
-        next_linear = weighted_target.clone();
-        clamp_vector_to_floor(&mut next_linear, min_linear_resistance);
+        return Err(Error::InvalidInput(
+            "Network2DSolver coupled solve produced a non-finite mixed resistance state"
+                .to_string(),
+        ));
     }
 
     for ((candidate, channel_trace), next_linear_value) in update_candidates
@@ -763,39 +748,6 @@ fn vector_slice_mut<T>(vector: &mut Array1<T>) -> &mut [T] {
     vector.storage_mut().as_mut_slice()
 }
 
-fn vector_sub<T>(lhs: &Array1<T>, rhs: &Array1<T>) -> Array1<T>
-where
-    T: FloatElement + Copy,
-{
-    vector_from_vec(
-        vector_slice(lhs)
-            .iter()
-            .zip(vector_slice(rhs))
-            .map(|(&left, &right)| left - right)
-            .collect(),
-    )
-}
-
-fn vector_add_component_scaled<T>(
-    base: &Array1<T>,
-    residual: &Array1<T>,
-    relaxation: &Array1<T>,
-) -> Array1<T>
-where
-    T: FloatElement + Copy,
-{
-    vector_from_vec(
-        vector_slice(base)
-            .iter()
-            .zip(vector_slice(residual))
-            .zip(vector_slice(relaxation))
-            .map(|((&base_value, &residual_value), &relaxation_value)| {
-                base_value + residual_value * relaxation_value
-            })
-            .collect(),
-    )
-}
-
 fn vector_is_finite<T>(vector: &Array1<T>) -> bool
 where
     T: NumericElement,
@@ -803,16 +755,6 @@ where
     vector_slice(vector)
         .iter()
         .all(|&value| <T as NumericElement>::is_finite(value))
-}
-
-fn clamp_relaxation<T>(value: T, floor: T, ceiling: T) -> T
-where
-    T: FloatElement + Copy,
-{
-    if !<T as NumericElement>::is_finite(value) {
-        return floor;
-    }
-    value.min_scalar(ceiling).max_scalar(floor)
 }
 
 fn clamp_vector_to_floor<T>(vector: &mut Array1<T>, floor: T)
@@ -837,4 +779,28 @@ where
         .edge_references()
         .map(|edge_ref| (edge_ref.weight().id.clone(), edge_ref.id()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_relaxation_matches_componentwise_secant_reference() {
+        let mut mixer = CoupledResistanceMixer::<f64>::new(COUPLING_ANDERSON_DEPTH)
+            .expect("invariant: configured relaxation bounds are valid");
+        let current = vector_from_vec(vec![0.0]);
+        let first_target = vector_from_vec(vec![1.0]);
+        let first = mixer
+            .aitken_candidate(&current, &first_target)
+            .expect("first provider relaxation update is finite");
+        assert_eq!(vector_slice(&first)[0].to_bits(), 1.0_f64.to_bits());
+
+        let second_target = vector_from_vec(vec![0.5]);
+        let second = mixer
+            .aitken_candidate(&first, &second_target)
+            .expect("second provider relaxation update is finite");
+        let expected = 2.0 / 3.0;
+        assert!((vector_slice(&second)[0] - expected).abs() <= 4.0 * f64::EPSILON);
+    }
 }

--- a/crates/cfd-2d/src/solvers/cell_tracking/tracker.rs
+++ b/crates/cfd-2d/src/solvers/cell_tracking/tracker.rs
@@ -177,7 +177,7 @@ impl<'a, V: VelocityFieldInterpolator> CellTracker<'a, V> {
                 * ((-dist_bot / wall_len).exp() - (-dist_top / wall_len).exp());
 
             // --- Buoyancy (negligible for blood cells, but included for correctness) ---
-            let ay_buoy = -(rho_cell - rho_f) / rho_cell * 9.81;
+            let ay_buoy = -(rho_cell - rho_f) / rho_cell * cfd_core::physics::constants::physics::universal::GRAVITY;
 
             // --- Total acceleration ---
             let ax = ax_drag;

--- a/crates/cfd-core/src/management/aggregates/parameters.rs
+++ b/crates/cfd-core/src/management/aggregates/parameters.rs
@@ -40,7 +40,7 @@ impl<T: FloatElement + Copy + RealField> Default for PhysicalParameters<T> {
                 .expect("invariant: positive default reference pressure is valid"),
             gravity: Vector3::new(
                 <T as NumericElement>::ZERO,
-                <T as FloatElement>::from_f64(-9.81),
+                <T as FloatElement>::from_f64(-crate::physics::constants::physics::universal::GRAVITY),
                 <T as NumericElement>::ZERO,
             ),
             time_step: <T as FloatElement>::from_f64(0.001),

--- a/crates/cfd-core/src/physics/cavitation/number.rs
+++ b/crates/cfd-core/src/physics/cavitation/number.rs
@@ -47,7 +47,7 @@ impl<T: FloatElement + Copy> CavitationNumber<T> {
 
     /// Calculate incipient cavitation index (Thoma number)
     pub fn thoma_number(&self, head: Length<T>) -> Dimensionless<T> {
-        let g = <T as FloatElement>::from_f64(9.81);
+        let g = <T as FloatElement>::from_f64(crate::physics::constants::physics::universal::GRAVITY);
         Dimensionless::from_base(
             (self.reference_pressure.into_base() - self.vapor_pressure.into_base())
                 / (self.density.into_base() * g * head.into_base()),

--- a/crates/cfd-core/src/physics/fluid/blood/constants.rs
+++ b/crates/cfd-core/src/physics/fluid/blood/constants.rs
@@ -46,6 +46,10 @@ pub const BLOOD_THERMAL_CONDUCTIVITY: f64 = 0.52;
 /// Reference: Fung (1993)
 pub const BLOOD_SPEED_OF_SOUND: f64 = 1570.0;
 
+/// Speed of sound in blood — medical ultrasound approximation \[m/s]
+/// Commonly used value in therapeutic ultrasound literature (Duck 1990).
+pub const BLOOD_SPEED_OF_SOUND_APPROX: f64 = 1540.0;
+
 /// Normal hematocrit (volume fraction of RBCs)
 pub const NORMAL_HEMATOCRIT: f64 = 0.45;
 

--- a/crates/cfd-optim/src/reporting/report_metrics.rs
+++ b/crates/cfd-optim/src/reporting/report_metrics.rs
@@ -866,8 +866,8 @@ pub fn compute_sdt_acoustic_metrics(
     let p_acoustic = (pressure_drop_pa + 101_325.0).max(50_000.0);
     let e_acoustic = acoustic_energy_density(
         p_acoustic, // consistent with RP pressure reference
-        1060.0,     // blood density [kg/m³]
-        1540.0,     // speed of sound in blood [m/s]
+        cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY, // [kg/m³]
+        cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX, // [m/s]
     );
 
     // Acoustic contrast factors for differential radiation force

--- a/crates/cfd-validation/src/manufactured/richardson/core.rs
+++ b/crates/cfd-validation/src/manufactured/richardson/core.rs
@@ -498,7 +498,7 @@ mod tests {
             RichardsonExtrapolation::extrapolate(phi1, phi2, phi3, r).expect("expected value");
 
         // Scale all values by constant factor
-        let scale = 3.14159;
+        let scale = std::f64::consts::PI;
         let (extrapolated2, order2) =
             RichardsonExtrapolation::extrapolate(phi1 * scale, phi2 * scale, phi3 * scale, r)
                 .expect("expected value");


### PR DESCRIPTION
## Outcome

Move cfd-2d coupled resistance relaxation to Harmonia's provider-owned transactional Aitken seam, retain Anderson as the outer mixer, remove the consumer-owned Aitken state and recovery fallback, and preserve the reference secant contract with a focused differential regression.

Also retain the preceding named-physical-constant cleanup that is part of this branch delta.

## Verification

- `cargo check -p cfd-2d --lib --locked` passes on the exact branch head.
- `cargo tree -p cfd-2d --locked --depth 1` resolves `harmonia` at `3d6682fc`.
- `rustfmt --edition 2021 --check crates/cfd-2d/src/network/coupled.rs` passes.
- Focused nextest reaches `PASS (1/1)` for `provider_relaxation_matches_componentwise_secant_reference`; the cargo wrapper exceeded the local command window after the nextest summary and is reported as a timeout, not a full-suite pass.

Refs: Atlas provider integration slice; Harmonia provider ownership.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates the coupled resistance relaxation in the 2D CFD solver from a consumer-owned Aitken implementation to the Harmonia library's provider-owned transactional Aitken relaxation scheme, while retaining Anderson acceleration as the outer mixer. The refactor removes manual state tracking and fallback recovery logic by delegating relaxation responsibilities to Harmonia, simplifies error handling by replacing resets with explicit errors for non-finite states, and includes a regression test to validate the new relaxation behavior matches the expected secant contract. Additionally, the PR replaces hardcoded physical constants (gravity, speed of sound in blood, and pi) with named constants from the existing `cfd-core::physics::constants` module for improved maintainability.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `crates/cfd-2d/Cargo.toml` |
| 3 | `Cargo.lock` |
| 4 | `crates/cfd-core/src/physics/fluid/blood/constants.rs` |
| 5 | `crates/cfd-2d/src/network/coupled.rs` |
| 6 | `crates/cfd-2d/src/solvers/cell_tracking/tracker.rs` |
| 7 | `crates/cfd-core/src/management/aggregates/parameters.rs` |
| 8 | `crates/cfd-core/src/physics/cavitation/number.rs` |
| 9 | `crates/cfd-optim/src/reporting/report_metrics.rs` |
| 10 | `crates/cfd-validation/src/manufactured/richardson/core.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared approximation for blood’s speed of sound for medical ultrasound calculations.
  * Improved consistency by centralizing gravity and blood-property constants.

* **Bug Fixes**
  * Coupled 1D/2D simulations now report invalid relaxation states and mismatched inputs instead of silently falling back to potentially inaccurate results.
  * Standardized gravity usage across buoyancy, cavitation, and default parameter calculations.

* **Tests**
  * Added coverage validating relaxation behavior against a secant-based reference.
  * Improved numerical test consistency by using the standard mathematical value of π.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->