### PR TITLE
refactor(cfd-validation): Migrate println! to tracing facade

### DIFF
--- a/crates/cfd-validation/src/benchmarking/performance.rs
+++ b/crates/cfd-validation/src/benchmarking/performance.rs
@@ -538,15 +538,15 @@ impl CfdPerformanceBenchmarks {
 
     /// Benchmark CFD algorithms with comprehensive profiling
     pub fn benchmark_cfd_algorithms(&self) -> Result<Vec<PerformanceProfile>> {
-        println!("🧪 Comprehensive CFD Algorithm Performance Profiling");
-        println!("==================================================");
+        tracing::info!("🧪 Comprehensive CFD Algorithm Performance Profiling");
+        tracing::info!("==================================================");
 
         let mut profiles = Vec::new();
         let registry = Self::create_algorithm_registry();
 
         // Benchmark SPMV operation
         if let Some(spmv_complexity) = registry.iter().find(|c| c.name == "SPMV") {
-            println!("\nBenchmarking Sparse Matrix-Vector Multiplication...");
+            tracing::info!("\nBenchmarking Sparse Matrix-Vector Multiplication...");
 
             // Create test matrix (64x64 Poisson system)
             let n = 64;
@@ -600,13 +600,14 @@ impl CfdPerformanceBenchmarks {
                 32768, // 32MB L3 cache
             )?;
 
-            println!(
+            tracing::info!(
                 "  Performance: {:.2} GFLOPS, {:.2} GB/s memory bandwidth",
-                profile.gflops, profile.memory_bandwidth
+                profile.gflops,
+                profile.memory_bandwidth
             );
-            println!("  Cache miss rate: {:.1}%", profile.cache_miss_rate * 100.0);
+            tracing::info!("  Cache miss rate: {:.1}%", profile.cache_miss_rate * 100.0);
             for rec in &profile.recommendations {
-                println!("  💡 {rec}");
+                tracing::info!("  💡 {rec}");
             }
 
             profiles.push(profile);
@@ -614,7 +615,7 @@ impl CfdPerformanceBenchmarks {
 
         // Benchmark manufactured solutions evaluation
         if let Some(ms_complexity) = registry.iter().find(|c| c.name == "ManufacturedSolutions") {
-            println!("\nBenchmarking Manufactured Solutions Evaluation...");
+            tracing::info!("\nBenchmarking Manufactured Solutions Evaluation...");
 
             use crate::manufactured::PolynomialNavierStokesMMS;
             let mms = PolynomialNavierStokesMMS::default(1.0, 1.0);
@@ -643,17 +644,18 @@ impl CfdPerformanceBenchmarks {
                 32768,
             )?;
 
-            println!(
+            tracing::info!(
                 "  Performance: {:.2} GFLOPS, {:.2} GB/s memory bandwidth",
-                profile.gflops, profile.memory_bandwidth
+                profile.gflops,
+                profile.memory_bandwidth
             );
-            println!("  Cache miss rate: {:.1}%", profile.cache_miss_rate * 100.0);
+            tracing::info!("  Cache miss rate: {:.1}%", profile.cache_miss_rate * 100.0);
 
             profiles.push(profile);
         }
 
-        println!("\n✅ Algorithm performance profiling completed!");
-        println!(
+        tracing::info!("\n✅ Algorithm performance profiling completed!");
+        tracing::info!(
             "   Analyzed {} algorithms with complexity and performance metrics",
             profiles.len()
         );
@@ -710,7 +712,7 @@ impl CfdPerformanceBenchmarks {
 
     /// Run comprehensive CFD benchmark suite
     pub fn run_cfd_suite(&self) -> Result<Vec<TimingResult>> {
-        println!("Running CFD Performance Benchmark Suite...");
+        tracing::info!("Running CFD Performance Benchmark Suite...");
 
         let benchmarks: Vec<BenchmarkOperation<'static>> = vec![
             (

--- a/crates/cfd-validation/src/benchmarking/production.rs
+++ b/crates/cfd-validation/src/benchmarking/production.rs
@@ -25,14 +25,14 @@ impl PerformanceProfiler {
 
     /// Run comprehensive CFD algorithm performance profiling
     pub fn run_comprehensive_profiling(&self) -> Result<PerformanceReport> {
-        println!("🔬 Comprehensive CFD Algorithm Performance Profiling");
-        println!("==================================================");
-        println!("Literature References:");
-        println!("- Saad (2003): Iterative Methods for Sparse Linear Systems");
-        println!("- Williams et al. (2009): SPMV on emerging multicore platforms");
-        println!("- Salari & Knupp (2000): Code verification by MMS");
-        println!("- LeVeque (2002): Finite Volume Methods for Hyperbolic Problems");
-        println!();
+        tracing::info!("🔬 Comprehensive CFD Algorithm Performance Profiling");
+        tracing::info!("==================================================");
+        tracing::info!("Literature References:");
+        tracing::info!("- Saad (2003): Iterative Methods for Sparse Linear Systems");
+        tracing::info!("- Williams et al. (2009): SPMV on emerging multicore platforms");
+        tracing::info!("- Salari & Knupp (2000): Code verification by MMS");
+        tracing::info!("- LeVeque (2002): Finite Volume Methods for Hyperbolic Problems");
+        tracing::info!("");
 
         // Run CFD algorithm benchmarks
         let profiles = self.benchmarks.benchmark_cfd_algorithms()?;
@@ -177,59 +177,59 @@ impl PerformanceProfiler {
 
     /// Display comprehensive performance report
     fn display_report(report: &PerformanceReport) {
-        println!("\n📊 Performance Profiling Summary");
-        println!("===============================");
-        println!(
+        tracing::info!("\n📊 Performance Profiling Summary");
+        tracing::info!("===============================");
+        tracing::info!(
             "Timestamp: {}",
             report.timestamp.format("%Y-%m-%d %H:%M:%S UTC")
         );
-        println!(
+        tracing::info!(
             "Total Algorithms Profiled: {}",
             report.summary.total_profiles
         );
-        println!(
+        tracing::info!(
             "Total Performance: {:.2} GFLOPS",
             report.summary.total_gflops
         );
-        println!(
+        tracing::info!(
             "Average Memory Bandwidth: {:.2} GB/s",
             report.summary.avg_memory_bandwidth
         );
-        println!(
+        tracing::info!(
             "Average Cache Efficiency: {:.1}%",
             report.summary.avg_cache_efficiency * 100.0
         );
-        println!(
+        tracing::info!(
             "Average Parallel Scalability: {:.1}%",
             report.summary.avg_scalability * 100.0
         );
-        println!(
+        tracing::info!(
             "Best Performing Algorithm: {}",
             report.summary.best_algorithm
         );
-        println!(
+        tracing::info!(
             "Algorithm Needing Optimization: {}",
             report.summary.worst_algorithm
         );
 
         if !report.recommendations.is_empty() {
-            println!("\n💡 Performance Recommendations");
-            println!("=============================");
+            tracing::info!("\n💡 Performance Recommendations");
+            tracing::info!("=============================");
             for (i, rec) in report.recommendations.iter().enumerate() {
-                println!(
+                tracing::info!(
                     "{}. [{}] {}: {}",
                     i + 1,
                     rec.severity,
                     rec.category,
                     rec.description
                 );
-                println!("   Solution: {}", rec.solution);
-                println!("   Reference: {}", rec.literature);
-                println!();
+                tracing::info!("   Solution: {}", rec.solution);
+                tracing::info!("   Reference: {}", rec.literature);
+                tracing::info!("");
             }
         }
 
-        println!("✅ Performance profiling completed successfully!");
+        tracing::info!("✅ Performance profiling completed successfully!");
     }
 }
 

--- a/crates/cfd-validation/src/benchmarking/scaling.rs
+++ b/crates/cfd-validation/src/benchmarking/scaling.rs
@@ -449,7 +449,7 @@ impl CfdScalingAnalysis {
             timing_data.push((num_threads, exec_time));
 
             // Store timing metadata for analysis
-            println!(
+            tracing::info!(
                 "Thread count: {}, Time: {:.4}s, Iterations: {}",
                 num_threads,
                 exec_time,
@@ -507,7 +507,7 @@ impl CfdScalingAnalysis {
 
             scaling_data.push((num_threads, problem_size, exec_time));
 
-            println!(
+            tracing::info!(
                 "Threads: {num_threads}, Grid: {resolution}x{resolution}, Cells: {problem_size}, Time: {exec_time:.4}s, Comm overhead: {comm_overhead:.4}s"
             );
         }
@@ -517,20 +517,20 @@ impl CfdScalingAnalysis {
 
     /// Run comprehensive CFD scaling analysis
     pub fn run_scaling_suite(&self) -> Result<Vec<(String, ScalingResult)>> {
-        println!("Running CFD Scaling Analysis Suite...");
+        tracing::info!("Running CFD Scaling Analysis Suite...");
 
         let mut results = Vec::new();
 
         // Solver scaling
         match self.analyze_cfd_solver_scaling() {
             Ok(result) => results.push(("CFD_Solver_Scaling".to_string(), result)),
-            Err(e) => println!("Warning: CFD solver scaling analysis failed: {e}"),
+            Err(e) => tracing::warn!("Warning: CFD solver scaling analysis failed: {e}"),
         }
 
         // Grid scaling
         match self.analyze_grid_scaling() {
             Ok(result) => results.push(("CFD_Grid_Scaling".to_string(), result)),
-            Err(e) => println!("Warning: CFD grid scaling analysis failed: {e}"),
+            Err(e) => tracing::warn!("Warning: CFD grid scaling analysis failed: {e}"),
         }
 
         Ok(results)

--- a/crates/cfd-validation/src/benchmarking/visualization.rs
+++ b/crates/cfd-validation/src/benchmarking/visualization.rs
@@ -1232,8 +1232,8 @@ impl PerformanceDashboard {
 
         std::fs::write(output_path, html_content)?;
 
-        println!("Performance dashboard generated: {output_path}");
-        println!("Open in browser to view interactive charts and detailed analysis");
+        tracing::info!("Performance dashboard generated: {output_path}");
+        tracing::info!("Open in browser to view interactive charts and detailed analysis");
 
         Ok(())
     }

--- a/crates/cfd-validation/src/benchmarks/threed/bifurcation.rs
+++ b/crates/cfd-validation/src/benchmarks/threed/bifurcation.rs
@@ -122,18 +122,18 @@ impl<T: CfdScalar + cfd_mesh::domain::core::Scalar> Benchmark<T> for Bifurcation
             .metrics
             .insert("dp Parent (Pa)".to_string(), solution.dp_parent);
 
-        println!("Bifurcation 3D Validation:");
-        println!("  Murray deviation:        {murray_deviation:?}");
-        println!(
+        tracing::info!("Bifurcation 3D Validation:");
+        tracing::info!("  Murray deviation:        {murray_deviation:?}");
+        tracing::info!(
             "  Mass conservation error: {:?}",
             solution.mass_conservation_error
         );
-        println!("  Q_parent:                {:?}", solution.q_parent);
-        println!(
+        tracing::info!("  Q_parent:                {:?}", solution.q_parent);
+        tracing::info!(
             "  Q_d1 + Q_d2:             {:?}",
             solution.q_daughter1 + solution.q_daughter2
         );
-        println!(
+        tracing::info!(
             "  Wall shear (parent, Pa): {:?}",
             solution.wall_shear_stress_parent
         );

--- a/crates/cfd-validation/src/benchmarks/threed/venturi.rs
+++ b/crates/cfd-validation/src/benchmarks/threed/venturi.rs
@@ -87,11 +87,11 @@ impl<T: CfdScalar + cfd_mesh::domain::core::Scalar> Benchmark<T> for VenturiFlow
             .metrics
             .insert("u_inlet".to_string(), solution.u_inlet);
 
-        println!("Venturi 3D Validation:");
-        println!("  u_inlet (FEM): {:?}", solution.u_inlet);
-        println!("  u_throat (FEM): {:?}", solution.u_throat);
-        println!("  Cp_throat (FEM): {:?}", solution.cp_throat);
-        println!("  Mass error: {:?}", solution.mass_error);
+        tracing::info!("Venturi 3D Validation:");
+        tracing::info!("  u_inlet (FEM): {:?}", solution.u_inlet);
+        tracing::info!("  u_throat (FEM): {:?}", solution.u_throat);
+        tracing::info!("  Cp_throat (FEM): {:?}", solution.cp_throat);
+        tracing::info!("  Mass error: {:?}", solution.mass_error);
 
         Ok(result)
     }

--- a/crates/cfd-validation/src/conservation/geometric.rs
+++ b/crates/cfd-validation/src/conservation/geometric.rs
@@ -317,11 +317,11 @@ impl<T: RealField + Copy + FloatElement> GeometricConservationChecker<T> {
 
     /// Comprehensive GCL test suite.
     pub fn run_comprehensive_gcl_tests(&self) -> Result<Vec<ConservationReport<T>>> {
-        println!("Testing Geometric Conservation Law (GCL)");
-        println!("========================================");
-        println!("GCL ensures schemes preserve constants on moving grids");
-        println!("Reference: Thomas & Lombard (1979)");
-        println!();
+        tracing::info!("Testing Geometric Conservation Law (GCL)");
+        tracing::info!("========================================");
+        tracing::info!("GCL ensures schemes preserve constants on moving grids");
+        tracing::info!("Reference: Thomas & Lombard (1979)");
+        tracing::info!("");
 
         let mut results = Vec::new();
         let test_values = vec![
@@ -340,18 +340,18 @@ impl<T: RealField + Copy + FloatElement> GeometricConservationChecker<T> {
         let passed_tests = results.iter().filter(|r| r.is_conserved).count();
         let total_tests = results.len();
 
-        println!("\nGCL Test Summary:");
-        println!("  Tests Passed: {passed_tests}/{total_tests}");
-        println!(
+        tracing::info!("\nGCL Test Summary:");
+        tracing::info!("  Tests Passed: {passed_tests}/{total_tests}");
+        tracing::info!(
             "  Success Rate: {:.1}%",
             100.0 * passed_tests as f32 / total_tests as f32
         );
 
         if passed_tests == total_tests {
-            println!("All GCL tests passed; schemes preserve constants correctly.");
+            tracing::info!("All GCL tests passed; schemes preserve constants correctly.");
         } else {
-            println!("Some GCL tests failed; schemes may not preserve constants.");
-            println!("This can cause accuracy issues in long-time simulations.");
+            tracing::info!("Some GCL tests failed; schemes may not preserve constants.");
+            tracing::info!("This can cause accuracy issues in long-time simulations.");
         }
 
         Ok(results)

--- a/crates/cfd-validation/src/conservation/mod.rs
+++ b/crates/cfd-validation/src/conservation/mod.rs
@@ -36,16 +36,16 @@ pub use vorticity::VorticityChecker;
 /// Run comprehensive conservation verification suite
 /// Implements MINOR-011: Complete Conservation Property Verification
 pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatElement>() {
-    println!("🧪 Comprehensive Conservation Property Verification Suite");
-    println!("======================================================");
-    println!(
+    tracing::info!("🧪 Comprehensive Conservation Property Verification Suite");
+    tracing::info!("======================================================");
+    tracing::info!(
         "MINOR-011: Verifying conservation of mass, momentum, energy, angular momentum, vorticity"
     );
-    println!("References: LeVeque (2002), Thomas & Lombard (1979), Batchelor (1967)");
-    println!();
+    tracing::info!("References: LeVeque (2002), Thomas & Lombard (1979), Batchelor (1967)");
+    tracing::info!("");
 
     // Mass conservation test
-    println!("Test 1: Mass Conservation (Incompressible Navier-Stokes)");
+    tracing::info!("Test 1: Mass Conservation (Incompressible Navier-Stokes)");
     let mass_checker =
         MassConservationChecker::<T>::new(<T as FloatElement>::from_f64(1e-6), 32, 32);
     let velocity_u = Array2::from_elem([32, 32], <T as FloatElement>::from_f64(1.0));
@@ -58,18 +58,18 @@ pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatEl
         <T as FloatElement>::from_f64(0.1),
     ) {
         Ok(report) => {
-            println!(
+            tracing::info!(
                 "  ✅ {}: Error = {:.2e}, Conserved: {}",
                 report.check_name,
                 <T as NumericElement>::to_f64(report.error),
                 report.is_conserved
             );
         }
-        Err(e) => println!("  ❌ Mass conservation test failed: {e}"),
+        Err(e) => tracing::info!("  ❌ Mass conservation test failed: {e}"),
     }
 
     // Momentum conservation test
-    println!("\nTest 2: Momentum Conservation (Steady State)");
+    tracing::info!("\nTest 2: Momentum Conservation (Steady State)");
     let momentum_checker = MomentumConservationChecker::<T>::new(
         <T as FloatElement>::from_f64(1e-6),
         32,
@@ -93,18 +93,18 @@ pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatEl
         Vector2::zeros(),                   // No gravity
     ) {
         Ok(report) => {
-            println!(
+            tracing::info!(
                 "  ✅ {}: Error = {:.2e}, Conserved: {}",
                 report.check_name,
                 <T as NumericElement>::to_f64(report.error),
                 report.is_conserved
             );
         }
-        Err(e) => println!("  ❌ Momentum conservation test failed: {e}"),
+        Err(e) => tracing::info!("  ❌ Momentum conservation test failed: {e}"),
     }
 
     // Energy conservation test (if temperature field available)
-    println!("\nTest 3: Energy Conservation (Thermal)");
+    tracing::info!("\nTest 3: Energy Conservation (Thermal)");
     let energy_checker = EnergyConservationChecker::<T>::new(
         <T as FloatElement>::from_f64(1e-6),
         32,
@@ -126,18 +126,18 @@ pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatEl
         None,                               // No source term
     ) {
         Ok(report) => {
-            println!(
+            tracing::info!(
                 "  ✅ {}: Error = {:.2e}, Conserved: {}",
                 report.check_name,
                 <T as NumericElement>::to_f64(report.error),
                 report.is_conserved
             );
         }
-        Err(e) => println!("  ❌ Energy conservation test failed: {e}"),
+        Err(e) => tracing::info!("  ❌ Energy conservation test failed: {e}"),
     }
 
     // Angular momentum conservation test
-    println!("\nTest 4: Angular Momentum Conservation (2D Cartesian)");
+    tracing::info!("\nTest 4: Angular Momentum Conservation (2D Cartesian)");
     let am_checker =
         AngularMomentumChecker::<T>::new_centered(<T as FloatElement>::from_f64(1e-6), 32, 32);
 
@@ -148,18 +148,18 @@ pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatEl
         <T as FloatElement>::from_f64(0.1),
     ) {
         Ok(report) => {
-            println!(
+            tracing::info!(
                 "  ✅ {}: Error = {:.2e}, Conserved: {}",
                 report.check_name,
                 <T as NumericElement>::to_f64(report.error),
                 report.is_conserved
             );
         }
-        Err(e) => println!("  ❌ Angular momentum conservation test failed: {e}"),
+        Err(e) => tracing::info!("  ❌ Angular momentum conservation test failed: {e}"),
     }
 
     // Vorticity conservation test
-    println!("\nTest 5: Vorticity Transport Conservation");
+    tracing::info!("\nTest 5: Vorticity Transport Conservation");
     let vorticity_checker = VorticityChecker::<T>::new(<T as FloatElement>::from_f64(1e-6), 32, 32);
 
     match vorticity_checker.check_vorticity_transport_2d(
@@ -170,42 +170,42 @@ pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatEl
         <T as FloatElement>::from_f64(0.1),
     ) {
         Ok(report) => {
-            println!(
+            tracing::info!(
                 "  ✅ {}: Error = {:.2e}, Conserved: {}",
                 report.check_name,
                 <T as NumericElement>::to_f64(report.error),
                 report.is_conserved
             );
         }
-        Err(e) => println!("  ❌ Vorticity conservation test failed: {e}"),
+        Err(e) => tracing::info!("  ❌ Vorticity conservation test failed: {e}"),
     }
 
     // Geometric conservation law test
-    println!("\nTest 6: Geometric Conservation Law");
+    tracing::info!("\nTest 6: Geometric Conservation Law");
     let gcl_checker =
         GeometricConservationChecker::<T>::new(<T as FloatElement>::from_f64(1e-14), 32, 32);
 
     match gcl_checker.run_comprehensive_gcl_tests() {
         Ok(results) => {
             let passed = results.iter().filter(|r| r.is_conserved).count();
-            println!("  GCL Tests: {}/{} passed", passed, results.len());
+            tracing::info!("  GCL Tests: {}/{} passed", passed, results.len());
             if passed > 0 {
-                println!(
+                tracing::info!(
                     "  ✅ Sample GCL result: {} (Error = {:.2e})",
                     results[0].check_name,
                     <T as NumericElement>::to_f64(results[0].error)
                 );
             }
         }
-        Err(e) => println!("  ❌ GCL test failed: {e}"),
+        Err(e) => tracing::info!("  ❌ GCL test failed: {e}"),
     }
 
-    println!("\n✅ Complete conservation property verification completed!");
-    println!("   All fundamental conservation laws have been tested:");
-    println!("   - Mass conservation (continuity equation)");
-    println!("   - Momentum conservation (Navier-Stokes)");
-    println!("   - Energy conservation (thermal transport)");
-    println!("   - Angular momentum conservation (rotation)");
-    println!("   - Vorticity conservation (flow rotation)");
-    println!("   - Geometric conservation law (numerical consistency)");
+    tracing::info!("\n✅ Complete conservation property verification completed!");
+    tracing::info!("   All fundamental conservation laws have been tested:");
+    tracing::info!("   - Mass conservation (continuity equation)");
+    tracing::info!("   - Momentum conservation (Navier-Stokes)");
+    tracing::info!("   - Energy conservation (thermal transport)");
+    tracing::info!("   - Angular momentum conservation (rotation)");
+    tracing::info!("   - Vorticity conservation (flow rotation)");
+    tracing::info!("   - Geometric conservation law (numerical consistency)");
 }

--- a/crates/cfd-validation/src/edge_case_testing/mod.rs
+++ b/crates/cfd-validation/src/edge_case_testing/mod.rs
@@ -114,10 +114,10 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
 
     /// Run comprehensive edge case validation suite
     pub fn run_comprehensive_edge_case_tests(&self) -> Result<EdgeCaseReport> {
-        println!("🔍 Comprehensive CFD Edge Case Validation Suite");
-        println!("==============================================");
-        println!("Testing boundary conditions, numerical stability, and algorithm limits");
-        println!();
+        tracing::info!("🔍 Comprehensive CFD Edge Case Validation Suite");
+        tracing::info!("==============================================");
+        tracing::info!("Testing boundary conditions, numerical stability, and algorithm limits");
+        tracing::info!("");
 
         let mut report = EdgeCaseReport {
             boundary_condition_tests: Vec::new(),
@@ -141,7 +141,7 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
 
     /// Test boundary condition edge cases
     fn test_boundary_condition_edge_cases(report: &mut EdgeCaseReport) -> Result<()> {
-        println!("\n🔲 Boundary Condition Edge Case Tests");
+        tracing::info!("\n🔲 Boundary Condition Edge Case Tests");
 
         report
             .boundary_condition_tests
@@ -159,13 +159,13 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
             .boundary_condition_tests
             .push(Self::test_time_dependent_boundary_conditions()?);
 
-        println!("  ✅ Completed 5 boundary condition edge case tests");
+        tracing::info!("  ✅ Completed 5 boundary condition edge case tests");
         Ok(())
     }
 
     /// Test numerical stability limits
     fn test_numerical_stability_limits(report: &mut EdgeCaseReport) -> Result<()> {
-        println!("\n🧮 Numerical Stability Edge Case Tests");
+        tracing::info!("\n🧮 Numerical Stability Edge Case Tests");
 
         report
             .stability_tests
@@ -183,13 +183,13 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
             .stability_tests
             .push(Self::test_long_time_integration_stability()?);
 
-        println!("  ✅ Completed 5 numerical stability edge case tests");
+        tracing::info!("  ✅ Completed 5 numerical stability edge case tests");
         Ok(())
     }
 
     /// Test convergence algorithm failures
     fn test_convergence_algorithm_failures(report: &mut EdgeCaseReport) -> Result<()> {
-        println!("\n🔄 Convergence Algorithm Edge Case Tests");
+        tracing::info!("\n🔄 Convergence Algorithm Edge Case Tests");
 
         report
             .convergence_tests
@@ -204,13 +204,13 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
             .convergence_tests
             .push(Self::test_restarted_method_failures()?);
 
-        println!("  ✅ Completed 4 convergence algorithm edge case tests");
+        tracing::info!("  ✅ Completed 4 convergence algorithm edge case tests");
         Ok(())
     }
 
     /// Test physical constraint violations
     fn test_physical_constraint_violations(report: &mut EdgeCaseReport) -> Result<()> {
-        println!("\n⚛️ Physical Constraint Edge Case Tests");
+        tracing::info!("\n⚛️ Physical Constraint Edge Case Tests");
 
         report
             .physical_constraint_tests
@@ -225,13 +225,13 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
             .physical_constraint_tests
             .push(Self::test_boundary_layer_separation()?);
 
-        println!("  ✅ Completed 4 physical constraint edge case tests");
+        tracing::info!("  ✅ Completed 4 physical constraint edge case tests");
         Ok(())
     }
 
     /// Test implementation edge cases
     fn test_implementation_edge_cases(report: &mut EdgeCaseReport) -> Result<()> {
-        println!("\n💻 Implementation Edge Case Tests");
+        tracing::info!("\n💻 Implementation Edge Case Tests");
 
         report
             .implementation_tests
@@ -246,7 +246,7 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
             .implementation_tests
             .push(Self::test_input_validation_boundaries()?);
 
-        println!("  ✅ Completed 4 implementation edge case tests");
+        tracing::info!("  ✅ Completed 4 implementation edge case tests");
         Ok(())
     }
 
@@ -313,9 +313,9 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
 
     /// Display comprehensive edge case report
     fn display_edge_case_report(report: &EdgeCaseReport) {
-        println!("\n📋 Comprehensive Edge Case Test Report");
-        println!("=====================================");
-        println!(
+        tracing::info!("\n📋 Comprehensive Edge Case Test Report");
+        tracing::info!("=====================================");
+        tracing::info!(
             "Overall Assessment: {} ({:.1}%)",
             match report.overall_assessment.overall_status {
                 OverallStatus::Excellent => "Excellent",
@@ -325,17 +325,18 @@ impl<T: RealField + Copy> EdgeCaseTestSuite<T> {
             },
             report.overall_assessment.pass_rate * 100.0
         );
-        println!(
+        tracing::info!(
             "Total Tests: {}/{}",
-            report.overall_assessment.passed_tests, report.overall_assessment.total_tests
+            report.overall_assessment.passed_tests,
+            report.overall_assessment.total_tests
         );
-        println!(
+        tracing::info!(
             "Critical Failures: {}",
             report.overall_assessment.critical_failures
         );
 
-        println!("\n✅ Edge case validation completed successfully!");
-        println!("   Comprehensive testing ensures CFD code robustness and reliability.");
+        tracing::info!("\n✅ Edge case validation completed successfully!");
+        tracing::info!("   Comprehensive testing ensures CFD code robustness and reliability.");
     }
 }
 

--- a/crates/cfd-validation/src/lib.rs
+++ b/crates/cfd-validation/src/lib.rs
@@ -128,7 +128,7 @@ pub mod time_integration;
 /// use cfd_validation::run_performance_profiling;
 ///
 /// let report = run_performance_profiling().expect("Performance profiling failed");
-/// println!("Total performance: {:.2} GFLOPS", report.summary.total_gflops);
+/// tracing::info!("Total performance: {:.2} GFLOPS", report.summary.total_gflops);
 /// ```
 pub fn run_performance_profiling(
 ) -> cfd_core::error::Result<benchmarking::production::PerformanceReport> {
@@ -154,7 +154,7 @@ pub fn run_performance_profiling(
 /// use cfd_validation::run_stability_analysis;
 ///
 /// let report = run_stability_analysis().expect("Stability analysis failed");
-/// println!("Overall stability score: {:.1}%", report.overall_assessment.overall_score * 100.0);
+/// tracing::info!("Overall stability score: {:.1}%", report.overall_assessment.overall_score * 100.0);
 /// ```
 pub fn run_stability_analysis(
 ) -> cfd_core::error::Result<time_integration::stability_analysis::StabilityAnalysisReport<f64>> {
@@ -179,8 +179,8 @@ pub fn run_stability_analysis(
 ///
 /// let registry = get_algorithm_complexity_registry();
 /// if let Some(cg_info) = registry.get("ConjugateGradient") {
-///     println!("CG Time Complexity: {}", cg_info.time_complexity);
-///     println!("Cache Efficiency: {:.1}%", cg_info.cache_efficiency * 100.0);
+///     tracing::info!("CG Time Complexity: {}", cg_info.time_complexity);
+///     tracing::info!("Cache Efficiency: {:.1}%", cg_info.cache_efficiency * 100.0);
 /// }
 /// ```
 pub fn get_algorithm_complexity_registry() -> algorithm_complexity::AlgorithmComplexityRegistry {
@@ -201,9 +201,9 @@ pub fn get_algorithm_complexity_registry() -> algorithm_complexity::AlgorithmCom
 /// use cfd_validation::run_edge_case_testing;
 ///
 /// let report = run_edge_case_testing().expect("Edge case testing failed");
-/// println!("Overall pass rate: {:.1}%", report.overall_assessment.pass_rate * 100.0);
+/// tracing::info!("Overall pass rate: {:.1}%", report.overall_assessment.pass_rate * 100.0);
 /// if report.overall_assessment.critical_failures > 0 {
-///     println!("Warning: {} critical failures detected!", report.overall_assessment.critical_failures);
+///     tracing::warn!("Warning: {} critical failures detected!", report.overall_assessment.critical_failures);
 /// }
 /// ```
 pub fn run_edge_case_testing() -> cfd_core::error::Result<edge_case_testing::EdgeCaseReport> {

--- a/crates/cfd-validation/src/manufactured/richardson/analysis.rs
+++ b/crates/cfd-validation/src/manufactured/richardson/analysis.rs
@@ -212,7 +212,7 @@ impl<T: RealField + Copy + FloatElement> ComprehensiveCFDValidationSuite<T> {
 
     /// Run MMS validation
     fn run_mms_validation(&mut self) -> Result<(), String> {
-        println!("Running comprehensive MMS validation suite...");
+        tracing::info!("Running comprehensive MMS validation suite...");
 
         // Add sample stability region data for testing
         let sample_region = StabilityRegion {
@@ -255,13 +255,13 @@ impl<T: RealField + Copy + FloatElement> ComprehensiveCFDValidationSuite<T> {
             .edge_case_results
             .push(sample_edge_case);
 
-        println!("MMS validation completed successfully");
+        tracing::info!("MMS validation completed successfully");
         Ok(())
     }
 
     /// Run boundary condition validation
     fn run_boundary_validation(&mut self) -> Result<(), String> {
-        println!("Running boundary condition validation...");
+        tracing::info!("Running boundary condition validation...");
 
         // Add sample boundary validation results
         let sample_boundary_result = BoundaryValidationResult {
@@ -274,39 +274,39 @@ impl<T: RealField + Copy + FloatElement> ComprehensiveCFDValidationSuite<T> {
         self.boundary_validation_results
             .push(sample_boundary_result);
 
-        println!("Boundary condition validation completed successfully");
+        tracing::info!("Boundary condition validation completed successfully");
         Ok(())
     }
 
     /// Run performance profiling
     fn run_performance_profiling(&mut self) -> Result<(), String> {
-        println!("Running performance profiling...");
+        tracing::info!("Running performance profiling...");
         self.update_performance_profile();
-        println!("Performance profiling completed");
+        tracing::info!("Performance profiling completed");
         Ok(())
     }
 
     /// Run numerical stability analysis
     fn run_numerical_stability_analysis(&mut self) -> Result<(), String> {
-        println!("Running numerical stability analysis...");
+        tracing::info!("Running numerical stability analysis...");
         self.update_numerical_stability_analysis();
-        println!("Numerical stability analysis completed");
+        tracing::info!("Numerical stability analysis completed");
         Ok(())
     }
 
     /// Run conservation analysis
     fn run_conservation_analysis(&mut self) -> Result<(), String> {
-        println!("Running conservation property analysis...");
+        tracing::info!("Running conservation property analysis...");
         self.update_conservation_analysis();
-        println!("Conservation analysis completed");
+        tracing::info!("Conservation analysis completed");
         Ok(())
     }
 
     /// Run edge case testing
     fn run_edge_case_testing(&mut self) -> Result<(), String> {
-        println!("Running edge case testing...");
+        tracing::info!("Running edge case testing...");
         self.update_edge_case_testing();
-        println!("Edge case testing completed");
+        tracing::info!("Edge case testing completed");
         Ok(())
     }
 

--- a/crates/cfd-validation/src/manufactured/richardson/validation.rs
+++ b/crates/cfd-validation/src/manufactured/richardson/validation.rs
@@ -84,7 +84,7 @@ where
         // Compute L2 errors for each grid size
         for &h in grid_sizes {
             let error = self.compute_l2_error(h)?;
-            println!(
+            tracing::info!(
                 "      h={:.4}, L2 error={:e}",
                 <T as NumericElement>::to_f64(h),
                 <T as NumericElement>::to_f64(error)
@@ -207,7 +207,7 @@ where
             } else {
                 // Fallback: use simple average when r^p ≈ 1 (unreliable convergence)
                 // This indicates numerical instability or poor grid refinement
-                println!("Warning: Richardson extrapolation numerically unstable (r^p ≈ 1). Using fallback averaging.");
+                tracing::warn!("Warning: Richardson extrapolation numerically unstable (r^p ≈ 1). Using fallback averaging.");
                 (phi_coarse + phi_fine) / <T as FloatElement>::from_f64(2.0)
             };
 

--- a/crates/cfd-validation/src/numerical/linear_solver.rs
+++ b/crates/cfd-validation/src/numerical/linear_solver.rs
@@ -26,25 +26,25 @@ impl LinearSolverValidator {
         // Test 1: Standard diagonal system
         match Self::test_diagonal_system::<T>() {
             Ok(test_results) => results.extend(test_results),
-            Err(e) => println!("Diagonal system test failed: {e}"),
+            Err(e) => tracing::info!("Diagonal system test failed: {e}"),
         }
 
         // Test 2: Tridiagonal system (1D Poisson)
         match Self::test_tridiagonal_system::<T>() {
             Ok(test_results) => results.extend(test_results),
-            Err(e) => println!("Tridiagonal system test failed: {e}"),
+            Err(e) => tracing::info!("Tridiagonal system test failed: {e}"),
         }
 
         // Test 3: 2D Poisson equation
         match Self::test_2d_poisson::<T>() {
             Ok(test_results) => results.extend(test_results),
-            Err(e) => println!("2D Poisson test failed: {e}"),
+            Err(e) => tracing::info!("2D Poisson test failed: {e}"),
         }
 
         // Test 4: Ill-conditioned system (expected to have some failures)
         match Self::test_ill_conditioned_system::<T>() {
             Ok(test_results) => results.extend(test_results),
-            Err(e) => println!("Ill-conditioned system test failed (expected): {e}"),
+            Err(e) => tracing::info!("Ill-conditioned system test failed (expected): {e}"),
         }
 
         Ok(results)
@@ -89,7 +89,7 @@ impl LinearSolverValidator {
                     results.push(result);
                 }
                 None => {
-                    println!("Solver {name} did not converge on diagonal system");
+                    tracing::info!("Solver {name} did not converge on diagonal system");
                 }
             }
         }
@@ -227,7 +227,7 @@ impl LinearSolverValidator {
                 }
                 None => {
                     // For ill-conditioned systems, solver failure is expected and should be reported honestly
-                    eprintln!("Solver {name} did not converge on ill-conditioned system");
+                    tracing::warn!("Solver {name} did not converge on ill-conditioned system");
                     // Do not create misleading results with zero solutions
                     // Skip this test case for solvers that cannot handle ill-conditioned systems
                 }

--- a/crates/cfd-validation/src/time_integration/stability_analysis.rs
+++ b/crates/cfd-validation/src/time_integration/stability_analysis.rs
@@ -124,13 +124,13 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
 
     /// Run comprehensive stability analysis suite
     pub fn run_comprehensive_stability_analysis(&self) -> Result<StabilityAnalysisReport<T>> {
-        println!("🔬 Comprehensive Stability Analysis Suite");
-        println!("=========================================");
-        println!("Literature References:");
-        println!("- Hairer & Nørsett (1993): Solving ODEs I");
-        println!("- Trefthen (1996): Finite Difference Methods");
-        println!("- LeVeque (2002): Finite Volume Methods");
-        println!();
+        tracing::info!("🔬 Comprehensive Stability Analysis Suite");
+        tracing::info!("=========================================");
+        tracing::info!("Literature References:");
+        tracing::info!("- Hairer & Nørsett (1993): Solving ODEs I");
+        tracing::info!("- Trefthen (1996): Finite Difference Methods");
+        tracing::info!("- LeVeque (2002): Finite Volume Methods");
+        tracing::info!("");
 
         let mut report = StabilityAnalysisReport {
             rk_stability_regions: Vec::new(),
@@ -165,7 +165,7 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
 
     /// Analyze stability regions for common RK methods
     fn analyze_rk_stability_regions(&self, report: &mut StabilityAnalysisReport<T>) -> Result<()> {
-        println!("\n📐 Runge-Kutta Stability Region Analysis");
+        tracing::info!("\n📐 Runge-Kutta Stability Region Analysis");
 
         // Forward Euler (RK1)
         let rk1_result = self.analyze_forward_euler_stability()?;
@@ -179,7 +179,7 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
         let rk4_result = self.analyze_rk4_stability()?;
         report.rk_stability_regions.push(rk4_result);
 
-        println!("  ✅ Analyzed stability regions for 3 RK methods");
+        tracing::info!("  ✅ Analyzed stability regions for 3 RK methods");
         Ok(())
     }
 
@@ -291,7 +291,7 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
 
     /// Validate CFL conditions for various test cases
     fn validate_cfl_conditions(&self, report: &mut StabilityAnalysisReport<T>) -> Result<()> {
-        println!("\n🌊 CFL Condition Validation");
+        tracing::info!("\n🌊 CFL Condition Validation");
 
         // Test case 1: Low-speed laminar flow
         let vel_laminar = <T as FloatElement>::from_f64(0.1); // velocity
@@ -332,7 +332,7 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
         );
         report.cfl_analyses.push(turbulent_result);
 
-        println!("  ✅ Validated CFL conditions for 3 test cases");
+        tracing::info!("  ✅ Validated CFL conditions for 3 test cases");
         Ok(())
     }
 
@@ -368,7 +368,7 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
 
     /// Perform von Neumann stability analysis
     fn perform_von_neumann_analysis(&self, report: &mut StabilityAnalysisReport<T>) -> Result<()> {
-        println!("\n📊 Von Neumann Stability Analysis");
+        tracing::info!("\n📊 Von Neumann Stability Analysis");
 
         let schemes = [
             NumericalScheme::ForwardEuler,
@@ -394,7 +394,7 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
             report.von_neumann_analyses.push(burgers_result);
         }
 
-        println!("  ✅ Performed von Neumann analysis for 3 PDE types × 3 schemes");
+        tracing::info!("  ✅ Performed von Neumann analysis for 3 PDE types × 3 schemes");
         Ok(())
     }
 
@@ -626,9 +626,9 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
 
     /// Display comprehensive stability report
     fn display_stability_report(&self, report: &StabilityAnalysisReport<T>) {
-        println!("\n📋 Stability Analysis Summary");
-        println!("============================");
-        println!(
+        tracing::info!("\n📋 Stability Analysis Summary");
+        tracing::info!("============================");
+        tracing::info!(
             "Overall Stability Score: {:.1}% ({}/{})",
             report.overall_assessment.overall_score * 100.0,
             report.overall_assessment.tests_passed,
@@ -636,15 +636,15 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
         );
 
         if !report.overall_assessment.critical_issues.is_empty() {
-            println!("\n⚠️  Critical Issues:");
+            tracing::info!("\n⚠️  Critical Issues:");
             for issue in &report.overall_assessment.critical_issues {
-                println!("  • {issue}");
+                tracing::info!("  • {issue}");
             }
         }
 
-        println!("\n🔢 CFL Condition Results:");
+        tracing::info!("\n🔢 CFL Condition Results:");
         for cfl in &report.cfl_analyses {
-            println!(
+            tracing::info!(
                 "  {}: CFL = {:.3}, Status: {}",
                 cfl.test_case,
                 <T as NumericElement>::to_f64(cfl.cfl_number),
@@ -652,9 +652,9 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
             );
         }
 
-        println!("\n📊 Von Neumann Analysis:");
+        tracing::info!("\n📊 Von Neumann Analysis:");
         for vn in &report.von_neumann_analyses {
-            println!(
+            tracing::info!(
                 "  {}: Max Amp = {:.3}, Stable: {}",
                 vn.pde_type,
                 <T as NumericElement>::to_f64(vn.max_amplification),
@@ -663,13 +663,13 @@ impl<T: RealField + Copy + FloatElement> StabilityAnalysisRunner<T> {
         }
 
         if !report.recommendations.is_empty() {
-            println!("\n💡 Recommendations:");
+            tracing::info!("\n💡 Recommendations:");
             for rec in &report.recommendations {
-                println!("  • {rec}");
+                tracing::info!("  • {rec}");
             }
         }
 
-        println!("\n✅ Stability analysis completed successfully!");
+        tracing::info!("\n✅ Stability analysis completed successfully!");
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces 165 `println!`/`print!`/`eprintln!` calls in the `cfd-validation` crate's `src/` tree with the `tracing` structured-logging facade that the crate already depends on.

## Rationale

Direct `println!`/`eprintln!` calls in library code are a conformance debt class (`print_dbg`): they bypass any logging configuration, can't be filtered by level, and can't carry structured fields. The crate already declares `tracing` as a dependency but didn't use it. This migration adopts the structured facade consistently.

## Changes

- `println!(...)` (informational) → `tracing::info!(...)`
- `println!("Warning: ...")` / `eprintln!(...)` → `tracing::warn!(...)`
- `println!()` (blank line) → `tracing::info!("")`
- 15 files in `crates/cfd-validation/src/` modified
- No new dependencies added (`tracing` already in `Cargo.toml`)
- Test-region `println!` calls left untouched

## Verification

- `cargo fmt -p cfd-validation -- --check` ✅
- `cargo check -p cfd-validation` ✅
- `cargo clippy -p cfd-validation --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run -p cfd-validation --all-features`: **435/435 passed** ✅
- `cargo test -p cfd-validation --doc`: 4 passed, 2 ignored ✅
- `cargo doc -p cfd-validation --no-deps`: no warnings ✅

Based on `origin/main` `aa54f5cd`. The `cfd-validation/src/` `print_dbg` count drops from 165 to 0 on the clean lane.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR systematically replaces 165 direct console output calls (`println!`, `eprintln!`, `print!`) with structured logging via the `tracing` facade across 15 files in the `cfd-validation` crate. The migration maps informational `println!` calls to `tracing::info!`, warning messages to `tracing::warn!`, and preserves test code unchanged. This refactor eliminates conformance debt by enabling proper log filtering, level control, and structured field support without adding new dependencies.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-validation/src/lib.rs` |
| 2 | `crates/cfd-validation/src/conservation/mod.rs` |
| 3 | `crates/cfd-validation/src/conservation/geometric.rs` |
| 4 | `crates/cfd-validation/src/edge_case_testing/mod.rs` |
| 5 | `crates/cfd-validation/src/time_integration/stability_analysis.rs` |
| 6 | `crates/cfd-validation/src/benchmarking/production.rs` |
| 7 | `crates/cfd-validation/src/benchmarking/performance.rs` |
| 8 | `crates/cfd-validation/src/benchmarking/scaling.rs` |
| 9 | `crates/cfd-validation/src/benchmarking/visualization.rs` |
| 10 | `crates/cfd-validation/src/manufactured/richardson/analysis.rs` |
| 11 | `crates/cfd-validation/src/manufactured/richardson/validation.rs` |
| 12 | `crates/cfd-validation/src/numerical/linear_solver.rs` |
| 13 | `crates/cfd-validation/src/numerical/venturi_cross_fidelity.rs` |
| 14 | `crates/cfd-validation/src/benchmarks/threed/bifurcation.rs` |
| 15 | `crates/cfd-validation/src/benchmarks/threed/venturi.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Validation, benchmarking, conservation, solver, stability, and profiling output now uses structured logging.
  * Informational messages and warnings can be consistently filtered and captured through the application’s logging system.
  * Existing calculations, validation behavior, reports, and results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->