### PR TITLE
style(cfdrs): Restore rustfmt conformance on main

### DIFF
--- a/crates/cfd-2d/src/solvers/cell_tracking/tracker.rs
+++ b/crates/cfd-2d/src/solvers/cell_tracking/tracker.rs
@@ -177,7 +177,8 @@ impl<'a, V: VelocityFieldInterpolator> CellTracker<'a, V> {
                 * ((-dist_bot / wall_len).exp() - (-dist_top / wall_len).exp());
 
             // --- Buoyancy (negligible for blood cells, but included for correctness) ---
-            let ay_buoy = -(rho_cell - rho_f) / rho_cell * cfd_core::physics::constants::physics::universal::GRAVITY;
+            let ay_buoy = -(rho_cell - rho_f) / rho_cell
+                * cfd_core::physics::constants::physics::universal::GRAVITY;
 
             // --- Total acceleration ---
             let ax = ax_drag;

--- a/crates/cfd-core/src/management/aggregates/parameters.rs
+++ b/crates/cfd-core/src/management/aggregates/parameters.rs
@@ -40,7 +40,9 @@ impl<T: FloatElement + Copy + RealField> Default for PhysicalParameters<T> {
                 .expect("invariant: positive default reference pressure is valid"),
             gravity: Vector3::new(
                 <T as NumericElement>::ZERO,
-                <T as FloatElement>::from_f64(-crate::physics::constants::physics::universal::GRAVITY),
+                <T as FloatElement>::from_f64(
+                    -crate::physics::constants::physics::universal::GRAVITY,
+                ),
                 <T as NumericElement>::ZERO,
             ),
             time_step: <T as FloatElement>::from_f64(0.001),

--- a/crates/cfd-core/src/physics/cavitation/number.rs
+++ b/crates/cfd-core/src/physics/cavitation/number.rs
@@ -47,7 +47,8 @@ impl<T: FloatElement + Copy> CavitationNumber<T> {
 
     /// Calculate incipient cavitation index (Thoma number)
     pub fn thoma_number(&self, head: Length<T>) -> Dimensionless<T> {
-        let g = <T as FloatElement>::from_f64(crate::physics::constants::physics::universal::GRAVITY);
+        let g =
+            <T as FloatElement>::from_f64(crate::physics::constants::physics::universal::GRAVITY);
         Dimensionless::from_base(
             (self.reference_pressure.into_base() - self.vapor_pressure.into_base())
                 / (self.density.into_base() * g * head.into_base()),


### PR DESCRIPTION
## Outcome

`main` is red, and the `Rust workspace gate` runs `cargo fmt --all --check` as its **first** step — so every open pull request fails there before reaching its own code, regardless of content.

Three files on `origin/main` are unformatted. Verified locally against a pristine checkout of the default branch with no other changes:

```
crates/cfd-2d/src/solvers/cell_tracking/tracker.rs
crates/cfd-core/src/management/aggregates/parameters.rs
crates/cfd-core/src/physics/cavitation/number.rs
```

rustfmt wraps two over-long constant paths and drops one redundant blank line. No behaviour changes.

## Relationship to #361

[#361](https://github.com/ryancinsight/CFDrs/pull/361) targets the same three files. This PR exists because that one is currently blocked by a *separate* failure — it clears fmt, check, clippy, and the full 3028-test run, then fails the numerical-fidelity pass 13/14. A whitespace change cannot cause that, so it is an independent problem.

Worth recording: I ran the exact CI `NUMERICAL_FIDELITY_FILTER` set locally against unmodified `main`:

```
Summary [101.300s] 14 tests run: 14 passed, 3060 skipped
```

All 14 pass on this host (Windows, 1.97.0 MSVC, `--test-threads 1`). So that failure is either flaky or Linux-specific, not a defect on the default branch's numerics. This PR's own CI run is the check on that: if the fidelity pass is green here, fmt was the whole blocker.

Close whichever of this and #361 is redundant once one lands.

## Verification

- `cargo fmt --all -- --check` — exit 0 (fails on `main`)
- Numerical fidelity filter — 14/14 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes formatting issues on the main branch that were causing all CI builds to fail at the `cargo fmt --all --check` step. The changes wrap three over-long constant paths to comply with rustfmt's line length requirements and remove one redundant blank line across three files. No functional or behavioral changes are introduced—this is purely whitespace/formatting cleanup to restore CI health.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-2d/src/solvers/cell_tracking/tracker.rs` |
| 2 | `crates/cfd-core/src/physics/cavitation/number.rs` |
| 3 | `crates/cfd-core/src/management/aggregates/parameters.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and consistency in internal calculations.
  * Normalized line endings in configuration-related code.
  * No changes to application behavior or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->