### PR TITLE
refactor(cfd-2d): migrate turbulence validation println! to tracing

### DIFF
--- a/crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs
+++ b/crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::print_stdout)]
 //! Turbulence Model Constants Validation against DNS Databases
 //!
 //! Implements MAJOR-004: Turbulence Model Constants Validation
@@ -112,20 +111,20 @@ impl<T: RealField + Copy> ConstantsValidationResult<T> {
     /// Display validation result
     pub fn display(&self) {
         let status = if self.passed { "✅ PASS" } else { "❌ FAIL" };
-        println!("{}: {} Constants Validation", status, self.model_name);
-        println!("  Reference: {}", self.reference);
-        println!(
+        tracing::info!("{}: {} Constants Validation", status, self.model_name);
+        tracing::info!("  Reference: {}", self.reference);
+        tracing::warn!(
             "  Baseline RMS Error: {:.4}",
             <T as NumericElement>::to_f64(self.baseline_error)
         );
-        println!(
+        tracing::info!(
             "  Max Uncertainty Bound: {:.4}",
             <T as NumericElement>::to_f64(self.max_uncertainty_bound)
         );
 
-        println!("  Constant Sensitivity Analysis:");
+        tracing::info!("  Constant Sensitivity Analysis:");
         for (constant_name, sensitivity) in &self.sensitivity_results {
-            println!(
+            tracing::info!(
                 "    {}: Δε = {:.4} (bounds: {:.4}, {:.4})",
                 constant_name,
                 <T as NumericElement>::to_f64(sensitivity.uncertainty_bound),
@@ -133,17 +132,17 @@ impl<T: RealField + Copy> ConstantsValidationResult<T> {
                 <T as NumericElement>::to_f64(sensitivity.plus_10_error)
             );
         }
-        println!();
+        tracing::info!("");
     }
 }
 
 /// Run comprehensive turbulence constants validation against DNS databases
 pub fn run_turbulence_constants_validation<T: RealField + Copy>() {
-    println!("🔬 Turbulence Model Constants Validation Suite");
-    println!("=============================================");
-    println!("MAJOR-004: Validating constants against DNS channel flow databases");
-    println!("References: Moser et al. (1999), Pope (2000), Wilcox (2008)");
-    println!();
+    tracing::info!("🔬 Turbulence Model Constants Validation Suite");
+    tracing::info!("=============================================");
+    tracing::info!("MAJOR-004: Validating constants against DNS channel flow databases");
+    tracing::info!("References: Moser et al. (1999), Pope (2000), Wilcox (2008)");
+    tracing::info!("");
 
     let validator = TurbulenceConstantsValidator::<T>::new();
     let results = validator.run_full_constants_validation();
@@ -156,19 +155,21 @@ pub fn run_turbulence_constants_validation<T: RealField + Copy>() {
         }
     }
 
-    println!("📊 Constants Validation Summary:");
-    println!("  Models Validated: {}/{}", passed_count, results.len());
-    println!(
+    tracing::info!("📊 Constants Validation Summary:");
+    tracing::info!("  Models Validated: {}/{}", passed_count, results.len());
+    tracing::info!(
         "  Success Rate: {:.1}%",
         100.0 * passed_count as f32 / results.len() as f32
     );
 
     if passed_count == results.len() {
-        println!("🎉 All turbulence model constants validated against DNS!");
-        println!("   Constants show acceptable uncertainty bounds and sensitivity.");
+        tracing::info!("🎉 All turbulence model constants validated against DNS!");
+        tracing::info!("   Constants show acceptable uncertainty bounds and sensitivity.");
     } else {
-        println!("⚠️  Some model constants require recalibration or uncertainty quantification.");
-        println!("   Review sensitivity analysis results for problematic constants.");
+        tracing::warn!(
+            "⚠️  Some model constants require recalibration or uncertainty quantification."
+        );
+        tracing::info!("   Review sensitivity analysis results for problematic constants.");
     }
 }
 

--- a/crates/cfd-2d/src/physics/turbulence/constants_validation/sensitivity.rs
+++ b/crates/cfd-2d/src/physics/turbulence/constants_validation/sensitivity.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::print_stdout)]
 //! Sensitivity analysis: validates turbulence constants against DNS channel flow.
 
 use super::{
@@ -14,7 +13,7 @@ use std::collections::HashMap;
 impl<T: RealField + Copy> TurbulenceConstantsValidator<T> {
     /// Validate k-ε model constants against DNS channel flow
     pub fn validate_k_epsilon_constants(&self) -> ConstantsValidationResult<T> {
-        println!(
+        tracing::info!(
             "🔬 Validating k-ε model constants against DNS channel flow (Re_τ = {})",
             self.dns_database.re_tau
         );
@@ -190,7 +189,7 @@ impl<T: RealField + Copy> TurbulenceConstantsValidator<T> {
 
     /// Validate k-ω SST model constants against DNS
     pub fn validate_k_omega_sst_constants(&self) -> ConstantsValidationResult<T> {
-        println!(
+        tracing::info!(
             "🔬 Validating k-ω SST model constants against DNS channel flow (Re_τ = {})",
             self.dns_database.re_tau
         );
@@ -312,7 +311,7 @@ impl<T: RealField + Copy> TurbulenceConstantsValidator<T> {
 
     /// Validate Spalart-Allmaras constants
     pub fn validate_spalart_allmaras_constants(&self) -> ConstantsValidationResult<T> {
-        println!(
+        tracing::info!(
             "🔬 Validating Spalart-Allmaras constants against DNS channel flow (Re_τ = {})",
             self.dns_database.re_tau
         );

--- a/crates/cfd-2d/src/physics/turbulence/validation/mod.rs
+++ b/crates/cfd-2d/src/physics/turbulence/validation/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::print_stdout)]
 //! Comprehensive turbulence model validation suite
 //!
 //! This module provides validation against:
@@ -97,22 +96,22 @@ impl ValidationResult {
     /// Display the result in a formatted way
     pub fn display(&self) {
         let status = if self.passed { "✅ PASS" } else { "❌ FAIL" };
-        println!("{}: {}", status, self.test_name);
-        println!("  Metric: {}", self.metric);
+        tracing::info!("{}: {}", status, self.test_name);
+        tracing::info!("  Metric: {}", self.metric);
         if !self.details.is_empty() {
-            println!("  Details: {}", self.details);
+            tracing::info!("  Details: {}", self.details);
         }
-        println!();
+        tracing::info!("");
     }
 }
 
 /// Run and display comprehensive turbulence validation against experimental benchmarks
 pub fn run_turbulence_validation<T: EunomiaRealField + Copy>() {
-    println!("🧪 Comprehensive Turbulence Model Validation Suite");
-    println!("=================================================");
-    println!("Validating against experimental benchmarks per ASME V&V 20-2009");
-    println!("References: White (2006), Moser et al. (1999), Comte-Bellot & Corrsin (1971)");
-    println!();
+    tracing::info!("🧪 Comprehensive Turbulence Model Validation Suite");
+    tracing::info!("=================================================");
+    tracing::info!("Validating against experimental benchmarks per ASME V&V 20-2009");
+    tracing::info!("References: White (2006), Moser et al. (1999), Comte-Bellot & Corrsin (1971)");
+    tracing::info!("");
 
     let validator = TurbulenceValidator::<T>::new(<T as FloatElement>::from_f64(0.01));
     let results = validator.run_full_validation_suite();
@@ -138,8 +137,8 @@ pub fn run_turbulence_validation<T: EunomiaRealField + Copy>() {
         }
     }
 
-    println!("🏭 RANS Model Validations:");
-    println!("-------------------------");
+    tracing::info!("🏭 RANS Model Validations:");
+    tracing::info!("-------------------------");
     for result in &rans_results {
         result.display();
         if result.passed {
@@ -149,8 +148,8 @@ pub fn run_turbulence_validation<T: EunomiaRealField + Copy>() {
         }
     }
 
-    println!("\n🌪️  LES/DES Model Validations:");
-    println!("----------------------------");
+    tracing::info!("\n🌪️  LES/DES Model Validations:");
+    tracing::info!("----------------------------");
     for result in &les_results {
         result.display();
         if result.passed {
@@ -160,8 +159,8 @@ pub fn run_turbulence_validation<T: EunomiaRealField + Copy>() {
         }
     }
 
-    println!("\n⚡ Performance Benchmarks:");
-    println!("------------------------");
+    tracing::info!("\n⚡ Performance Benchmarks:");
+    tracing::info!("------------------------");
     for result in &results {
         if result.test_name.contains("Performance") {
             result.display();
@@ -173,38 +172,38 @@ pub fn run_turbulence_validation<T: EunomiaRealField + Copy>() {
         }
     }
 
-    println!("\n📊 Validation Summary:");
-    println!(
+    tracing::info!("\n📊 Validation Summary:");
+    tracing::info!(
         "  RANS Tests: {} passed, {} total",
         rans_results.iter().filter(|r| r.passed).count(),
         rans_results.len(),
     );
-    println!(
+    tracing::info!(
         "  LES/DES Tests: {} passed, {} total",
         les_results.iter().filter(|r| r.passed).count(),
         les_results.len()
     );
-    println!("  Total: {passed} passed, {failed} failed, {total_tests} total");
-    println!(
+    tracing::info!("  Total: {passed} passed, {failed} failed, {total_tests} total");
+    tracing::info!(
         "  Success Rate: {:.1}%",
         100.0 * passed as f32 / total_tests as f32
     );
 
     if failed == 0 {
-        println!("🎉 All turbulence validation tests passed!");
-        println!("   CFD models validated against experimental benchmarks.");
+        tracing::info!("🎉 All turbulence validation tests passed!");
+        tracing::info!("   CFD models validated against experimental benchmarks.");
     } else {
-        println!("⚠️  {failed} validation tests failed - review implementation");
-        println!("   Models may require calibration or bug fixes.");
+        tracing::warn!("⚠️  {failed} validation tests failed - review implementation");
+        tracing::info!("   Models may require calibration or bug fixes.");
     }
 }
 
 /// Run RANS model benchmark suite
 pub fn run_rans_benchmark_suite<T: EunomiaRealField + Copy>() {
-    println!("🏭 RANS Turbulence Model Benchmark Suite");
-    println!("=======================================");
-    println!("Validating k-ε, k-ω SST, and SA models against experimental data");
-    println!();
+    tracing::info!("🏭 RANS Turbulence Model Benchmark Suite");
+    tracing::info!("=======================================");
+    tracing::info!("Validating k-ε, k-ω SST, and SA models against experimental data");
+    tracing::info!("");
 
     let validator = TurbulenceValidator::<T>::new(<T as FloatElement>::from_f64(0.01));
     let results = validator.run_rans_benchmark_suite();
@@ -221,9 +220,9 @@ pub fn run_rans_benchmark_suite<T: EunomiaRealField + Copy>() {
         }
     }
 
-    println!("\n📊 RANS Benchmark Summary:");
-    println!("  Passed: {passed}/{}", results.len());
-    println!(
+    tracing::info!("\n📊 RANS Benchmark Summary:");
+    tracing::info!("  Passed: {passed}/{}", results.len());
+    tracing::info!(
         "  Success Rate: {:.1}%",
         100.0 * passed as f32 / results.len() as f32
     );
@@ -231,10 +230,10 @@ pub fn run_rans_benchmark_suite<T: EunomiaRealField + Copy>() {
 
 /// Run LES/DES benchmark suite
 pub fn run_les_benchmark_suite<T: EunomiaRealField + Copy>() {
-    println!("🌪️  LES/DES Turbulence Model Benchmark Suite");
-    println!("===========================================");
-    println!("Validating Smagorinsky LES and DES models");
-    println!();
+    tracing::info!("🌪️  LES/DES Turbulence Model Benchmark Suite");
+    tracing::info!("===========================================");
+    tracing::info!("Validating Smagorinsky LES and DES models");
+    tracing::info!("");
 
     let validator = TurbulenceValidator::<T>::new(<T as FloatElement>::from_f64(0.01));
     let results = validator.run_les_benchmark_suite();
@@ -251,9 +250,9 @@ pub fn run_les_benchmark_suite<T: EunomiaRealField + Copy>() {
         }
     }
 
-    println!("\n📊 LES/DES Benchmark Summary:");
-    println!("  Passed: {passed}/{}", results.len());
-    println!(
+    tracing::info!("\n📊 LES/DES Benchmark Summary:");
+    tracing::info!("  Passed: {passed}/{}", results.len());
+    tracing::info!(
         "  Success Rate: {:.1}%",
         100.0 * passed as f32 / results.len() as f32
     );


### PR DESCRIPTION
## Summary

Migrate **60** `println!`/`print!` calls in the cfd-2d turbulence validation modules to the structured `tracing` facade (already a workspace dependency), eliminating direct stdout writes from production library code.

### Files changed
- `crates/cfd-2d/src/physics/turbulence/validation/mod.rs` — 38 calls
- `crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs` — 19 calls
- `crates/cfd-2d/src/physics/turbulence/constants_validation/sensitivity.rs` — 3 calls

### Mapping
- `println!(...)` (informational) → `tracing::info!(...)`
- `println!("⚠️ ...")` / `eprintln!(...)` (warnings/failures) → `tracing::warn!(...)`
- `println!()` (blank line) → `tracing::info!("")`
- Removed 3 now-unused `#![allow(clippy::print_stdout)]` directives

### Verification (local, clean lane from `origin/main` `aa54f5cd`)
- `cargo fmt -p cfd-2d --check` ✅
- `cargo check -p cfd-2d` ✅
- `cargo clippy -p cfd-2d --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run -p cfd-2d --all-features` — 590 passed, 27 skipped ✅
- `cargo test --doc -p cfd-2d --all-features` — 2 passed, 2 ignored ✅
- `cargo doc -p cfd-2d --no-deps --all-features` — no new warnings from changed files (pre-existing `NetworkBlueprint` link error in `network/mod.rs` is unchanged)

No test-region code, source logic, or dependencies changed. Hosted checks are the acceptance oracle.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates 60 `println!` and `print!` calls in the turbulence validation modules to the structured `tracing` facade. The changes replace informational `println!` statements with `tracing::info!`, warning messages with `tracing::warn!`, and removes three `#![allow(clippy::print_stdout)]` directives. This eliminates direct stdout writes from production library code while maintaining the same output behavior through the tracing infrastructure.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `crates/cfd-2d/src/physics/turbulence/validation/mod.rs` |
| 2 | `crates/cfd-2d/src/physics/turbulence/constants_validation/mod.rs` |
| 3 | `crates/cfd-2d/src/physics/turbulence/constants_validation/sensitivity.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Turbulence validation and benchmark messages are now reported through structured logging.
  * Normal results use informational logs, while validation failures and warnings are clearly distinguished.
  * Validation calculations and externally visible interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->