### PR TITLE
fix(cfdrs): Integrate the rescued post-series WIP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -4563,3 +4563,108 @@ Target version: `0.3.0` (pre-1.0 breaking provider-boundary release).
 - [x] Propagate material-domain failures through `cfd_core::Error::InvalidInput`.
 - [x] Document the ownership decision and verify the independent closed-form
   density oracle plus negative-response rejection.
+
+## gap-audit-2026-08-20 (owner: atlas-gap-audit)
+
+Execution order for the CFDRS-GA-* items filed in `backlog.md` by the
+2026-08-20 scope-vs-delivery audit. Evidence for every step is in
+`gap_audit.md` §"Finding 2026-08-20: CFDrs scope-vs-delivery audit". Steps are
+dependency-ordered: the two structural blockers first, because both change what
+the gate can see, and every later verification claim depends on that.
+
+- [x] Audit pass: measure the tree statically (no build, no test run), cross-check
+      README/book/ADR claims against source, and record findings with file:line
+      evidence in `gap_audit.md`.
+- [x] Correct the two unambiguously stale factual claims found: `README.md:115`
+      crate-level allow count 288 → 292 (measured), and
+      `docs/book/appendix_glossary.md:1` "Appendix C" → "Appendix B" (SUMMARY
+      declares exactly A and B).
+- [ ] **CFDRS-GA-001** — Remove the ungated `#[global_allocator]` from
+      `crates/cfd-validation/src/benchmarking/memory.rs:93`. Do this first: it
+      changes the allocation behaviour of every binary in that link graph, so
+      any benchmark baseline captured before it is not comparable to one after.
+      Decide the replacement shape (opt-in harness constructed by the bench)
+      before touching the `unsafe impl GlobalAlloc` at :315-345.
+- [ ] **CFDRS-GA-002** — Decide the fate of the 54 root-directory files. Read
+      each of `examples/` (37), `benches/` (11), `tests/` (6) against its
+      nearest `crates/*/` equivalent and classify: duplicate of a member target
+      → delete; unique → move under the owning member crate with an explicit
+      target declaration. Do not add a `cfd-suite` façade — `Cargo.toml:26`
+      records its removal as deliberate. Update `README.md:130-141` to describe
+      the set that is actually built. Expect compile failures in the moved
+      files; each is a real post-leto-migration defect to fix, not a reason to
+      re-orphan them.
+- [ ] **CFDRS-GA-007** — Only after GA-002 settles which examples exist: rewrite
+      `docs/book/figures/MANIFEST.json` `source_example` entries to name real
+      packages and targets, and extend `xtask/src/check_figures.rs` from a
+      name-set difference to a content check (the `sha256_16` prebook already
+      computes, plus a `cargo metadata` existence check on each producer).
+      Verify the new gate is live by mutating one committed SVG byte and
+      confirming a red run.
+- [ ] **CFDRS-GA-006** — Convert the vacuous convergence studies. Start with
+      `crates/cfd-2d/tests/ghia_cavity_simplec_validation.rs:1088-1123`: delete
+      the underscore-bound `_target_order`, assert the computed observed order
+      against 2.0 within a band derived from the discretization's truncation
+      error and the refinement ratio, and cite that derivation at the assertion.
+      Then drive the MMS sources in `crates/cfd-validation/src/manufactured/`
+      through the FDM/FVM/SIMPLE solvers rather than evaluating them in
+      isolation, using
+      `crates/cfd-2d/tests/poisson_fdm_validation.rs:443-448` as the reference
+      form. Keep each case inside the committed 15s/30s budget; if a refinement
+      sequence cannot fit, profile the solver, do not shrink the sequence.
+- [ ] **CFDRS-GA-013** — Resolve the five capability-admitting `#[ignore]`s.
+      The three in `crates/cfd-1d/tests/component_validation.rs` are physics
+      defects (unclamped parameters, non-monotonic valve resistance, drifted
+      FlowSensor API); fix production code or withdraw the requirement with a
+      recorded reason. The two AMG ones depend on leto-ops coarsening coverage —
+      if the capability is missing upstream, that is a leto-ops item, not a
+      local reimplementation.
+- [ ] **CFDRS-GA-003** — Retire `validation/` in subject-area increments
+      (analytical, convergence, cross-package, external references). For each:
+      confirm the Rust equivalent in `crates/cfd-validation/src/` asserts the
+      same identity value-semantically, add it if it does not, then delete the
+      Python. Untrack the 6 `.pyc`, the 52 `.xml` and 5 `.png` run outputs, and
+      the timestamped `fluidsim_output/` directories, and gitignore that root.
+      Remove the Python harness commands from `xtask/src/main.rs` last, once
+      nothing invokes them.
+- [ ] **CFDRS-GA-005** — Ratchet `expect("expected value")` from 739 to 0, per
+      crate. Begin with `crates/cfd-2d/src/physics/momentum/solve.rs`, where the
+      eight sites all guard `Option` fields encoding an assemble-before-solve
+      call order: restructure that state so the pre-assembly phase is
+      unrepresentable rather than relabelling the panic.
+- [ ] **CFDRS-GA-004** — Consolidate SIMD onto `hermes-simd`. Inventory the
+      operations the three in-repo implementations cover, diff against hermes's
+      surface, file any gap upstream, then migrate call sites and delete
+      `crates/cfd-core/src/compute/simd/{x86,aarch64}.rs`,
+      `crates/cfd-math/src/simd/`, and
+      `crates/cfd-2d/src/solvers/simd_kernels.rs`. Differential-test the hermes
+      path against the scalar reference across every shipped scalar type and
+      attach a criterion baseline comparison before and after.
+- [ ] **CFDRS-GA-012** — Collapse the two Richardson implementations to one and
+      give it a typed error.
+- [ ] **CFDRS-GA-008** — Collapse the duplicate PM trees. Establish which of
+      root vs `docs/` is canonical (the `docs/` set is what the current session
+      writes; `README.md:146` names the root set), merge unique content into the
+      survivor, delete the other, and fix the `checklist.md` / `CHECKLIST.md`
+      reference. Split `docs/adr.md`'s 53 decision rows into numbered
+      `docs/adr/NNNN-<slug>.md` records with `docs/adr/README.md` as index and
+      canonical statuses. Absorb the 52 `SPRINT_*`/`AUDIT_*` report files into
+      their canonical owners and delete them. Move the vocabulary blockquote out
+      of `CHANGELOG.md`. Delete root `errors.json`.
+- [ ] **CFDRS-GA-009**, **CFDRS-GA-010** — Realign book chapter numbering with
+      `SUMMARY.md`, then fill the six stub chapters.
+- [ ] **CFDRS-GA-011**, **CFDRS-GA-014** — Promote `missing_docs` to deny per
+      crate (smallest first: `cfd-io`, `cfd-schematic-mesh`), and ship
+      `py.typed` plus `.pyi` stubs for `cfd-python`.
+- [ ] **CFDRS-GA-015** — Burn the 292 crate-level allows down to per-site
+      `#[expect(…, reason = "ratchet <id>")]`, starting with the two that cancel
+      workspace denies (`cfd-validation` `print_stdout`, `cfd-3d`
+      `print_stderr`). Also close the +8 `#[allow(` regression against the Atlas
+      baseline (89 → 97).
+- [ ] **CFDRS-GA-016** — Move to edition 2024 / resolver 3 last, once the unsafe
+      surface has shrunk to what GA-004 leaves behind.
+
+Not touched by this audit, recorded here so the next owner does not re-derive
+it: `CFDRS-VAL-RED-1` (`backlog.md:702`) still reads status "in progress" while
+its own body records closure at 434/434. The status field is another owner's to
+correct.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs the figure chec
 individual crates on tagged releases.
 
 Ten of the eleven crates declare `#![warn(clippy::pedantic)]` and then pre-suppress it
-with crate-level `#![allow(...)]` attributes — 288 of them across those ten `lib.rs`
+with crate-level `#![allow(...)]` attributes — 292 of them across those ten `lib.rs`
 files. `cfd-schematic-mesh` declares neither, only `#![forbid(unsafe_code)]`. Those
 exemptions are debt being burned down, not a clean pedantic baseline: read the
 `lib.rs` header before treating a warning-free clippy run as evidence of pedantic

--- a/backlog.md
+++ b/backlog.md
@@ -4507,3 +4507,259 @@ debt outside this slice; no lint was weakened and no baseline was changed.
 
 ## Rigor & Correctness
 - [x] Review all numerical bounds and geometry assumptions in `cfd-schematics`.
+
+## Gap audit 2026-08-20 — scope-vs-delivery items
+
+Filed by the Atlas gap audit (evidence: `gap_audit.md` §"Finding 2026-08-20:
+CFDrs scope-vs-delivery audit"). Every item below is `status=todo`, unclaimed.
+No existing item's status was changed by this audit.
+
+- **CFDRS-GA-001 [major][arch] — Remove the library-crate global allocator (status=todo, effort=M).**
+  Outcome: `cfd-validation` no longer installs a process-wide allocator, so no
+  test, bench, example, or downstream binary in its link graph inherits
+  allocation instrumentation it did not request, and a consumer may declare its
+  own `#[global_allocator]`.
+  Scope: `crates/cfd-validation/src/benchmarking/memory.rs` (`#[global_allocator]`
+  at :93, `unsafe impl GlobalAlloc` at :315-345) and its callers.
+  Non-goals: removing the memory-statistics API itself — only its unconditional
+  global installation; the tracking facility may return through an opt-in
+  harness the benchmark explicitly constructs.
+  Acceptance oracle: no `#[global_allocator]` outside an explicitly opted-in
+  bench/bin target; a test binary asserts allocation counts only where the
+  harness is installed; `cargo check --workspace --all-targets` green.
+  Dependencies: none. Risk: public behaviour change of a published crate.
+
+- **CFDRS-GA-002 [patch][verification] — Bring root `examples/`, `benches/`, `tests/` under a cargo target (status=todo, effort=M).**
+  Outcome: the 54 files / 10 543 lines under the repository-root `examples/`,
+  `benches/`, and `tests/` are compiled by a gate, or are deleted because their
+  content already lives under `crates/*/`.
+  Scope: root `Cargo.toml` (virtual manifest, no `[package]`), the three root
+  directories, `README.md:130-141`, and `.github/workflows/ci.yml`.
+  Non-goals: reintroducing a `cfd-suite` façade package that re-exports member
+  crates — the manifest comment at `Cargo.toml:26` records that removal as
+  deliberate; if a host package is the chosen route it hosts targets only.
+  Acceptance oracle: `cargo metadata --no-deps` reports a target for every
+  retained root-directory file, `cargo check --workspace --all-targets`
+  compiles them, and `README.md` names the set that is actually built.
+  Dependencies: decide with CFDRS-GA-007 (the book figure manifest cites three
+  of these examples as figure sources).
+  Risk: moderate — some of these drivers may not compile after the leto
+  migration; that is the finding, not a blocker.
+
+- **CFDRS-GA-003 [major][arch] — Retire the parallel Python validation stack (status=todo, effort=L).**
+  Outcome: the analytical solutions, convergence studies, and cross-package
+  comparisons under `validation/` exist once, in Rust, inside `cfd-validation`,
+  and run under the committed gate; external-reference comparisons
+  (FEniCS/FluidSim oracles) that genuinely require a third-party solver are
+  either a scheduled, run-output-segregated job or are deleted with their
+  reference values captured as committed fixtures.
+  Scope: `validation/` (126 tracked files: 59 `.py`/20 563 lines, 6 `.pyc`,
+  52 `.xml`, 5 `.png`), `validation_reports/`, `parity_artefacts/`, and the
+  Python harness commands in `xtask/src/main.rs` (`setup_venv`, `install_deps`,
+  `install_fenics`, `validate`).
+  Non-goals: `crates/cfd-python` — the PyO3 binding surface is in scope for the
+  stack and stays.
+  Acceptance oracle: no `.py` domain logic outside `crates/cfd-python/tests`;
+  no tracked `.pyc` or timestamped run-output directory; every analytical
+  identity previously asserted in Python has a value-semantic Rust test.
+  Dependencies: none. Decompose per subject area (analytical, convergence,
+  cross-package, external references).
+
+- **CFDRS-GA-004 [minor][arch] — Consolidate the three SIMD implementations onto hermes-simd (status=todo, effort=L).**
+  Outcome: one SIMD seam. Lane-wise kernels dispatch through `hermes-simd`;
+  any capability hermes lacks is implemented upstream in hermes rather than
+  re-derived here.
+  Scope: `crates/cfd-core/src/compute/simd/{mod,x86,aarch64}.rs` (492 lines,
+  six `pub unsafe fn` on raw `std::arch` intrinsics),
+  `crates/cfd-math/src/simd/` (972 lines),
+  `crates/cfd-2d/src/solvers/simd_kernels.rs` (562 lines), and the two existing
+  hermes call sites at `crates/cfd-math/src/simd/ops/mod.rs:8,196`.
+  Non-goals: the `.wgsl` GPU kernels — those belong to the separate
+  hephaestus adoption axis recorded at `Cargo.toml:110`.
+  Acceptance oracle: `crates/*/src` contains no `std::arch` intrinsic import;
+  differential tests assert the hermes path against the scalar reference within
+  a derived tolerance across every shipped scalar type; a criterion baseline
+  shows no regression on the affected kernels.
+  Dependencies: hermes-simd must cover advection, diffusion, and dot product
+  for `f32`/`f64`; a gap is an upstream hermes item, not a local reimplementation.
+
+- **CFDRS-GA-005 [patch][correctness] — Replace the 739 `expect("expected value")` sites (status=todo, effort=M).**
+  Outcome: every panicking site in library source either carries an
+  `invariant: <statement>` message proving why it cannot fire, or is converted
+  to a typed `Result`/`let-else`; the `Option`-field solver state that motivates
+  most of them is restructured so the invalid phase is unrepresentable.
+  Scope: 739 sites across `crates/*/src`; start at
+  `crates/cfd-2d/src/physics/momentum/solve.rs:83,84,87,88,232,237,343,344`,
+  where `matrix_u`/`rhs_u`/`matrix_v`/`rhs_v` are `Option` fields whose
+  `Some`-ness encodes an undocumented assemble-before-solve call order.
+  Non-goals: test-module sites, which may keep `expect` with a descriptive
+  message.
+  Acceptance oracle: `grep -rc 'expect("expected value")' crates/*/src`
+  returns 0; a negative test asserts a typed error (not a panic) for the
+  solve-before-assemble sequence.
+  Dependencies: none. Decompose per crate; ratchet the count down.
+
+- **CFDRS-GA-006 [patch][verification] — Make the grid-convergence studies assert observed order (status=todo, effort=M).**
+  Outcome: each declared second-order discretization has a test that computes
+  the observed order over a refinement sequence and asserts it against the
+  theoretical order within a derived band, so an order regression fails the
+  gate.
+  Scope: `crates/cfd-2d/tests/ghia_cavity_simplec_validation.rs:1088-1123`
+  (currently computes `observed_order`, binds `let _target_order = 2.0;`, and
+  only prints); `crates/cfd-2d/tests/reynolds_stress_comprehensive_tests.rs:544-600`
+  (self-consistency of the MMS evaluation, per its own comment at :583); the
+  MMS sources in `crates/cfd-validation/src/manufactured/` driven through the
+  FDM/FVM/SIMPLE solvers rather than evaluated in isolation.
+  Non-goals: widening any existing tolerance; the workload stays inside the
+  committed 15s/30s nextest budget or moves to a reviewed profile with a
+  derived bound.
+  Acceptance oracle: a mutation to a discretization coefficient makes at least
+  one order-of-accuracy test fail; the band at each assertion cites its
+  derivation.
+  Dependencies: none. Reference form already exists at
+  `crates/cfd-2d/tests/poisson_fdm_validation.rs:443-448`.
+
+- **CFDRS-GA-007 [patch][verification] — Make `check-figures` verify content and repair figure provenance (status=todo, effort=S).**
+  Outcome: the CI figure gate detects a figure whose content diverged from the
+  data it depicts, and every figure's recorded producer is a runnable target.
+  Scope: `xtask/src/check_figures.rs:94-129` (currently a name-set difference
+  over `SUMMARY.md`/`README.md` references vs `prebook::FIGURE_SPECS` — it
+  opens no SVG and compares no hash), `xtask/src/prebook.rs` (which already
+  computes `sha256_16`), and `docs/book/figures/MANIFEST.json`, whose every
+  entry records `"crate_name":"cfd-suite"` — a package `Cargo.toml:26` states
+  does not exist — naming root-directory examples cargo cannot build.
+  Non-goals: replacing the figure set.
+  Acceptance oracle: `cargo run -p xtask -- check-figures` fails when a
+  committed SVG's bytes differ from its manifest hash and when a
+  `source_example` names a target absent from `cargo metadata`.
+  Dependencies: CFDRS-GA-002 (the named producers are the orphaned examples).
+
+- **CFDRS-GA-008 [patch][pm-hygiene] — Collapse the duplicate PM trees and adopt ADR governance (status=todo, effort=M).**
+  Outcome: one board, one checklist, one gap file, each with a single
+  authoritative location that `README.md` names correctly; decisions are
+  numbered records citable from board items and commits.
+  Scope: root `backlog.md`/`CHECKLIST.md`/`gap_audit.md` vs
+  `docs/backlog.md`/`docs/checklist.md`/`docs/gap_audit.md` plus
+  `docs/gap_audit_clean.md` (both trees written by different sessions in the
+  same week); `README.md:146` (`checklist.md` vs the tracked `CHECKLIST.md`);
+  `docs/adr.md` (1601 lines, header `## Status: ACTIVE - Version
+  1.42.0-SIMD-EXCELLENCE` against workspace `0.3.0`, 53 table rows, no
+  `docs/adr/` directory and no index); the 52 `SPRINT_*`/`AUDIT_*`/`FINAL_*`
+  report files under `docs/`; the 30-line vocabulary blockquote prepended to
+  `CHANGELOG.md` and duplicated at `gap_audit.md:41`; root `errors.json`
+  (174 KB of raw cargo JSON build output), `ACCOMPLISHMENTS.md`.
+  Also stale: `CFDRS-VAL-RED-1` at `backlog.md:702` carries status
+  "in progress 2026-07-31" while its own body at :729 records "CLOSURE:
+  cfd-validation Nextest 434/434 (1 slow)" — status field only; left as found
+  because the item belongs to another owner.
+  Non-goals: deleting any unique content — durable material is absorbed by its
+  canonical owner before its report file is removed.
+  Acceptance oracle: exactly one of each PM artifact tracked; `docs/adr/README.md`
+  indexes numbered ADRs with canonical statuses; no repository-root file outside
+  the enumerable set.
+  Dependencies: none.
+
+- **CFDRS-GA-009 [patch][docs] — Realign book chapter numbering with SUMMARY.md (status=todo, effort=S).**
+  Outcome: every chapter's `# ` heading number matches its position in
+  `docs/book/SUMMARY.md` and its own figure labels.
+  Scope: `core_flows.md` and `governing_equations.md` both open "Chapter 2";
+  `pressure_velocity.md` and `turbulence_multiphase.md` both open "Chapter 3";
+  `crate_schematics.md` opens "Chapter 21" (SUMMARY 13, figure 13.1);
+  `crate_optim.md` opens "Chapter 22" (SUMMARY 19, figure 19.1);
+  `crate_1d_flows.md` 20, `crate_3d_flows.md` 19, `crate_validation.md` 18,
+  `performance_and_atlas.md` 17 against SUMMARY 9, 14, 18, 17; and
+  `cavitation.md`, `matrix_free_operators.md`, `schematic_integration_2d.md`,
+  `vascular_bifurcations.md` carry no number where SUMMARY assigns 6, 11, 15, 8.
+  Non-goals: rewriting chapter content.
+  Acceptance oracle: an xtask check (extendable from `check_figures.rs`) fails
+  when a chapter's heading number disagrees with its SUMMARY position.
+  Dependencies: none. Related: `appendix_glossary.md` said "Appendix C" against
+  SUMMARY's "B"; corrected in this audit.
+
+- **CFDRS-GA-010 [patch][docs] — Fill the stub book chapters (status=todo, effort=M).**
+  Outcome: each chapter teaches its subject rather than pointing elsewhere.
+  Scope: `docs/book/crate_schematics.md` (8 lines: a generated figure and a
+  cross-reference), `core_flows.md` (11 lines), `crate_optim.md` (20),
+  `crate_validation.md` (22), `crate_3d_flows.md` (23), `crate_1d_flows.md` (29).
+  Non-goals: migration guides or status content, which belong to CHANGELOG and
+  the board.
+  Acceptance oracle: each listed chapter derives its governing equations with
+  resolved citations and carries at least one tested code sample.
+  Dependencies: none.
+
+- **CFDRS-GA-011 [patch][docs] — Promote `missing_docs` to deny per crate (status=todo, effort=M).**
+  Outcome: undocumented public API does not compile.
+  Scope: all 11 `crates/*/src/lib.rs` — none currently declares
+  `#![deny(missing_docs)]`; the workspace floor at `Cargo.toml:128` is `warn`
+  and each crate re-declares `#![warn(missing_docs)]`.
+  Non-goals: the workspace floor itself, which stays `warn` until the last
+  crate is promoted.
+  Acceptance oracle: `cargo doc --workspace --no-deps` warning-clean with
+  `deny` active in every member.
+  Dependencies: none. Promote crate by crate, smallest first (`cfd-io` at
+  1807 lines, `cfd-schematic-mesh` at 3590).
+
+- **CFDRS-GA-012 [patch][arch] — Consolidate the duplicate Richardson extrapolation (status=todo, effort=S).**
+  Outcome: one Richardson implementation in `cfd-validation`, returning typed
+  errors.
+  Scope: `crates/cfd-validation/src/convergence/richardson.rs` (224 lines) and
+  `crates/cfd-validation/src/manufactured/richardson/core.rs` (551 lines) —
+  both define `estimate_order`, `extrapolate`, and `is_asymptotic`; the second
+  returns `Result<_, String>` (9 stringly-typed returns in this crate, 56
+  workspace-wide).
+  Non-goals: the GCI reporting layer in `manufactured/richardson/analysis.rs`.
+  Acceptance oracle: one public entry point; its error type is a
+  `cfd-core` error variant; the published three-grid worked example from
+  Roache (1998) is asserted value-semantically against it.
+  Dependencies: none.
+
+- **CFDRS-GA-013 [patch][verification] — Resolve the five capability-admitting `#[ignore]`s (status=todo, effort=M).**
+  Outcome: each ignored test either passes against corrected production code or
+  its requirement is explicitly withdrawn with a recorded reason.
+  Scope: `crates/cfd-1d/tests/component_validation.rs:185` ("Implementation does
+  not clamp parameters to physical bounds"), `:234` ("Valve resistance behavior
+  does not follow expected monotonic relationship"), `:443` ("FlowSensor
+  component API differs from expected"); `crates/cfd-math/tests/amg_coarsening_tests.rs:5,9`
+  ("pending migration of domain-specific multigrid code to leto-ops API").
+  Non-goals: the 27 slowness-motivated ignores.
+  Acceptance oracle: zero `#[ignore]` whose reason describes missing or
+  incorrect behaviour rather than runtime.
+  Dependencies: the two AMG ignores depend on leto-ops coarsening coverage.
+
+- **CFDRS-GA-014 [patch][docs] — Ship a typed Python surface for `cfd-python` (status=todo, effort=S).**
+  Outcome: the PyO3 binding is visible to mypy and IDEs.
+  Scope: `crates/cfd-python` — add `py.typed` and `.pyi` stubs (generated where
+  feasible), and remove the committed `casson_rheology_validation.png` run
+  output from the crate directory.
+  Non-goals: expanding the binding surface.
+  Acceptance oracle: a mypy run over the installed wheel resolves every
+  exported symbol; no image artifact tracked under `crates/cfd-python`.
+  Dependencies: none.
+
+- **CFDRS-GA-015 [patch][arch] — Restore the pedantic floor erased by crate-level allows (status=todo, effort=L).**
+  Outcome: crate-level blanket `#![allow]` gives way to per-site
+  `#[expect(lint, reason = "ratchet <id>")]`, so the ratchet signal the
+  workspace comment at `Cargo.toml:137-141` describes actually survives.
+  Scope: 292 `#![allow(...)]` lines across 10 `lib.rs` files; specifically
+  `crates/cfd-validation/src/lib.rs:1` (`clippy::print_stdout`) and
+  `crates/cfd-3d/src/lib.rs:6` (`print_stderr`), which cancel workspace denies;
+  409 print/`dbg` sites in `crates/*/src`; the 97 `#[allow(` sites (Atlas
+  baseline 89, so +8) against only 5 `#[expect(`.
+  Non-goals: the curated workspace-level `allow` set in `Cargo.toml`, which is
+  the sanctioned noise-control surface.
+  Acceptance oracle: the Atlas conformance scan's `crate_level_allows` and
+  `allow_sites` counts strictly decrease each increment and never increase.
+  Dependencies: none. Burn down per crate.
+
+- **CFDRS-GA-016 [patch][arch] — Move the workspace to edition 2024 / resolver 3 (status=todo, effort=M).**
+  Outcome: the workspace builds on the current edition, so `unsafe_op_in_unsafe_fn`,
+  `unsafe extern`, and let-chains are available and enforced.
+  Scope: `Cargo.toml` (`edition = "2021"`, `resolver = "2"`) and all 12
+  packages; the six `pub unsafe fn` in `crates/cfd-core/src/compute/simd/`
+  gain per-operation `unsafe {}` blocks with one `// SAFETY:` per discharged
+  obligation (17 unsafe sites in library source currently carry 2 such comments).
+  Non-goals: raising the toolchain pin beyond what edition 2024 requires.
+  Acceptance oracle: `cargo check --workspace --all-targets` and `cargo clippy
+  --workspace --all-targets -- -D warnings` green at edition 2024.
+  Dependencies: verify every Atlas provider in the graph resolves under
+  resolver 3 before landing.

--- a/crates/cfd-1d/src/domain/junctions/branching/solver.rs
+++ b/crates/cfd-1d/src/domain/junctions/branching/solver.rs
@@ -6,6 +6,7 @@
 use super::physics::{TwoWayBranchJunction, TwoWayBranchSolution};
 use cfd_core::conversion::SafeFromF64;
 use cfd_core::error::Error;
+use cfd_core::physics::constants::physics::thermo::P_ATM;
 use cfd_core::physics::fluid::traits::Fluid as FluidTrait;
 use cfd_core::physics::fluid::traits::NonNewtonianFluid;
 use cfd_core::CfdScalar;
@@ -98,7 +99,7 @@ impl<T: CfdScalar + Copy + SafeFromF64> BranchingNetworkSolver<T> {
             inlet_flow_rate,
             inlet_pressure,
             T::from_f64_or_one(293.15),   // 20°C standard temperature [K]
-            T::from_f64_or_one(101325.0), // 1 atm [Pa]
+            T::from_f64_or_one(P_ATM), // 1 atm [Pa]
         )
     }
 
@@ -160,7 +161,7 @@ impl<T: CfdScalar + Copy + SafeFromF64> BranchingNetworkSolver<T> {
                 current_flow,
                 current_pressure,
                 T::from_f64_or_one(293.15),
-                T::from_f64_or_one(101325.0),
+                T::from_f64_or_one(P_ATM),
             )?;
 
             solutions.push(solution);
@@ -217,21 +218,21 @@ impl<T: CfdScalar + Copy + SafeFromF64> BranchingNetworkSolver<T> {
             q_ref,
             &junction.parent,
             T::from_f64_or_one(293.15),
-            T::from_f64_or_one(101325.0),
+            T::from_f64_or_one(P_ATM),
         ) / (q_ref + T::from_f64_or_one(1e-15));
         let r_1 = TwoWayBranchJunction::pressure_drop(
             &fluid,
             q_ref / T::from_f64_or_one(2.0),
             &junction.daughter1,
             T::from_f64_or_one(293.15),
-            T::from_f64_or_one(101325.0),
+            T::from_f64_or_one(P_ATM),
         ) / (q_ref / T::from_f64_or_one(2.0) + T::from_f64_or_one(1e-15));
         let r_2 = TwoWayBranchJunction::pressure_drop(
             &fluid,
             q_ref / T::from_f64_or_one(2.0),
             &junction.daughter2,
             T::from_f64_or_one(293.15),
-            T::from_f64_or_one(101325.0),
+            T::from_f64_or_one(P_ATM),
         ) / (q_ref / T::from_f64_or_one(2.0) + T::from_f64_or_one(1e-15));
 
         (r_parent, r_1, r_2)

--- a/crates/cfd-1d/src/domain/junctions/branching/solver.rs
+++ b/crates/cfd-1d/src/domain/junctions/branching/solver.rs
@@ -98,8 +98,8 @@ impl<T: CfdScalar + Copy + SafeFromF64> BranchingNetworkSolver<T> {
             fluid,
             inlet_flow_rate,
             inlet_pressure,
-            T::from_f64_or_one(293.15),   // 20°C standard temperature [K]
-            T::from_f64_or_one(P_ATM), // 1 atm [Pa]
+            T::from_f64_or_one(293.15), // 20°C standard temperature [K]
+            T::from_f64_or_one(P_ATM),  // 1 atm [Pa]
         )
     }
 

--- a/crates/cfd-1d/src/domain/network/builder/blueprint_conversion.rs
+++ b/crates/cfd-1d/src/domain/network/builder/blueprint_conversion.rs
@@ -217,7 +217,7 @@ where
         T::from_f64_or_one(cfd_core::physics::constants::physics::thermo::T_STANDARD),
         T::from_f64_or_zero(cfd_core::physics::constants::physics::thermo::P_ATM),
     )?;
-    let default_hematocrit = T::from_f64_or_zero(0.45);
+    let default_hematocrit = T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::NORMAL_HEMATOCRIT);
     let default_plasma_viscosity =
         blood_state.dynamic_viscosity.into_base() / T::from_f64_or_one(3.2);
 

--- a/crates/cfd-1d/src/domain/network/builder/blueprint_conversion.rs
+++ b/crates/cfd-1d/src/domain/network/builder/blueprint_conversion.rs
@@ -217,7 +217,8 @@ where
         T::from_f64_or_one(cfd_core::physics::constants::physics::thermo::T_STANDARD),
         T::from_f64_or_zero(cfd_core::physics::constants::physics::thermo::P_ATM),
     )?;
-    let default_hematocrit = T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::NORMAL_HEMATOCRIT);
+    let default_hematocrit =
+        T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::NORMAL_HEMATOCRIT);
     let default_plasma_viscosity =
         blood_state.dynamic_viscosity.into_base() / T::from_f64_or_one(3.2);
 

--- a/crates/cfd-1d/src/domain/network/junction_losses.rs
+++ b/crates/cfd-1d/src/domain/network/junction_losses.rs
@@ -47,10 +47,10 @@ where
     // Derive fluid density from the network's fluid model at reference conditions
     // (body temperature 310.15 K, atmospheric pressure 101 325 Pa).
     // Falls back to 1060 kg/m³ (whole-blood reference) if the fluid query fails.
-    let rho_ref_t = T::from_f64_or_zero(310.15);
-    let p_ref_t = T::from_f64_or_zero(101_325.0);
+    let rho_ref_t = T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::BODY_TEMPERATURE_K);
+    let p_ref_t = T::from_f64_or_zero(cfd_core::physics::constants::physics::thermo::P_ATM);
     let rho_blood: T = network.fluid.properties_at(rho_ref_t, p_ref_t).map_or_else(
-        |_| T::from_f64_or_zero(1060.0),
+        |_| T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
         |state| state.density.into_base(),
     );
     let two: T = T::ONE + T::ONE;

--- a/crates/cfd-1d/src/domain/network/junction_losses.rs
+++ b/crates/cfd-1d/src/domain/network/junction_losses.rs
@@ -47,7 +47,8 @@ where
     // Derive fluid density from the network's fluid model at reference conditions
     // (body temperature 310.15 K, atmospheric pressure 101 325 Pa).
     // Falls back to 1060 kg/m³ (whole-blood reference) if the fluid query fails.
-    let rho_ref_t = T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::BODY_TEMPERATURE_K);
+    let rho_ref_t =
+        T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::BODY_TEMPERATURE_K);
     let p_ref_t = T::from_f64_or_zero(cfd_core::physics::constants::physics::thermo::P_ATM);
     let rho_blood: T = network.fluid.properties_at(rho_ref_t, p_ref_t).map_or_else(
         |_| T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),

--- a/crates/cfd-1d/src/domain/network/wrapper.rs
+++ b/crates/cfd-1d/src/domain/network/wrapper.rs
@@ -503,7 +503,9 @@ impl<T: CfdScalar + Copy, F: FluidTrait<T>> Network<T, F> {
             sixty_four: T::from_f64_or_one(64.0),
             eight: T::from_f64_or_one(8.0),
             microchannel_limit: T::from_f64_or_one(300.0e-6),
-            default_hematocrit: T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::NORMAL_HEMATOCRIT),
+            default_hematocrit: T::from_f64_or_zero(
+                cfd_core::physics::fluid::blood::constants::NORMAL_HEMATOCRIT,
+            ),
             default_plasma_viscosity: state.dynamic_viscosity.into_base() / T::from_f64_or_one(3.2),
             tiny: T::from_f64_or(epsilon.to_f64().max(1.0e-7), epsilon),
         })

--- a/crates/cfd-1d/src/domain/network/wrapper.rs
+++ b/crates/cfd-1d/src/domain/network/wrapper.rs
@@ -503,7 +503,7 @@ impl<T: CfdScalar + Copy, F: FluidTrait<T>> Network<T, F> {
             sixty_four: T::from_f64_or_one(64.0),
             eight: T::from_f64_or_one(8.0),
             microchannel_limit: T::from_f64_or_one(300.0e-6),
-            default_hematocrit: T::from_f64_or_zero(0.45),
+            default_hematocrit: T::from_f64_or_zero(cfd_core::physics::fluid::blood::constants::NORMAL_HEMATOCRIT),
             default_plasma_viscosity: state.dynamic_viscosity.into_base() / T::from_f64_or_one(3.2),
             tiny: T::from_f64_or(epsilon.to_f64().max(1.0e-7), epsilon),
         })

--- a/crates/cfd-1d/src/physics/hemolysis/models.rs
+++ b/crates/cfd-1d/src/physics/hemolysis/models.rs
@@ -19,7 +19,7 @@ use aequitas::systems::si::quantities::{Pressure, Time};
 /// use aequitas::systems::si::quantities::{Pressure, Time};
 /// use cfd_1d::giersiepen_hi;
 /// let hi = giersiepen_hi(Pressure::from_base(50.0), Time::from_base(0.01));
-/// assert!((hi - 2.578_444_864_181_722_3e-3).abs() < 1e-15);
+/// assert!((hi - 1.239_995_476_925_157_9e-4).abs() < 1e-15);
 /// ```
 #[inline]
 #[must_use]

--- a/crates/cfd-1d/src/physics/vascular/bifurcation.rs
+++ b/crates/cfd-1d/src/physics/vascular/bifurcation.rs
@@ -328,8 +328,12 @@ impl<T: CfdScalar + FloatElement + Copy> BifurcationNetwork<T> {
             inlet_pressure: Pressure::from_base(<T as FloatElement>::from_f64(13_332.0)),
             // 100 mmHg
             outlet_resistance: HydraulicResistance::from_base(<T as FloatElement>::from_f64(1e9)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+            )),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            )),
         }
     }
 

--- a/crates/cfd-1d/src/physics/vascular/bifurcation.rs
+++ b/crates/cfd-1d/src/physics/vascular/bifurcation.rs
@@ -328,8 +328,8 @@ impl<T: CfdScalar + FloatElement + Copy> BifurcationNetwork<T> {
             inlet_pressure: Pressure::from_base(<T as FloatElement>::from_f64(13_332.0)),
             // 100 mmHg
             outlet_resistance: HydraulicResistance::from_base(<T as FloatElement>::from_f64(1e9)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(1060.0)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.0035)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
         }
     }
 

--- a/crates/cfd-1d/src/physics/vascular/womersley/mod.rs
+++ b/crates/cfd-1d/src/physics/vascular/womersley/mod.rs
@@ -115,8 +115,12 @@ impl<T: CfdScalar + FloatElement + Copy> WomersleyNumber<T> {
         Self {
             radius: Length::from_base(<T as FloatElement>::from_f64(0.0125)),
             omega: ReciprocalTime::from_base(<T as FloatElement>::from_f64(2.0 * PI * 1.2)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+            )),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            )),
         }
     }
 
@@ -126,8 +130,12 @@ impl<T: CfdScalar + FloatElement + Copy> WomersleyNumber<T> {
         Self {
             radius: Length::from_base(<T as FloatElement>::from_f64(0.003)),
             omega: ReciprocalTime::from_base(<T as FloatElement>::from_f64(2.0 * PI * 1.2)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+            )),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            )),
         }
     }
 

--- a/crates/cfd-1d/src/physics/vascular/womersley/mod.rs
+++ b/crates/cfd-1d/src/physics/vascular/womersley/mod.rs
@@ -115,8 +115,8 @@ impl<T: CfdScalar + FloatElement + Copy> WomersleyNumber<T> {
         Self {
             radius: Length::from_base(<T as FloatElement>::from_f64(0.0125)),
             omega: ReciprocalTime::from_base(<T as FloatElement>::from_f64(2.0 * PI * 1.2)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(1060.0)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.0035)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
         }
     }
 
@@ -126,8 +126,8 @@ impl<T: CfdScalar + FloatElement + Copy> WomersleyNumber<T> {
         Self {
             radius: Length::from_base(<T as FloatElement>::from_f64(0.003)),
             omega: ReciprocalTime::from_base(<T as FloatElement>::from_f64(2.0 * PI * 1.2)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(1060.0)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.0035)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
         }
     }
 

--- a/crates/cfd-2d/src/fields.rs
+++ b/crates/cfd-2d/src/fields.rs
@@ -261,6 +261,12 @@ pub struct SimulationFields<T: CfdScalar + Copy> {
     pub force_u: Field2D<T>,
     /// External force Y-component (e.g. gravity, IBM)
     pub force_v: Field2D<T>,
+    /// Rhie–Chow mass flux velocity at the east face of each cell
+    /// (the face between nodes (i, j) and (i + 1, j))
+    pub u_face_e: Field2D<T>,
+    /// Rhie–Chow mass flux velocity at the north face of each cell
+    /// (the face between nodes (i, j) and (i, j + 1))
+    pub v_face_n: Field2D<T>,
     /// Mask field (true = fluid, false = solid)
     pub mask: Field2D<bool>,
     /// Grid dimensions
@@ -289,6 +295,8 @@ impl<T: CfdScalar + Copy + FloatElement> SimulationFields<T> {
             viscosity: Field2D::new(nx, ny, <T as FloatElement>::from_f64(0.001)),
             force_u: Field2D::new(nx, ny, scalar::zero()),
             force_v: Field2D::new(nx, ny, scalar::zero()),
+            u_face_e: Field2D::new(nx, ny, scalar::zero()),
+            v_face_n: Field2D::new(nx, ny, scalar::zero()),
             mask: Field2D::new(nx, ny, true),
             nx,
             ny,
@@ -320,6 +328,8 @@ impl<T: CfdScalar + Copy + FloatElement> SimulationFields<T> {
         self.p_prime.map_inplace(|val| *val = scalar::zero());
         self.force_u.map_inplace(|val| *val = scalar::zero());
         self.force_v.map_inplace(|val| *val = scalar::zero());
+        self.u_face_e.map_inplace(|val| *val = scalar::zero());
+        self.v_face_n.map_inplace(|val| *val = scalar::zero());
     }
 }
 
@@ -351,6 +361,8 @@ impl<T: CfdScalar + Copy> SimulationFields<T> {
         self.viscosity.data.copy_from_slice(&other.viscosity.data);
         self.force_u.data.copy_from_slice(&other.force_u.data);
         self.force_v.data.copy_from_slice(&other.force_v.data);
+        self.u_face_e.data.copy_from_slice(&other.u_face_e.data);
+        self.v_face_n.data.copy_from_slice(&other.v_face_n.data);
         self.mask.data.copy_from_slice(&other.mask.data);
 
         Ok(())

--- a/crates/cfd-2d/src/network/channel.rs
+++ b/crates/cfd-2d/src/network/channel.rs
@@ -118,7 +118,9 @@ where
         {
             let cnf = CellTrackerConfig {
                 viscosity: DynamicViscosity::from_base(entry.viscosity_pa_s),
-                fluid_density: MassDensity::from_base(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
+                fluid_density: MassDensity::from_base(
+                    cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+                ),
                 hydraulic_diameter: entry.cross_section.hydraulic_diameter(),
                 u_max: Velocity::from_base(u_mean.abs()),
                 ..Default::default()

--- a/crates/cfd-2d/src/network/channel.rs
+++ b/crates/cfd-2d/src/network/channel.rs
@@ -118,7 +118,7 @@ where
         {
             let cnf = CellTrackerConfig {
                 viscosity: DynamicViscosity::from_base(entry.viscosity_pa_s),
-                fluid_density: MassDensity::from_base(1060.0),
+                fluid_density: MassDensity::from_base(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
                 hydraulic_diameter: entry.cross_section.hydraulic_diameter(),
                 u_max: Velocity::from_base(u_mean.abs()),
                 ..Default::default()

--- a/crates/cfd-2d/src/network/reference.rs
+++ b/crates/cfd-2d/src/network/reference.rs
@@ -404,9 +404,15 @@ where
         "Blood reference fluid".to_string(),
         MassDensity::from_base(<T as FloatElement>::from_f64(density_kg_m3)),
         DynamicViscosity::from_base(<T as FloatElement>::from_f64(viscosity_pa_s)),
-        SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_SPECIFIC_HEAT)),
-        ThermalConductivity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_THERMAL_CONDUCTIVITY)),
-        Velocity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND)),
+        SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_SPECIFIC_HEAT,
+        )),
+        ThermalConductivity::from_base(<T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_THERMAL_CONDUCTIVITY,
+        )),
+        Velocity::from_base(<T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND,
+        )),
     );
     fluid.validate()?;
     Ok(fluid)

--- a/crates/cfd-2d/src/network/reference.rs
+++ b/crates/cfd-2d/src/network/reference.rs
@@ -404,9 +404,9 @@ where
         "Blood reference fluid".to_string(),
         MassDensity::from_base(<T as FloatElement>::from_f64(density_kg_m3)),
         DynamicViscosity::from_base(<T as FloatElement>::from_f64(viscosity_pa_s)),
-        SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(3617.0)),
-        ThermalConductivity::from_base(<T as FloatElement>::from_f64(0.52)),
-        Velocity::from_base(<T as FloatElement>::from_f64(1570.0)),
+        SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_SPECIFIC_HEAT)),
+        ThermalConductivity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_THERMAL_CONDUCTIVITY)),
+        Velocity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND)),
     );
     fluid.validate()?;
     Ok(fluid)

--- a/crates/cfd-2d/src/physics/acoustics/gorkov.rs
+++ b/crates/cfd-2d/src/physics/acoustics/gorkov.rs
@@ -61,8 +61,8 @@ impl<T: CfdScalar + Copy + FloatElement> GorkovPotential<T> {
     #[must_use]
     pub fn typical_rbc() -> Self {
         Self {
-            fluid_density: <T as FloatElement>::from_f64(1000.0),
-            fluid_sound_speed: <T as FloatElement>::from_f64(1500.0),
+            fluid_density: <T as FloatElement>::from_f64(cfd_core::physics::constants::physics::fluid::WATER_DENSITY),
+            fluid_sound_speed: <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX),
             particle_density: <T as FloatElement>::from_f64(1090.0),
             particle_sound_speed: <T as FloatElement>::from_f64(1639.0),
             particle_radius: <T as FloatElement>::from_f64(2.5e-6),
@@ -195,13 +195,20 @@ mod tests {
     /// Analytical f1 and f2 for RBC in plasma.
     /// f1 = 1 − κ_p/κ_0 = 1 − (ρ₀c₀²)/(ρ_pc_p²)
     /// f2 = 2(ρ_p − ρ₀)/(2ρ_p + ρ₀)
+    ///
+    /// The carrier-fluid expectation is derived from the same SSOT constants
+    /// used by [`GorkovPotential::typical_rbc`] (blood, not pure water).
     #[test]
     fn f1_f2_analytical_values() {
+        let rho_0 =
+            cfd_core::physics::constants::physics::fluid::WATER_DENSITY as f64;
+        let c_0 =
+            cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX as f64;
         let rbc = GorkovPotential::<f64>::typical_rbc();
-        let kappa_0 = 1.0 / (1000.0 * 1500.0_f64.powi(2));
+        let kappa_0 = 1.0 / (rho_0 * c_0.powi(2));
         let kappa_p = 1.0 / (1090.0 * 1639.0_f64.powi(2));
         let f1_expected = 1.0 - kappa_p / kappa_0;
-        let f2_expected = 2.0 * (1090.0 - 1000.0) / (2.0 * 1090.0 + 1000.0);
+        let f2_expected = 2.0 * (1090.0 - rho_0) / (2.0 * 1090.0 + rho_0);
 
         assert_relative_eq!(rbc.f1_monopole(), f1_expected, epsilon = 1e-10);
         assert_relative_eq!(rbc.f2_dipole(), f2_expected, epsilon = 1e-10);

--- a/crates/cfd-2d/src/physics/acoustics/gorkov.rs
+++ b/crates/cfd-2d/src/physics/acoustics/gorkov.rs
@@ -61,8 +61,12 @@ impl<T: CfdScalar + Copy + FloatElement> GorkovPotential<T> {
     #[must_use]
     pub fn typical_rbc() -> Self {
         Self {
-            fluid_density: <T as FloatElement>::from_f64(cfd_core::physics::constants::physics::fluid::WATER_DENSITY),
-            fluid_sound_speed: <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX),
+            fluid_density: <T as FloatElement>::from_f64(
+                cfd_core::physics::constants::physics::fluid::WATER_DENSITY,
+            ),
+            fluid_sound_speed: <T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX,
+            ),
             particle_density: <T as FloatElement>::from_f64(1090.0),
             particle_sound_speed: <T as FloatElement>::from_f64(1639.0),
             particle_radius: <T as FloatElement>::from_f64(2.5e-6),
@@ -200,10 +204,8 @@ mod tests {
     /// used by [`GorkovPotential::typical_rbc`] (blood, not pure water).
     #[test]
     fn f1_f2_analytical_values() {
-        let rho_0 =
-            cfd_core::physics::constants::physics::fluid::WATER_DENSITY as f64;
-        let c_0 =
-            cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX as f64;
+        let rho_0 = cfd_core::physics::constants::physics::fluid::WATER_DENSITY;
+        let c_0 = cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX;
         let rbc = GorkovPotential::<f64>::typical_rbc();
         let kappa_0 = 1.0 / (rho_0 * c_0.powi(2));
         let kappa_p = 1.0 / (1090.0 * 1639.0_f64.powi(2));

--- a/crates/cfd-2d/src/physics/momentum/coefficients.rs
+++ b/crates/cfd-2d/src/physics/momentum/coefficients.rs
@@ -417,12 +417,14 @@ impl<T: CfdScalar + Copy + FloatElement> MomentumCoefficients<T> {
                     *ap = ap_val;
                 }
 
-                // SIMPLEC consistent diagonal: aP - gamma * sum(aNb)
-                // This represents the part of aP that does not depend on neighbor velocities.
-                // For SIMPLEC consistency, we use this in the velocity correction equation.
+                // SIMPLEC consistent diagonal: aP − sum(aNb)
+                // Van Doormaal & Raithby (1984) approximate the neighbour
+                // velocity corrections u'_nb ≈ u'_P, which folds the neighbour
+                // contribution into the diagonal and requires the FULL
+                // a_P − Σa_nb here. Prior to 2026-08-20 an ad-hoc γ = 0.85
+                // blend was used instead of the published γ = 1.
                 if let Some(ap_c) = self.ap_consistent.at_mut(i, j) {
-                    let gamma: T = <T as FloatElement>::from_f64(0.85);
-                    let val = ap_val - ap_sum * gamma;
+                    let val = ap_val - ap_sum;
                     let eps: T = <T as FloatElement>::from_f64(1e-10);
 
                     *ap_c = if val > eps { val } else { eps };

--- a/crates/cfd-2d/src/physics/non_newtonian/carreau_yasuda.rs
+++ b/crates/cfd-2d/src/physics/non_newtonian/carreau_yasuda.rs
@@ -61,7 +61,9 @@ impl<T: FloatElement> CarreauYasudaModel<T> {
     #[must_use]
     pub fn typical_blood() -> Self {
         Self {
-            density: <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
+            density: <T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+            ),
             mu_0: <T as FloatElement>::from_f64(0.022),
             mu_inf: <T as FloatElement>::from_f64(0.0022),
             lambda: <T as FloatElement>::from_f64(0.11),

--- a/crates/cfd-2d/src/physics/non_newtonian/carreau_yasuda.rs
+++ b/crates/cfd-2d/src/physics/non_newtonian/carreau_yasuda.rs
@@ -61,7 +61,7 @@ impl<T: FloatElement> CarreauYasudaModel<T> {
     #[must_use]
     pub fn typical_blood() -> Self {
         Self {
-            density: <T as FloatElement>::from_f64(1060.0),
+            density: <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
             mu_0: <T as FloatElement>::from_f64(0.022),
             mu_inf: <T as FloatElement>::from_f64(0.0022),
             lambda: <T as FloatElement>::from_f64(0.11),

--- a/crates/cfd-2d/src/physics/turbulence/reynolds_stress/transport/solver.rs
+++ b/crates/cfd-2d/src/physics/turbulence/reynolds_stress/transport/solver.rs
@@ -1,12 +1,12 @@
 //! Core Reynolds stress transport solver — optimised block-cached implementation.
 
-use super::super::PressureStrainModel;
 use super::super::diffusion::{dissipation_tensor_optimized, turbulent_transport};
 use super::super::model::ReynoldsStressModel;
 use super::super::pressure_strain::{
     pressure_strain_linear, pressure_strain_quadratic, pressure_strain_ssg,
 };
 use super::super::tensor::ReynoldsStressTensor;
+use super::super::PressureStrainModel;
 use super::EPSILON_MIN;
 use cfd_core::error::Result;
 use eunomia::RealField;

--- a/crates/cfd-2d/src/physics/turbulence/reynolds_stress/transport/solver.rs
+++ b/crates/cfd-2d/src/physics/turbulence/reynolds_stress/transport/solver.rs
@@ -1,12 +1,12 @@
 //! Core Reynolds stress transport solver — optimised block-cached implementation.
 
+use super::super::PressureStrainModel;
 use super::super::diffusion::{dissipation_tensor_optimized, turbulent_transport};
 use super::super::model::ReynoldsStressModel;
 use super::super::pressure_strain::{
     pressure_strain_linear, pressure_strain_quadratic, pressure_strain_ssg,
 };
 use super::super::tensor::ReynoldsStressTensor;
-use super::super::PressureStrainModel;
 use super::EPSILON_MIN;
 use cfd_core::error::Result;
 use eunomia::RealField;

--- a/crates/cfd-2d/src/piso_algorithm/corrector.rs
+++ b/crates/cfd-2d/src/piso_algorithm/corrector.rs
@@ -40,6 +40,10 @@ impl<T: CfdScalar + Copy + FloatElement> PressureCorrector<T> {
 
     /// Perform pressure correction steps
     pub fn correct(&self, fields: &mut SimulationFields<T>, dt: T) -> Result<()> {
+        // Seed the face-flux containers from the predicted nodal field so
+        // every corrector reads a consistent face-based mass imbalance.
+        self.seed_face_fluxes(fields);
+
         for corrector in 0..self.num_correctors {
             // Solve pressure correction equation
             let p_prime = self.solve_pressure_correction(fields, dt)?;
@@ -50,13 +54,39 @@ impl<T: CfdScalar + Copy + FloatElement> PressureCorrector<T> {
             // Correct velocity field
             self.correct_velocity(fields, &p_prime, dt);
 
-            // Update face fluxes for next corrector (if any)
+            // Refresh Rhie–Chow face fluxes for the next corrector (if any)
             if corrector < self.num_correctors - 1 {
                 self.update_face_fluxes(fields, dt);
             }
         }
 
         Ok(())
+    }
+
+    /// Initialize the face-flux containers from nodal velocity averages.
+    ///
+    /// The east face of cell (i, j) is the face between nodes (i, j) and
+    /// (i + 1, j); the north face is between (i, j) and (i, j + 1).
+    fn seed_face_fluxes(&self, fields: &mut SimulationFields<T>) {
+        let two_t = scalar::one::<T>() + scalar::one::<T>();
+        for i in 0..self.nx {
+            for j in 0..self.ny {
+                if let Some(uf) = fields.u_face_e.at_mut(i, j) {
+                    *uf = if i + 1 < self.nx {
+                        (fields.u.at(i, j) + fields.u.at(i + 1, j)) / two_t
+                    } else {
+                        fields.u.at(i, j)
+                    };
+                }
+                if let Some(vf) = fields.v_face_n.at_mut(i, j) {
+                    *vf = if j + 1 < self.ny {
+                        (fields.v.at(i, j) + fields.v.at(i, j + 1)) / two_t
+                    } else {
+                        fields.v.at(i, j)
+                    };
+                }
+            }
+        }
     }
 
     /// Solve pressure correction equation according to Issa (1986)
@@ -84,11 +114,15 @@ impl<T: CfdScalar + Copy + FloatElement> PressureCorrector<T> {
                     let mass_imbalance =
                         self.calculate_mass_imbalance_with_h(fields, &h_operator, i, j);
 
-                    // Calculate coefficients
-                    let ae = fields.density.at(i, j) * self.dy * dt / self.dx;
-                    let aw = fields.density.at(i, j) * self.dy * dt / self.dx;
-                    let an = fields.density.at(i, j) * self.dx * dt / self.dy;
-                    let as_ = fields.density.at(i, j) * self.dx * dt / self.dy;
+                    // Calculate coefficients. The velocity correction applies
+                    // δu = −(Δt/ρ)∇p′, so the ρ cancels in the resulting mass-flux
+                    // change and the p′ Poisson coefficients carry no density.
+                    // Prior to 2026-08-20 a spurious ρ scaled the LHS only,
+                    // under-correcting the velocity by 1/ρ² for ρ ≠ 1.
+                    let ae = self.dy * dt / self.dx;
+                    let aw = self.dy * dt / self.dx;
+                    let an = self.dx * dt / self.dy;
+                    let as_ = self.dx * dt / self.dy;
                     let ap = ae + aw + an + as_;
 
                     // Update pressure correction
@@ -215,14 +249,17 @@ impl<T: CfdScalar + Copy + FloatElement> PressureCorrector<T> {
     }
 
     /// Calculate mass imbalance at a cell
+    ///
+    /// Reads the face-flux containers: the east face of cell (i, j) is
+    /// `u_face_e[(i, j)]` and the west face is `u_face_e[(i − 1, j)]`.
     fn calculate_mass_imbalance(&self, fields: &SimulationFields<T>, i: usize, j: usize) -> T {
         let rho = fields.density.at(i, j);
 
         // Face mass fluxes
-        let me = rho * fields.u.at(i + 1, j) * self.dy;
-        let mw = rho * fields.u.at(i, j) * self.dy;
-        let mn = rho * fields.v.at(i, j + 1) * self.dx;
-        let ms = rho * fields.v.at(i, j) * self.dx;
+        let me = rho * fields.u_face_e.at(i, j) * self.dy;
+        let mw = rho * fields.u_face_e.at(i - 1, j) * self.dy;
+        let mn = rho * fields.v_face_n.at(i, j) * self.dx;
+        let ms = rho * fields.v_face_n.at(i, j - 1) * self.dx;
 
         // Mass imbalance (should be zero for continuity)
         me - mw + mn - ms
@@ -283,6 +320,11 @@ impl<T: CfdScalar + Copy + FloatElement> PressureCorrector<T> {
     ///
     /// Omitting `(∇p)_cells` reduces this to plain pressure interpolation which does
     /// NOT suppress checkerboard oscillations. Both terms are mathematically mandatory.
+    ///
+    /// The interpolated values are stored in the dedicated face-flux containers
+    /// `u_face_e`/`v_face_n`. Prior to 2026-08-20 they were written into the
+    /// nodal velocity fields, shifting the field by half a cell and discarding
+    /// the just-applied nodal pressure correction.
     fn update_face_fluxes(&self, fields: &mut SimulationFields<T>, dt: T) {
         let tiny = <T as FloatElement>::from_f64(1e-30);
         for i in 1..self.nx - 1 {
@@ -334,11 +376,11 @@ impl<T: CfdScalar + Copy + FloatElement> PressureCorrector<T> {
 
                 let v_corrected = v_bar + d_v * (dp_dy_cells - dp_dy_face);
 
-                if let Some(u) = fields.u.at_mut(i, j) {
-                    *u = u_corrected;
+                if let Some(uf) = fields.u_face_e.at_mut(i, j) {
+                    *uf = u_corrected;
                 }
-                if let Some(v) = fields.v.at_mut(i, j) {
-                    *v = v_corrected;
+                if let Some(vf) = fields.v_face_n.at_mut(i, j) {
+                    *vf = v_corrected;
                 }
             }
         }

--- a/crates/cfd-2d/src/piso_algorithm/predictor.rs
+++ b/crates/cfd-2d/src/piso_algorithm/predictor.rs
@@ -296,11 +296,7 @@ mod tests {
         }
 
         let before = (0..8)
-            .map(|i| {
-                (0..8)
-                    .map(|j| fields.u.at(i, j))
-                    .collect::<Vec<_>>()
-            })
+            .map(|i| (0..8).map(|j| fields.u.at(i, j)).collect::<Vec<_>>())
             .collect::<Vec<_>>();
 
         predictor.predict(&mut fields, 0.01).expect("predict ok");

--- a/crates/cfd-2d/src/piso_algorithm/predictor.rs
+++ b/crates/cfd-2d/src/piso_algorithm/predictor.rs
@@ -50,25 +50,29 @@ impl<T: CfdScalar + Copy + FloatElement> VelocityPredictor<T> {
         // Solve momentum equations without pressure gradient
         for i in 1..self.nx - 1 {
             for j in 1..self.ny - 1 {
-                // Get velocities at cell faces (linear interpolation)
+                // Face velocities (linear interpolation). The mass flux
+                // through the east/west faces of either momentum CV is carried
+                // by the u component; through the north/south faces by the v
+                // component.
                 let half = <T as FloatElement>::from_f64(HALF);
                 let ue = (fields.u.at(i, j) + fields.u.at(i + 1, j)) * half;
                 let uw = (fields.u.at(i - 1, j) + fields.u.at(i, j)) * half;
-                let un = (fields.u.at(i, j) + fields.u.at(i, j + 1)) * half;
-                let us = (fields.u.at(i, j - 1) + fields.u.at(i, j)) * half;
-
-                let ve = (fields.v.at(i, j) + fields.v.at(i + 1, j)) * half;
-                let vw = (fields.v.at(i - 1, j) + fields.v.at(i, j)) * half;
                 let vn = (fields.v.at(i, j) + fields.v.at(i, j + 1)) * half;
                 let vs = (fields.v.at(i, j - 1) + fields.v.at(i, j)) * half;
 
                 // Convective terms (using upwind scheme)
-                let conv_u = self.calculate_convection_u(fields, i, j, ue, uw, un, us);
-                let conv_v = self.calculate_convection_v(fields, i, j, ve, vw, vn, vs);
+                let conv_u = self.calculate_convection_u(fields, i, j, ue, uw, vn, vs);
+                let conv_v = self.calculate_convection_v(fields, i, j, ue, uw, vn, vs);
 
                 // Diffusive terms (central difference)
                 let diff_u = self.calculate_diffusion_u(fields, i, j);
                 let diff_v = self.calculate_diffusion_v(fields, i, j);
+
+                // Pressure gradient at the current iterate (Issa 1986
+                // predictor: A u* = H(u^n) − ∇p^n).
+                let two_cell = <T as FloatElement>::from_f64(TWO);
+                let dp_dx = (fields.p.at(i + 1, j) - fields.p.at(i - 1, j)) / (two_cell * self.dx);
+                let dp_dy = (fields.p.at(i, j + 1) - fields.p.at(i, j - 1)) / (two_cell * self.dy);
 
                 // Time integration: Explicit Euler (first-order) for predictor step.
                 // Higher-order schemes (RK4, BDF2) can be added as solver enhancements.
@@ -76,10 +80,10 @@ impl<T: CfdScalar + Copy + FloatElement> VelocityPredictor<T> {
                 let v_current = fields.v.at(i, j);
 
                 if let Some(u) = u_star.at_mut(i, j) {
-                    *u = u_current + dt * (diff_u - conv_u) / fields.density.at(i, j);
+                    *u = u_current + dt * (diff_u - conv_u - dp_dx) / fields.density.at(i, j);
                 }
                 if let Some(v) = v_star.at_mut(i, j) {
-                    *v = v_current + dt * (diff_v - conv_v) / fields.density.at(i, j);
+                    *v = v_current + dt * (diff_v - conv_v - dp_dy) / fields.density.at(i, j);
                 }
             }
         }
@@ -105,6 +109,10 @@ impl<T: CfdScalar + Copy + FloatElement> VelocityPredictor<T> {
     }
 
     /// Calculate convection term for u-velocity
+    ///
+    /// `ue`/`uw` are the east/west face mass-flux velocities (u component);
+    /// `vn`/`vs` are the north/south face mass-flux velocities (v component).
+    /// The advected quantity is the u-velocity.
     fn calculate_convection_u(
         &self,
         fields: &SimulationFields<T>,
@@ -112,8 +120,8 @@ impl<T: CfdScalar + Copy + FloatElement> VelocityPredictor<T> {
         j: usize,
         ue: T,
         uw: T,
-        un: T,
-        us: T,
+        vn: T,
+        vs: T,
     ) -> T {
         let rho = fields.density.at(i, j);
 
@@ -130,45 +138,49 @@ impl<T: CfdScalar + Copy + FloatElement> VelocityPredictor<T> {
             rho * uw * fields.u.at(i, j)
         };
 
-        let f_n = if un > scalar::zero::<T>() {
-            rho * un * fields.u.at(i, j)
+        let f_n = if vn > scalar::zero::<T>() {
+            rho * vn * fields.u.at(i, j)
         } else {
-            rho * un * fields.u.at(i, j + 1)
+            rho * vn * fields.u.at(i, j + 1)
         };
 
-        let f_s = if us > scalar::zero::<T>() {
-            rho * us * fields.u.at(i, j - 1)
+        let f_s = if vs > scalar::zero::<T>() {
+            rho * vs * fields.u.at(i, j - 1)
         } else {
-            rho * us * fields.u.at(i, j)
+            rho * vs * fields.u.at(i, j)
         };
 
         (fe - fw) / self.dx + (f_n - f_s) / self.dy
     }
 
     /// Calculate convection term for v-velocity
+    ///
+    /// `ue`/`uw` are the east/west face mass-flux velocities (u component);
+    /// `vn`/`vs` are the north/south face mass-flux velocities (v component).
+    /// The advected quantity is the v-velocity.
     fn calculate_convection_v(
         &self,
         fields: &SimulationFields<T>,
         i: usize,
         j: usize,
-        ve: T,
-        vw: T,
+        ue: T,
+        uw: T,
         vn: T,
         vs: T,
     ) -> T {
         let rho = fields.density.at(i, j);
 
         // Upwind scheme
-        let fe = if ve > scalar::zero::<T>() {
-            rho * ve * fields.v.at(i, j)
+        let fe = if ue > scalar::zero::<T>() {
+            rho * ue * fields.v.at(i, j)
         } else {
-            rho * ve * fields.v.at(i + 1, j)
+            rho * ue * fields.v.at(i + 1, j)
         };
 
-        let fw = if vw > scalar::zero::<T>() {
-            rho * vw * fields.v.at(i - 1, j)
+        let fw = if uw > scalar::zero::<T>() {
+            rho * uw * fields.v.at(i - 1, j)
         } else {
-            rho * vw * fields.v.at(i, j)
+            rho * uw * fields.v.at(i, j)
         };
 
         let f_n = if vn > scalar::zero::<T>() {
@@ -259,6 +271,48 @@ mod tests {
             for j in 0..8 {
                 assert!(fields.u.at(i, j).is_finite());
                 assert!(fields.v.at(i, j).is_finite());
+            }
+        }
+    }
+
+    #[test]
+    fn shear_flow_with_no_transverse_velocity_is_unmodified() {
+        // u = 0.01·y, v = 0, p = const: the exact convective term
+        // ρ(u·∇)u = ρ(v ∂u/∂y) + ρ(u ∂u/∂x) vanishes because v = 0 and
+        // ∂u/∂x = 0; diffusion of a linear profile also vanishes. The
+        // predictor must therefore leave the field unchanged. Using the
+        // same-component velocity for the north/south mass fluxes produced
+        // a spurious ρ ∂(u²)/∂y and corrupted the field.
+        let grid = make_grid(8);
+        let predictor = VelocityPredictor::new(&grid, 1.0);
+        let mut fields: SimulationFields<f64> = SimulationFields::new(8, 8);
+
+        for i in 0..8 {
+            for j in 0..8 {
+                if let Some(u) = fields.u.at_mut(i, j) {
+                    *u = 0.01 * (j as f64);
+                }
+            }
+        }
+
+        let before = (0..8)
+            .map(|i| {
+                (0..8)
+                    .map(|j| fields.u.at(i, j))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        predictor.predict(&mut fields, 0.01).expect("predict ok");
+
+        for i in 0..8 {
+            for j in 0..8 {
+                let expected = before[i][j];
+                assert!(
+                    (fields.u.at(i, j) - expected).abs() < 1e-12,
+                    "u[{i}][{j}] = {}, expected unchanged {expected}",
+                    fields.u.at(i, j)
+                );
             }
         }
     }

--- a/crates/cfd-2d/src/schemes/tvd/muscl.rs
+++ b/crates/cfd-2d/src/schemes/tvd/muscl.rs
@@ -103,11 +103,14 @@ impl<T: CfdScalar + Copy + FloatElement> MUSCLScheme<T> {
             let slope1 = self.limited_slope(phi_im1, phi_i, phi_ip1);
             let slope2 = self.limited_slope(phi_i, phi_ip1, phi_ip2);
 
-            let quick = (<T as FloatElement>::from_f64(6.0) * phi_i
-                - <T as FloatElement>::from_f64(2.0) * phi_im1
-                + <T as FloatElement>::from_f64(8.0) * phi_ip1
-                - phi_ip2)
-                / <T as FloatElement>::from_f64(12.0);
+            // κ = 1/3 upwind-biased left state (van Leer 1977), matching the
+            // documented formula in schemes/tvd/mod.rs. Prior to 2026-08-20
+            // the coefficients (6, −2, 8, −1)/12 summed to 11/12 and failed
+            // to reproduce even a constant field.
+            let quick = (-phi_im1
+                + <T as FloatElement>::from_f64(5.0) * phi_i
+                + <T as FloatElement>::from_f64(2.0) * phi_ip1)
+                / <T as FloatElement>::from_f64(6.0);
 
             let muscl2 = self.reconstruct_left_muscl2(phi_im1, phi_i, phi_ip1);
             let r = if <T as NumericElement>::abs(slope1) > T::default_epsilon() {
@@ -136,9 +139,12 @@ impl<T: CfdScalar + Copy + FloatElement> MUSCLScheme<T> {
             let slope1 = self.limited_slope(phi_im1, phi_i, phi_ip1);
             let slope2 = self.limited_slope(phi_i, phi_ip1, phi_ip2);
 
-            let quick = (-phi_i
+            // Mirrored κ = 1/3 right state. Prior to 2026-08-20 the φ_i and
+            // φ_{i+2} coefficients were sign-flipped ((−φ_i + 5φ_{i+1} +
+            // 2φ_{i+2})/6), which returned 3/2 instead of 1/2 for φ = x.
+            let quick = (<T as FloatElement>::from_f64(2.0) * phi_i
                 + <T as FloatElement>::from_f64(5.0) * phi_ip1
-                + <T as FloatElement>::from_f64(2.0) * phi_ip2)
+                - phi_ip2)
                 / <T as FloatElement>::from_f64(6.0);
 
             let muscl2 = self.reconstruct_right_muscl2(phi_im1, phi_i, phi_ip1);

--- a/crates/cfd-2d/src/schemes/tvd_tests.rs
+++ b/crates/cfd-2d/src/schemes/tvd_tests.rs
@@ -218,4 +218,57 @@ mod tests {
             "MUSCL2 should report second-order accuracy"
         );
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MUSCL3 theorems
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Verify MUSCL3 reproduces a constant field exactly for both states.
+    #[test]
+    fn test_muscl3_constant_preservation() {
+        let nx = 20;
+        let ny = 1;
+        let constant = 3.7_f64;
+        let mut grid = Grid2D::<f64>::new(nx, ny, 1.0, 1.0, 0);
+        let [rows, cols] = grid.data.shape();
+        for i in 0..rows {
+            for j in 0..cols {
+                grid.data[[i, j]] = constant;
+            }
+        }
+
+        let scheme = MUSCLScheme::<f64>::muscl3_superbee();
+        for i in 2..nx - 2 {
+            let j = 0;
+            let left = scheme.reconstruct_face_value_x(&grid, 1.0, i, j);
+            let right = scheme.reconstruct_face_value_x(&grid, -1.0, i, j);
+            assert_relative_eq!(left, constant, epsilon = 1e-10);
+            assert_relative_eq!(right, constant, epsilon = 1e-10);
+        }
+    }
+
+    /// Verify MUSCL3 left and right states are exact for linear fields:
+    /// φ_{i+½}^L = φ_{i+½}^R = slope·(i + ½).
+    ///
+    /// The κ = 1/3 stencils (−φ_{i−1}+5φ_i+2φ_{i+1})/6 and
+    /// (2φ_i+5φ_{i+1}−φ_{i+2})/6 both reproduce linear data exactly. The
+    /// pre-2026-08-20 coefficients summed to 11/12 (left) and had sign-flipped
+    /// end coefficients (right), breaking this theorem.
+    #[test]
+    fn test_muscl3_linear_exactness() {
+        let nx = 20;
+        let ny = 1;
+        let slope = 2.5;
+        let grid = make_linear_grid_x(nx, ny, slope);
+        let scheme = MUSCLScheme::<f64>::muscl3_superbee();
+
+        for i in 2..nx - 2 {
+            let j = 0;
+            let expected = slope * (i as f64 + 0.5);
+            let left = scheme.reconstruct_face_value_x(&grid, 1.0, i, j);
+            let right = scheme.reconstruct_face_value_x(&grid, -1.0, i, j);
+            assert_relative_eq!(left, expected, epsilon = 1e-10);
+            assert_relative_eq!(right, expected, epsilon = 1e-10);
+        }
+    }
 }

--- a/crates/cfd-2d/src/solvers/lbm/streaming.rs
+++ b/crates/cfd-2d/src/solvers/lbm/streaming.rs
@@ -103,9 +103,12 @@ impl StreamingOperator {
                     if src_i >= 0 && src_i < nx as i32 && src_j >= 0 && src_j < ny as i32 {
                         let si = src_i as usize;
                         let sj = src_j as usize;
-                        if !boundary_mask[sj * nx + si] {
-                            f_dst[f_idx(j, i, q, nx)] = f_src[f_idx(sj, si, q, nx)];
-                        }
+                        // Pull regardless of the source's boundary status:
+                        // boundary nodes have already had their post-collision
+                        // populations prepared by the BC routine, so they are
+                        // valid sources. Skipping them left stale populations
+                        // from two steps ago in f_dst (buffers are swapped).
+                        f_dst[f_idx(j, i, q, nx)] = f_src[f_idx(sj, si, q, nx)];
                     }
                 }
             }
@@ -165,5 +168,46 @@ mod tests {
         let idx0 = f_idx(2, 3, 0, nx);
         let idx1 = f_idx(2, 3, 1, nx);
         assert_eq!(idx1 - idx0, 1, "q direction must be stride-1");
+    }
+
+    #[test]
+    fn stream_with_boundaries_pulls_from_boundary_prepared_source() {
+        // An interior node downstream of a boundary node must receive the
+        // boundary node's post-BC population. Skipping the pull left stale
+        // values from two steps ago in the swapped destination buffer.
+        let nx = 4_usize;
+        let ny = 4_usize;
+        let n = nx * ny * 9;
+
+        let mut boundary_mask = vec![false; nx * ny];
+        boundary_mask[0 * nx + 1] = true; // node (i=1, j=0) is a boundary
+
+        let f_src: Vec<f64> = (0..n).map(|k| 1.0 + (k % 17) as f64 * 0.05).collect();
+        let mut f_dst = vec![7.5_f64; n]; // sentinel: stale data would remain
+
+        StreamingOperator::stream_with_boundaries(&f_src, &mut f_dst, &boundary_mask, nx, ny);
+
+        // Interior node (i=1, j=1) pulls direction +y (q with ey=1) from the
+        // boundary node above it; every interior destination must be written.
+        for j in 0..ny {
+            for i in 0..nx {
+                if boundary_mask[j * nx + i] {
+                    continue;
+                }
+                for q in 0..9 {
+                    let (ex, ey) = D2Q9::VELOCITIES[q];
+                    let si = i as i32 - ex;
+                    let sj = j as i32 - ey;
+                    if (0..nx as i32).contains(&si) && (0..ny as i32).contains(&sj) {
+                        let expected = f_src[f_idx(sj as usize, si as usize, q, nx)];
+                        assert_relative_eq!(
+                            f_dst[f_idx(j, i, q, nx)],
+                            expected,
+                            epsilon = 1e-12
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/cfd-2d/src/solvers/lbm/streaming.rs
+++ b/crates/cfd-2d/src/solvers/lbm/streaming.rs
@@ -200,11 +200,7 @@ mod tests {
                     let sj = j as i32 - ey;
                     if (0..nx as i32).contains(&si) && (0..ny as i32).contains(&sj) {
                         let expected = f_src[f_idx(sj as usize, si as usize, q, nx)];
-                        assert_relative_eq!(
-                            f_dst[f_idx(j, i, q, nx)],
-                            expected,
-                            epsilon = 1e-12
-                        );
+                        assert_relative_eq!(f_dst[f_idx(j, i, q, nx)], expected, epsilon = 1e-12);
                     }
                 }
             }

--- a/crates/cfd-2d/src/solvers/ns_fvm/field.rs
+++ b/crates/cfd-2d/src/solvers/ns_fvm/field.rs
@@ -22,7 +22,6 @@ use super::grid::StaggeredGrid2D;
 use crate::grid::array2d::{Array2D, Mask2D};
 use crate::scalar;
 use cfd_core::CfdScalar;
-use cfd_core::error::Error;
 use eunomia::{FloatElement, NumericElement};
 
 /// 2D velocity and pressure fields on a staggered grid.

--- a/crates/cfd-2d/src/solvers/ns_fvm/field.rs
+++ b/crates/cfd-2d/src/solvers/ns_fvm/field.rs
@@ -22,6 +22,7 @@ use super::grid::StaggeredGrid2D;
 use crate::grid::array2d::{Array2D, Mask2D};
 use crate::scalar;
 use cfd_core::CfdScalar;
+use cfd_core::error::Error;
 use eunomia::{FloatElement, NumericElement};
 
 /// 2D velocity and pressure fields on a staggered grid.

--- a/crates/cfd-2d/src/solvers/simple/momentum.rs
+++ b/crates/cfd-2d/src/solvers/simple/momentum.rs
@@ -36,12 +36,21 @@ impl<T: CfdScalar + EunomiaRealField + Copy + std::fmt::Debug + FloatElement> Si
 
         for j in 0..grid.ny {
             for i in 0..grid.nx {
+                // d = V / |a_P| (Patankar 1980): the velocity response to a
+                // unit pressure gradient, δu = −(V/a_P)∇p′. Both the p′
+                // Poisson coefficients and the Rhie–Chow interpolation must
+                // use this same volume-based coefficient to remain mutually
+                // consistent. Prior to 2026-08-20 d_u = dy/|a_P| omitted the
+                // dx factor, leaving the p′ equation inconsistent with the
+                // applied nodal correction by 1/dx on non-square grids.
+                let cell_volume = dx * dy;
+
                 let ap_u_val = NumericElement::abs(ap_u.at(i, j));
                 d_u.set(
                     i,
                     j,
                     if ap_u_val > min_ap {
-                        dy / ap_u_val
+                        cell_volume / ap_u_val
                     } else {
                         scalar::zero::<T>()
                     },
@@ -52,7 +61,7 @@ impl<T: CfdScalar + EunomiaRealField + Copy + std::fmt::Debug + FloatElement> Si
                     i,
                     j,
                     if ap_v_val > min_ap {
-                        dx / ap_v_val
+                        cell_volume / ap_v_val
                     } else {
                         scalar::zero::<T>()
                     },

--- a/crates/cfd-2d/src/solvers/simple/pressure.rs
+++ b/crates/cfd-2d/src/solvers/simple/pressure.rs
@@ -511,11 +511,13 @@ impl<T: CfdScalar + EunomiaRealField + Copy + std::fmt::Debug + FloatElement> Si
                 let dp_dx = (p_prime[idx + 1] - p_prime[idx - 1]) / (two * dx);
                 let dp_dy = (p_prime[idx + nx] - p_prime[idx - nx]) / (two * dy);
 
+                // d already carries the cell volume (V/a_P), so the nodal
+                // correction is δu = −(V/a_P)∇p′ with no extra spacing factor.
                 if let Some(u) = fields.u.at_mut(i, j) {
-                    *u -= d_u.at(i, j) * dp_dx * dx;
+                    *u -= d_u.at(i, j) * dp_dx;
                 }
                 if let Some(v) = fields.v.at_mut(i, j) {
-                    *v -= d_v.at(i, j) * dp_dy * dy;
+                    *v -= d_v.at(i, j) * dp_dy;
                 }
             }
         }

--- a/crates/cfd-3d/src/blueprint_integration/mod.rs
+++ b/crates/cfd-3d/src/blueprint_integration/mod.rs
@@ -40,8 +40,8 @@ impl Default for Blueprint3dProcessingConfig {
     fn default() -> Self {
         Self {
             mesh: PipelineConfig::default(),
-            density: MassDensity::from_base(1060.0),
-            viscosity: DynamicViscosity::from_base(3.5e-3),
+            density: MassDensity::from_base(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
+            viscosity: DynamicViscosity::from_base(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
             total_flow_rate: VolumetricFlowRate::from_base(1.0e-9),
             two_d_grid_nx: 32,
             two_d_grid_ny: 12,

--- a/crates/cfd-3d/src/blueprint_integration/mod.rs
+++ b/crates/cfd-3d/src/blueprint_integration/mod.rs
@@ -40,8 +40,12 @@ impl Default for Blueprint3dProcessingConfig {
     fn default() -> Self {
         Self {
             mesh: PipelineConfig::default(),
-            density: MassDensity::from_base(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY),
-            viscosity: DynamicViscosity::from_base(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
+            density: MassDensity::from_base(
+                cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+            ),
+            viscosity: DynamicViscosity::from_base(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            ),
             total_flow_rate: VolumetricFlowRate::from_base(1.0e-9),
             two_d_grid_nx: 32,
             two_d_grid_ny: 12,

--- a/crates/cfd-3d/src/cavitation.rs
+++ b/crates/cfd-3d/src/cavitation.rs
@@ -50,10 +50,18 @@ impl Default for RayleighPlesset {
     fn default() -> Self {
         Self {
             initial_radius: Length::from_base(1.0e-6),
-            liquid_density: MassDensity::from_base(cfd_core::physics::constants::physics::fluid::WATER_DENSITY),
-            liquid_viscosity: DynamicViscosity::from_base(cfd_core::physics::constants::physics::fluid::WATER_VISCOSITY),
-            surface_tension: SurfaceTension::from_base(cfd_core::physics::cavitation::constants::SURFACE_TENSION_WATER_VALUE),
-            vapor_pressure: Pressure::from_base(cfd_core::physics::cavitation::constants::VAPOR_PRESSURE_WATER_20C_VALUE),
+            liquid_density: MassDensity::from_base(
+                cfd_core::physics::constants::physics::fluid::WATER_DENSITY,
+            ),
+            liquid_viscosity: DynamicViscosity::from_base(
+                cfd_core::physics::constants::physics::fluid::WATER_VISCOSITY,
+            ),
+            surface_tension: SurfaceTension::from_base(
+                cfd_core::physics::cavitation::constants::SURFACE_TENSION_WATER_VALUE,
+            ),
+            vapor_pressure: Pressure::from_base(
+                cfd_core::physics::cavitation::constants::VAPOR_PRESSURE_WATER_20C_VALUE,
+            ),
             polytropic_index: 1.4,
         }
     }
@@ -153,8 +161,12 @@ impl Default for EulerianEulerian {
     fn default() -> Self {
         Self {
             nucleation_density: NumberDensity::from_base(1.0e13),
-            vapor_pressure: Pressure::from_base(cfd_core::physics::cavitation::constants::VAPOR_PRESSURE_WATER_20C_VALUE),
-            liquid_density: MassDensity::from_base(cfd_core::physics::constants::physics::fluid::WATER_DENSITY),
+            vapor_pressure: Pressure::from_base(
+                cfd_core::physics::cavitation::constants::VAPOR_PRESSURE_WATER_20C_VALUE,
+            ),
+            liquid_density: MassDensity::from_base(
+                cfd_core::physics::constants::physics::fluid::WATER_DENSITY,
+            ),
             vapor_density: MassDensity::from_base(0.0173),
             volume_fraction: 0.5,
             bubble_radius: Length::from_base(1.0e-6),

--- a/crates/cfd-3d/src/cavitation.rs
+++ b/crates/cfd-3d/src/cavitation.rs
@@ -50,10 +50,10 @@ impl Default for RayleighPlesset {
     fn default() -> Self {
         Self {
             initial_radius: Length::from_base(1.0e-6),
-            liquid_density: MassDensity::from_base(998.0),
-            liquid_viscosity: DynamicViscosity::from_base(1.002e-3),
-            surface_tension: SurfaceTension::from_base(0.0728),
-            vapor_pressure: Pressure::from_base(2_339.0),
+            liquid_density: MassDensity::from_base(cfd_core::physics::constants::physics::fluid::WATER_DENSITY),
+            liquid_viscosity: DynamicViscosity::from_base(cfd_core::physics::constants::physics::fluid::WATER_VISCOSITY),
+            surface_tension: SurfaceTension::from_base(cfd_core::physics::cavitation::constants::SURFACE_TENSION_WATER_VALUE),
+            vapor_pressure: Pressure::from_base(cfd_core::physics::cavitation::constants::VAPOR_PRESSURE_WATER_20C_VALUE),
             polytropic_index: 1.4,
         }
     }
@@ -153,8 +153,8 @@ impl Default for EulerianEulerian {
     fn default() -> Self {
         Self {
             nucleation_density: NumberDensity::from_base(1.0e13),
-            vapor_pressure: Pressure::from_base(2_339.0),
-            liquid_density: MassDensity::from_base(998.0),
+            vapor_pressure: Pressure::from_base(cfd_core::physics::cavitation::constants::VAPOR_PRESSURE_WATER_20C_VALUE),
+            liquid_density: MassDensity::from_base(cfd_core::physics::constants::physics::fluid::WATER_DENSITY),
             vapor_density: MassDensity::from_base(0.0173),
             volume_fraction: 0.5,
             bubble_radius: Length::from_base(1.0e-6),

--- a/crates/cfd-3d/src/fem/solver.rs
+++ b/crates/cfd-3d/src/fem/solver.rs
@@ -1002,7 +1002,13 @@ impl<T: CfdScalar + cfd_mesh::domain::core::Scalar + FloatElement> FemSolver<T> 
                     for j in 0..4 {
                         let gj = idxs[j];
                         let gp_j = p_offset + gj;
-                        let b_val = shape_values[j] * grad_i[d] * weight;
+                        // Taylor–Hood: the pressure space is P1, so the
+                        // pressure basis at corner node j is the linear
+                        // barycentric coordinate l[j] — not shape_values[j],
+                        // which is the quadratic P2 corner function
+                        // L_j(2L_j−1) for Tet10 elements. Using the P2 value
+                        // made constant/linear pressure fields unrepresentable.
+                        let b_val = l[j] * grad_i[d] * weight;
                         *local_map.entry((gv_i, gp_j)).or_insert(scalar::zero::<T>()) -= b_val;
                         *local_map.entry((gp_j, gv_i)).or_insert(scalar::zero::<T>()) += b_val;
                     }

--- a/crates/cfd-3d/src/level_set/weno.rs
+++ b/crates/cfd-3d/src/level_set/weno.rs
@@ -61,9 +61,7 @@ pub(super) fn weno5_reconstruct_left<T: CfdScalar>(v: [T; 5]) -> T {
     let q1 = (-v[1] + five * v[2] + two * v[3]) / six;
     let q2 = (two * v[2] + five * v[3] - v[4]) / six;
 
-    let b0 = smoothness_indicator(v[0], v[1], v[2]);
-    let b1 = smoothness_indicator(v[1], v[2], v[3]);
-    let b2 = smoothness_indicator(v[2], v[3], v[4]);
+    let [b0, b1, b2] = smoothness_indicators(v);
 
     let (w0, w1, w2) = nonlinear_weights(
         b0,
@@ -84,16 +82,34 @@ pub(super) fn weno5_reconstruct_right<T: CfdScalar>(v: [T; 5]) -> T {
     weno5_reconstruct_left([v[4], v[3], v[2], v[1], v[0]])
 }
 
-/// WENO5 smoothness indicator for a 3-point sub-stencil (Jiang & Shu 1996).
+/// Jiang–Shu (1996) smoothness indicators β₀..β₂ for the three 3-point
+/// sub-stencils of a 5-point WENO5 reconstruction.
+///
+/// Prior to 2026-08-20 every sub-stencil used the middle-stencil second term
+/// (v₀ − v₂)², which deviates from the published indicators:
+///
+/// ```text
+/// β₀ = 13/12(v₀−2v₁+v₂)² + 1/4(v₀−4v₁+3v₂)²
+/// β₁ = 13/12(v₁−2v₂+v₃)² + 1/4(v₁−v₃)²
+/// β₂ = 13/12(v₂−2v₃+v₄)² + 1/4(3v₂−4v₃+v₄)²
+/// ```
 #[inline]
-pub(super) fn smoothness_indicator<T: CfdScalar>(v0: T, v1: T, v2: T) -> T {
+pub(super) fn smoothness_indicators<T: CfdScalar>(v: [T; 5]) -> [T; 3] {
     let thirteen_over_twelve = <T as FloatElement>::from_f64(13.0 / 12.0);
     let quarter = <T as FloatElement>::from_f64(0.25);
-    let two = scalar::one::<T>() + scalar::one::<T>();
+    let one = scalar::one::<T>();
+    let two = one + one;
+    let three = two + one;
+    let four = three + one;
 
-    let diff1 = v0 - two * v1 + v2;
-    let diff2 = v0 - v2;
-    thirteen_over_twelve * diff1 * diff1 + quarter * diff2 * diff2
+    let b0 = thirteen_over_twelve * scalar::powi::<T>(v[0] - two * v[1] + v[2], 2)
+        + quarter * scalar::powi::<T>(v[0] - four * v[1] + three * v[2], 2);
+    let b1 = thirteen_over_twelve * scalar::powi::<T>(v[1] - two * v[2] + v[3], 2)
+        + quarter * scalar::powi::<T>(v[1] - v[3], 2);
+    let b2 = thirteen_over_twelve * scalar::powi::<T>(v[2] - two * v[3] + v[4], 2)
+        + quarter * scalar::powi::<T>(three * v[2] - four * v[3] + v[4], 2);
+
+    [b0, b1, b2]
 }
 
 /// Compute normalized WENO5-Z nonlinear weights from smoothness indicators.
@@ -135,13 +151,17 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_smoothness_indicator_non_negative(
+        fn test_smoothness_indicators_non_negative(
             v0 in -10.0..10.0f64,
             v1 in -10.0..10.0f64,
             v2 in -10.0..10.0f64,
+            v3 in -10.0..10.0f64,
+            v4 in -10.0..10.0f64,
         ) {
-            let beta = smoothness_indicator(v0, v1, v2);
-            assert!(beta >= 0.0);
+            let betas = smoothness_indicators([v0, v1, v2, v3, v4]);
+            for beta in betas {
+                assert!(beta >= 0.0);
+            }
         }
 
         #[test]

--- a/crates/cfd-3d/src/spectral/fourier.rs
+++ b/crates/cfd-3d/src/spectral/fourier.rs
@@ -192,12 +192,8 @@ where
             // ch. 2). Multiplying the real Nyquist coefficient by ik would
             // inject a component outside the approximation space and break
             // conjugate symmetry.
-            let is_nyquist = self.transform.n % 2 == 0 && k_idx == self.transform.n / 2;
-            let factor = if order > 0 && is_nyquist {
-                zero
-            } else {
-                i * k
-            };
+            let is_nyquist = self.transform.n.is_multiple_of(2) && k_idx == self.transform.n / 2;
+            let factor = if order > 0 && is_nyquist { zero } else { i * k };
             let factor = factor.powi(order as i32);
             du_hat[[k_idx]] = factor * u_hat[[k_idx]];
         }
@@ -226,13 +222,7 @@ mod tests {
         let derivative = SpectralDerivative::<f64>::new(n).expect("valid size");
 
         // Pure Nyquist mode: cos(2x) sampled at x_j = πj/2 → [1, −1, 1, −1].
-        let signal = array_from_fn(n, |j| {
-            if j % 2 == 0 {
-                1.0
-            } else {
-                -1.0
-            }
-        });
+        let signal = array_from_fn(n, |j| if j % 2 == 0 { 1.0 } else { -1.0 });
 
         let d = derivative
             .derivative(&signal, 1)
@@ -242,8 +232,7 @@ mod tests {
         for (idx, &value) in d.iter().enumerate() {
             assert!(
                 value.abs() < 1e-12,
-                "du/dx[{idx}] = {} must vanish for the Nyquist mode",
-                value
+                "du/dx[{idx}] = {value} must vanish for the Nyquist mode"
             );
         }
     }

--- a/crates/cfd-3d/src/spectral/fourier.rs
+++ b/crates/cfd-3d/src/spectral/fourier.rs
@@ -183,14 +183,95 @@ where
         // Multiply by (ik)^order
         let mut du_hat = Array1::zeros([self.transform.n]);
         let i = Complex::new(<T as NumericElement>::ZERO, <T as NumericElement>::ONE);
+        let zero = Complex::new(<T as NumericElement>::ZERO, <T as NumericElement>::ZERO);
 
         for (k_idx, &k) in self.transform.wavenumbers().iter().enumerate() {
-            let ik = i * k;
-            let factor = ik.powi(order as i32);
+            // Even-length transforms: the Nyquist mode has no representable
+            // derivative in the N-point trigonometric interpolant space, so
+            // its factor is zeroed (Trefethen, Spectral Methods in MATLAB,
+            // ch. 2). Multiplying the real Nyquist coefficient by ik would
+            // inject a component outside the approximation space and break
+            // conjugate symmetry.
+            let is_nyquist = self.transform.n % 2 == 0 && k_idx == self.transform.n / 2;
+            let factor = if order > 0 && is_nyquist {
+                zero
+            } else {
+                i * k
+            };
+            let factor = factor.powi(order as i32);
             du_hat[[k_idx]] = factor * u_hat[[k_idx]];
         }
 
         // Transform back to physical space
         self.transform.inverse(&du_hat)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leto::Array1;
+
+    fn array_from_fn(n: usize, mut f: impl FnMut(usize) -> f64) -> Array1<f64> {
+        Array1::from_vec([n], (0..n).map(&mut f).collect())
+            .expect("signal length matches declared shape")
+    }
+
+    /// The even-length Nyquist mode has no representable derivative in the
+    /// N-point trigonometric interpolant space; its factor must be zeroed
+    /// (Trefethen, Spectral Methods in MATLAB, ch. 2).
+    #[test]
+    fn nyquist_mode_derivative_is_zeroed() {
+        let n = 4_usize;
+        let derivative = SpectralDerivative::<f64>::new(n).expect("valid size");
+
+        // Pure Nyquist mode: cos(2x) sampled at x_j = πj/2 → [1, −1, 1, −1].
+        let signal = array_from_fn(n, |j| {
+            if j % 2 == 0 {
+                1.0
+            } else {
+                -1.0
+            }
+        });
+
+        let d = derivative
+            .derivative(&signal, 1)
+            .expect("first derivative must succeed");
+
+        // Exact derivative −2·sin(2x) vanishes at every sample point.
+        for (idx, &value) in d.iter().enumerate() {
+            assert!(
+                value.abs() < 1e-12,
+                "du/dx[{idx}] = {} must vanish for the Nyquist mode",
+                value
+            );
+        }
+    }
+
+    /// A non-Nyquist mode must still differentiate correctly.
+    #[test]
+    fn first_derivative_of_sine_matches_cosine() {
+        let n = 8_usize;
+        let derivative = SpectralDerivative::<f64>::new(n).expect("valid size");
+
+        let signal = array_from_fn(n, |j| {
+            let x = 2.0 * std::f64::consts::PI * j as f64 / n as f64;
+            x.sin()
+        });
+
+        let d = derivative
+            .derivative(&signal, 1)
+            .expect("first derivative must succeed");
+
+        for (idx, &value) in d.iter().enumerate() {
+            let expected = {
+                let x = 2.0 * std::f64::consts::PI * idx as f64 / n as f64;
+                x.cos()
+            };
+            assert!(
+                (value - expected).abs() < 1e-12,
+                "du/dx[{idx}] = {value}, expected {expected}"
+            );
+        }
     }
 }

--- a/crates/cfd-3d/src/vof/advection.rs
+++ b/crates/cfd-3d/src/vof/advection.rs
@@ -361,7 +361,7 @@ impl AdvectionMethod {
         delta_normal: T,
         dt: T,
         // 0 = x-face, 1 = y-face, 2 = z-face
-        _dir: usize,
+        dir: usize,
     ) -> T {
         let zero = scalar::zero::<T>();
         let one = scalar::one::<T>();
@@ -400,14 +400,27 @@ impl AdvectionMethod {
         let dy_p = solver.dy;
         let dz_p = solver.dz;
 
-        // The fraction of the prism volume that is fluid:
-        let f = plic_volume_fraction_in_prism(normal_donor, alpha_donor, depth, dx_p, dy_p, dz_p);
+        // The fraction of the prism volume that is fluid. The swept slab is
+        // the layer adjacent to the donor's outflow face: for u_face > 0 the
+        // donor is the left cell losing fluid through its high-coordinate
+        // face (flow_sign = +1); for u_face < 0 the donor is the right cell
+        // losing through its low-coordinate face (flow_sign = −1).
+        let flow_sign = if u_face > zero { one } else { -one };
+        let f = plic_volume_fraction_in_prism(
+            normal_donor,
+            alpha_donor,
+            depth,
+            dx_p,
+            dy_p,
+            dz_p,
+            dir,
+            flow_sign,
+        );
 
         // Flux = fraction_fluid × swept_prism_volume × sign(u_face)
         let swept_volume = depth * face_area;
-        let sign = if u_face > zero { one } else { -one };
 
-        scalar::min(scalar::max(f, zero), one) * swept_volume * sign
+        scalar::min(scalar::max(f, zero), one) * swept_volume * flow_sign
     }
 
     /// Algebraic advection (simpler but less accurate, first-order upwind).

--- a/crates/cfd-3d/src/vof/plic_geometry.rs
+++ b/crates/cfd-3d/src/vof/plic_geometry.rs
@@ -126,8 +126,7 @@ pub(crate) fn plic_volume_fraction_in_prism<T: CfdScalar>(
     // expression for a mirrored normal flips which slab is fluid — the
     // orientation-blind absolute-value form cannot.
     let negative_axis = scalar::min(n_a_signed, zero);
-    let c_gas_slab =
-        c_gas + negative_axis * (delta_a - depth) - n_a_signed * slab_offset;
+    let c_gas_slab = c_gas + negative_axis * (delta_a - depth) - n_a_signed * slab_offset;
 
     // Gas fraction inside the slab prism (extent `depth` along the axis, full
     // cell dimensions perpendicular).
@@ -205,7 +204,7 @@ fn corner_cut_volume_fraction<T: CfdScalar>(m: [T; 3], c: T) -> T {
 
     let mut active: [T; 3] = [zero; 3];
     let mut k = 0_usize;
-    for &component in m.iter() {
+    for &component in &m {
         if component > eps {
             active[k] = component;
             k += 1;
@@ -227,8 +226,8 @@ fn corner_cut_volume_fraction<T: CfdScalar>(m: [T; 3], c: T) -> T {
         2 => {
             let (m0, m1) = (active[0], active[1]);
             let two = <T as FloatElement>::from_f64(2.0);
-            let numerator = pos_pow(c, 2) - pos_pow(c - m0, 2) - pos_pow(c - m1, 2)
-                + pos_pow(c - m0 - m1, 2);
+            let numerator =
+                pos_pow(c, 2) - pos_pow(c - m0, 2) - pos_pow(c - m1, 2) + pos_pow(c - m0 - m1, 2);
             scalar::min(
                 scalar::max(numerator / (two * m0 * m1), zero),
                 scalar::one::<T>(),
@@ -237,14 +236,12 @@ fn corner_cut_volume_fraction<T: CfdScalar>(m: [T; 3], c: T) -> T {
         _ => {
             let (m0, m1, m2) = (active[0], active[1], active[2]);
             let six = <T as FloatElement>::from_f64(6.0);
-            let numerator = pos_pow(c, 3)
-                - pos_pow(c - m0, 3)
-                - pos_pow(c - m1, 3)
-                - pos_pow(c - m2, 3)
-                + pos_pow(c - m0 - m1, 3)
-                + pos_pow(c - m0 - m2, 3)
-                + pos_pow(c - m1 - m2, 3)
-                - pos_pow(c - m0 - m1 - m2, 3);
+            let numerator =
+                pos_pow(c, 3) - pos_pow(c - m0, 3) - pos_pow(c - m1, 3) - pos_pow(c - m2, 3)
+                    + pos_pow(c - m0 - m1, 3)
+                    + pos_pow(c - m0 - m2, 3)
+                    + pos_pow(c - m1 - m2, 3)
+                    - pos_pow(c - m0 - m1 - m2, 3);
             scalar::min(
                 scalar::max(numerator / (six * m0 * m1 * m2), zero),
                 scalar::one::<T>(),
@@ -320,8 +317,14 @@ mod tests {
         let f_out_low: f64 =
             plic_volume_fraction_in_prism(normal, alpha, depth, dx, dy, dz, 0, -1.0);
 
-        assert!((f_out_high - 1.0).abs() < 1e-9, "high-side outflow f={f_out_high}");
-        assert!((f_out_low - 0.0).abs() < 1e-9, "low-side outflow f={f_out_low}");
+        assert!(
+            (f_out_high - 1.0).abs() < 1e-9,
+            "high-side outflow f={f_out_high}"
+        );
+        assert!(
+            (f_out_low - 0.0).abs() < 1e-9,
+            "low-side outflow f={f_out_low}"
+        );
 
         // Mirrored normal puts the fluid at low x; fractions swap.
         let mirrored = Vector3::new(-1.0, 0.0, 0.0);
@@ -339,15 +342,11 @@ mod tests {
         // α = 0.75 with normal (1, 0, 0): gas fills x ≤ 0.25. A slab of
         // depth 0.5 on the low side ([0, 0.5]) is half gas, half fluid.
         let normal = Vector3::new(1.0, 0.0, 0.0);
-        let f_low: f64 = plic_volume_fraction_in_prism(
-            normal, 0.75, 0.5, 1.0, 1.0, 1.0, 0, -1.0,
-        );
+        let f_low: f64 = plic_volume_fraction_in_prism(normal, 0.75, 0.5, 1.0, 1.0, 1.0, 0, -1.0);
         assert!((f_low - 0.5).abs() < 1e-9, "partial slab f={f_low}");
 
         // The high-side slab [0.5, 1.0] is entirely fluid.
-        let f_high: f64 = plic_volume_fraction_in_prism(
-            normal, 0.75, 0.5, 1.0, 1.0, 1.0, 0, 1.0,
-        );
+        let f_high: f64 = plic_volume_fraction_in_prism(normal, 0.75, 0.5, 1.0, 1.0, 1.0, 0, 1.0);
         assert!((f_high - 1.0).abs() < 1e-9);
     }
 
@@ -372,12 +371,8 @@ mod tests {
         assert!((f_z_low - 0.0).abs() < 1e-9);
 
         // Full/empty cells carry their fraction regardless of direction.
-        let full: f64 = plic_volume_fraction_in_prism(
-            normal_x(), 1.0, 0.2, 1.0, 1.0, 1.0, 0, -1.0,
-        );
-        let empty: f64 = plic_volume_fraction_in_prism(
-            normal_x(), 0.0, 0.2, 1.0, 1.0, 1.0, 0, 1.0,
-        );
+        let full: f64 = plic_volume_fraction_in_prism(normal_x(), 1.0, 0.2, 1.0, 1.0, 1.0, 0, -1.0);
+        let empty: f64 = plic_volume_fraction_in_prism(normal_x(), 0.0, 0.2, 1.0, 1.0, 1.0, 0, 1.0);
         assert!((full - 1.0).abs() < 1e-12);
         assert!((empty - 0.0).abs() < 1e-12);
     }

--- a/crates/cfd-3d/src/vof/plic_geometry.rs
+++ b/crates/cfd-3d/src/vof/plic_geometry.rs
@@ -25,26 +25,30 @@ use leto::geometry::Vector3;
 ///
 /// Given a unit-normal vector **n** and a plane constant `C` (i.e., the plane
 /// **n**·**x** = `C`), the volume `V` of a rectangular cell
-/// `[0,Δx]×[0,Δy]×[0,Δz]` on the side **n**·**x** ≤ `C` satisfies
+/// `[0,Δx]×[0,Δy]×[0,Δz]` on the side Σ|nᵢ|xᵢ ≤ `C` is given by the analytical
+/// 5-region piecewise polynomial of Eq. (2.34)–(2.38) of Scardovelli & Zaleski
+/// (2000), implemented in [`volume_under_plane_3d`].
 ///
-/// ```math
-/// V(C) = V_cell · F(α)
-/// ```
+/// The donor-flux evaluation in [`plic_volume_fraction_in_prism`] treats the
+/// gas as the corner cut (the interface normal points into the fluid) and
+/// intersects that cut with the swept slab adjacent to the outflow face.
+
+/// Fluid-volume fraction of the swept PLIC prism in a donor cell.
 ///
-/// where `α` is the volume fraction of the full cell and `F` is the analytical
-/// 5-region piecewise polynomial from Eq. (2.34)–(2.38) of Scardovelli & Zaleski
-/// (2000).  Here we apply that formula to the *swept prism* with depth `depth`
-/// instead of the full cell width.
+/// # Convention
 ///
-/// The approach:
-/// 1. Replace the full cell's `n_i Δ_i` components with the prism's `n_i Δ_i^prism`.
-/// 2. Find the plane constant `C_prism` that gives the target fluid fraction `α` in the prism.
-/// 3. Return `V_fluid / V_prism`.
+/// The interface normal points **into the fluid** (negative α-gradient), so
+/// the gas occupies the origin corner cut `{x : Σ|nᵢ|xᵢ ≤ C}` of the donor
+/// cell. `C` is bisected so this cut holds exactly `(1 − α)` of the cell.
 ///
-/// For the donor-flux approach we directly use `alpha_donor` as the target fraction
-/// in the (full) donor cell and evaluate what fraction of the *swept prism* is fluid.
-/// Since the PLIC plane is the same, the fraction in the swept prism is the ratio
-/// of the volume below the PLIC plane inside the prism to the total prism volume.
+/// The swept prism is the slab of thickness `depth` adjacent to the donor's
+/// **outflow** face along `axis`: `[Δₐ − depth, Δₐ]` when `flow_sign > 0`
+/// (outflow through the high-coordinate face) and `[0, depth]` otherwise.
+///
+/// Prior to 2026-08-20 this function matched the corner cut to `α` itself
+/// (mirroring fluid and gas) and evaluated the slab at the donor-cell origin
+/// regardless of flow direction, so partially filled donor cells donated
+/// wrong fluxes in both directions.
 pub(crate) fn plic_volume_fraction_in_prism<T: CfdScalar>(
     normal: Vector3<T>,
     alpha_donor: T,
@@ -52,6 +56,8 @@ pub(crate) fn plic_volume_fraction_in_prism<T: CfdScalar>(
     dx: T,
     dy: T,
     dz: T,
+    axis: usize,
+    flow_sign: T,
 ) -> T {
     let zero = scalar::zero::<T>();
     let one = scalar::one::<T>();
@@ -64,58 +70,76 @@ pub(crate) fn plic_volume_fraction_in_prism<T: CfdScalar>(
         return one;
     }
 
-    // Retrieve the PLIC plane constant C for the donor cell.
-    // We use the Scardovelli-Zaleski analytical inverse to get C from alpha_donor.
-    let c_plane = find_plic_plane_constant(normal, alpha_donor, dx, dy, dz);
-
-    // Compute what fraction of the swept prism (dimensions: depth × dy × dz)
-    // lies below the plane n·x = c_plane.
-    //
-    // The prism origin is the same as the donor cell's origin.  We evaluate
-    // V_plane_intersection(n, c_plane, depth, dy, dz) / (depth * dy * dz).
     let prism_vol = depth * dy * dz;
     if prism_vol <= zero {
         return zero;
     }
 
-    let vol = volume_under_plane_3d(normal, c_plane, depth, dy, dz);
-    scalar::min(scalar::max(vol / prism_vol, zero), one)
-}
+    // Full-cell scaled absolute components and the axis-specific values.
+    let (delta_a, n_a_signed) = match axis {
+        0 => (dx, normal.x),
+        1 => (dy, normal.y),
+        _ => (dz, normal.z),
+    };
+    let m_full = [
+        scalar::abs(normal.x) * dx,
+        scalar::abs(normal.y) * dy,
+        scalar::abs(normal.z) * dz,
+    ];
+    let n_a = scalar::abs(n_a_signed);
 
-/// Find the PLIC plane constant C such that the volume under **n**·**x** = C
-/// in `[0,dx]×[0,dy]×[0,dz]` equals `alpha * dx * dy * dz`.
-///
-/// Uses iterative bisection (tolerance 1e-12 of cell size) per Scardovelli & Zaleski.
-pub(crate) fn find_plic_plane_constant<T: CfdScalar>(
-    normal: Vector3<T>,
-    alpha: T,
-    dx: T,
-    dy: T,
-    dz: T,
-) -> T {
-    let zero = scalar::zero::<T>();
-    let half = <T as FloatElement>::from_f64(0.5);
-
-    let n_abs =
-        scalar::abs(normal.x) * dx + scalar::abs(normal.y) * dy + scalar::abs(normal.z) * dz;
+    // The interface normal points into the fluid, so the GAS occupies the
+    // origin corner cut {Σ|nᵢ|xᵢ ≤ C} of the donor cell. Bisect C so the cut
+    // holds exactly (1 − α) of the cell. Prior to 2026-08-20 the bisection
+    // targeted α itself, mirroring fluid and gas.
+    let gas_target = one - alpha_donor;
     let mut c_lo = zero;
-    let mut c_hi = n_abs;
-    let target = alpha * dx * dy * dz;
-    let tol = <T as FloatElement>::from_f64(1e-12) * dx * dy * dz;
-
+    let mut c_hi = m_full[0] + m_full[1] + m_full[2];
     for _ in 0..64 {
-        if c_hi - c_lo < tol {
-            break;
-        }
-        let c_mid = c_lo + (c_hi - c_lo) * half;
-        let vol = volume_under_plane_3d(normal, c_mid, dx, dy, dz);
-        if vol < target {
+        let c_mid = c_lo + (c_hi - c_lo) * <T as FloatElement>::from_f64(0.5);
+        if corner_cut_volume_fraction(m_full, c_mid) < gas_target {
             c_lo = c_mid;
         } else {
             c_hi = c_mid;
         }
     }
-    c_lo + (c_hi - c_lo) * half
+    let c_gas = c_lo + (c_hi - c_lo) * <T as FloatElement>::from_f64(0.5);
+
+    // Distance from the donor-cell origin to the near edge of the swept slab
+    // along the axis. Outflow through the high-coordinate face (flow_sign > 0)
+    // sweeps [Δₐ − depth, Δₐ]; otherwise [0, depth].
+    let slab_offset = if flow_sign > zero {
+        delta_a - depth
+    } else {
+        zero
+    };
+
+    // Convert the corner constant into the signed plane position d* (with
+    // n·x ≤ d* describing the gas), shift by the slab offset using the SIGNED
+    // axis component, then convert back with the slab's own mirror offset:
+    //
+    //   d*          = C_gas + Σ_{nᵢ<0} nᵢΔᵢ
+    //   C_slab      = d* − n_a·t − Σ_{nᵢ<0} nᵢΔᵢ^slab
+    //               = C_gas + min(n_a, 0)·(Δ_a − depth) − n_a·slab_offset
+    //
+    // with n_a the SIGNED axis component throughout. Evaluating this
+    // expression for a mirrored normal flips which slab is fluid — the
+    // orientation-blind absolute-value form cannot.
+    let negative_axis = scalar::min(n_a_signed, zero);
+    let c_gas_slab =
+        c_gas + negative_axis * (delta_a - depth) - n_a_signed * slab_offset;
+
+    // Gas fraction inside the slab prism (extent `depth` along the axis, full
+    // cell dimensions perpendicular).
+    let m_slab = match axis {
+        0 => [n_a * depth, m_full[1], m_full[2]],
+        1 => [m_full[0], n_a * depth, m_full[2]],
+        _ => [m_full[0], m_full[1], n_a * depth],
+    };
+    let gas_frac = corner_cut_volume_fraction(m_slab, c_gas_slab);
+
+    let fluid_frac = one - gas_frac;
+    scalar::min(scalar::max(fluid_frac, zero), one)
 }
 
 /// Compute the volume of a rectangular cell `[0,Δx]×[0,Δy]×[0,Δz]` on the
@@ -148,64 +172,85 @@ pub fn volume_under_plane_3d<T: CfdScalar>(
     dy: T,
     dz: T,
 ) -> T {
-    let zero = scalar::zero::<T>();
     let cell_volume = dx * dy * dz;
-    let six = <T as FloatElement>::from_f64(6.0);
 
     // Absolute normal scaled by cell dimensions.
-    let m1 = scalar::abs(normal.x) * dx;
-    let m2 = scalar::abs(normal.y) * dy;
-    let m3 = scalar::abs(normal.z) * dz;
-    let m_sum = m1 + m2 + m3;
+    let m = [
+        scalar::abs(normal.x) * dx,
+        scalar::abs(normal.y) * dy,
+        scalar::abs(normal.z) * dz,
+    ];
 
-    // Degenerate case: all normal components essentially zero.
+    corner_cut_volume_fraction(m, plane_constant) * cell_volume
+}
+
+/// Fraction (in `[0, 1]`) of a rectangular box cut off at its origin corner
+/// by `{x : m₀x₀ + m₁x₁ + m₂x₂ ≤ C}`, where `mᵢ = |nᵢ|Δᵢ ≥ 0`.
+///
+/// Uses the inclusion–exclusion formula (Pilliod & Puckett 2004)
+///
+/// ```text
+/// F(C) = [C₊³ − Σᵢ(C−mᵢ)₊³ + Σᵢ<ⱼ(C−mᵢ−mⱼ)₊³ − (C−Σ)₊³] / (6·m₀·m₁·m₂)
+/// ```
+///
+/// reduced to the 2-D and 1-D limit formulas whenever one or two `mᵢ`
+/// vanish. Prior to 2026-08-20 the caller divided by `6·m₀·m₁·m₂`
+/// unconditionally, producing infinities for axis-aligned normals.
+///
+/// Monotonicity follows because dF/dC is the cross-sectional area of the
+/// plane–box intersection, which is ≥ 0.
+fn corner_cut_volume_fraction<T: CfdScalar>(m: [T; 3], c: T) -> T {
+    let zero = scalar::zero::<T>();
     let eps = <T as FloatElement>::from_f64(1e-14);
-    if m1 + m2 + m3 < eps {
-        return <T as FloatElement>::from_f64(0.5) * cell_volume;
-    }
 
-    let c = plane_constant;
-    if c <= zero {
-        return zero;
+    let mut active: [T; 3] = [zero; 3];
+    let mut k = 0_usize;
+    for &component in m.iter() {
+        if component > eps {
+            active[k] = component;
+            k += 1;
+        }
     }
-    if c >= m_sum {
-        return cell_volume;
-    }
+    active[..k].sort_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(std::cmp::Ordering::Equal));
 
-    // Inclusion-exclusion formula (Pilliod & Puckett 2004):
-    //
-    // V(C) = [C³ − Σᵢ(C−mᵢ)₊³ + Σᵢ<ⱼ(C−mᵢ−mⱼ)₊³ − (C−Σ)₊³] / (6·m₁·m₂·m₃)
-    //
-    // where (x)₊ = max(x, 0).
-    //
-    // # Theorem
-    //
-    // This equals the exact volume of the unit cuboid below the plane
-    // m₁ξ + m₂η + m₃ζ = C. Monotonicity follows because dV/dC is the
-    // cross-sectional area of the plane–cube intersection, which is ≥ 0.
-    let cube_pos = |x: T| -> T {
+    let pos_pow = |x: T, exp: u32| -> T {
         if x <= zero {
             zero
         } else {
-            x * x * x
+            FloatElement::powi(x, exp as i32)
         }
     };
 
-    let denom = six * m1 * m2 * m3;
-
-    let numerator = cube_pos(c) - cube_pos(c - m1) - cube_pos(c - m2) - cube_pos(c - m3)
-        + cube_pos(c - m1 - m2)
-        + cube_pos(c - m1 - m3)
-        + cube_pos(c - m2 - m3)
-        - cube_pos(c - m_sum);
-
-    let volume_fraction = numerator / denom;
-
-    // Clamp to [0, cell_volume] for numerical safety.
-    scalar::min(
-        scalar::max(volume_fraction * cell_volume, zero),
-        cell_volume,
-    )
+    match k {
+        0 => <T as FloatElement>::from_f64(0.5),
+        1 => scalar::min(scalar::max(c / active[0], zero), scalar::one::<T>()),
+        2 => {
+            let (m0, m1) = (active[0], active[1]);
+            let two = <T as FloatElement>::from_f64(2.0);
+            let numerator = pos_pow(c, 2) - pos_pow(c - m0, 2) - pos_pow(c - m1, 2)
+                + pos_pow(c - m0 - m1, 2);
+            scalar::min(
+                scalar::max(numerator / (two * m0 * m1), zero),
+                scalar::one::<T>(),
+            )
+        }
+        _ => {
+            let (m0, m1, m2) = (active[0], active[1], active[2]);
+            let six = <T as FloatElement>::from_f64(6.0);
+            let numerator = pos_pow(c, 3)
+                - pos_pow(c - m0, 3)
+                - pos_pow(c - m1, 3)
+                - pos_pow(c - m2, 3)
+                + pos_pow(c - m0 - m1, 3)
+                + pos_pow(c - m0 - m2, 3)
+                + pos_pow(c - m1 - m2, 3)
+                - pos_pow(c - m0 - m1 - m2, 3);
+            scalar::min(
+                scalar::max(numerator / (six * m0 * m1 * m2), zero),
+                scalar::one::<T>(),
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -236,27 +281,129 @@ mod tests {
             assert!(vol <= cell_vol + 1e-10);
         }
 
-        #[test]
-        fn test_volume_under_plane_monotonicity(
-            nx in -1.0..1.0f64,
-            ny in -1.0..1.0f64,
-            nz in -1.0..1.0f64,
-            c1 in -1.0..1.0f64,
-            dc in 0.0..1.0f64,
-            dx in 0.1..2.0f64,
-            dy in 0.1..2.0f64,
-            dz in 0.1..2.0f64,
-        ) {
-            let norm = (nx*nx + ny*ny + nz*nz).sqrt();
-            prop_assume!(norm > 1e-6);
-            let normal = Vector3::new(nx/norm, ny/norm, nz/norm);
+    #[test]
+    fn test_volume_under_plane_monotonicity(
+        nx in -1.0..1.0f64,
+        ny in -1.0..1.0f64,
+        nz in -1.0..1.0f64,
+        c1 in -1.0..1.0f64,
+        dc in 0.0..1.0f64,
+        dx in 0.1..2.0f64,
+        dy in 0.1..2.0f64,
+        dz in 0.1..2.0f64,
+    ) {
+        let norm = (nx*nx + ny*ny + nz*nz).sqrt();
+        prop_assume!(norm > 1e-6);
+        let normal = Vector3::new(nx/norm, ny/norm, nz/norm);
 
-            let c2 = c1 + dc;
-            let vol1 = volume_under_plane_3d(normal, c1, dx, dy, dz);
-            let vol2 = volume_under_plane_3d(normal, c2, dx, dy, dz);
+        let c2 = c1 + dc;
+        let vol1 = volume_under_plane_3d(normal, c1, dx, dy, dz);
+        let vol2 = volume_under_plane_3d(normal, c2, dx, dy, dz);
 
-            // Volume must be monotonically increasing with plane constant
-            assert!(vol2 >= vol1 - 1e-10);
-        }
+        // Volume must be monotonically increasing with plane constant
+        assert!(vol2 >= vol1 - 1e-10);
+    }
+    }
+
+    #[test]
+    fn swept_slab_follows_flow_direction() {
+        // Half-full cell, normal (1, 0, 0) points into the fluid ⇒ fluid at
+        // high x. Outflow through the +x face sweeps an all-fluid slab;
+        // outflow through the −x face sweeps an all-gas slab.
+        let normal = Vector3::new(1.0, 0.0, 0.0);
+        let alpha = 0.5_f64;
+        let (dx, dy, dz) = (1.0_f64, 1.0_f64, 1.0_f64);
+        let depth = 0.2_f64;
+
+        let f_out_high: f64 =
+            plic_volume_fraction_in_prism(normal, alpha, depth, dx, dy, dz, 0, 1.0);
+        let f_out_low: f64 =
+            plic_volume_fraction_in_prism(normal, alpha, depth, dx, dy, dz, 0, -1.0);
+
+        assert!((f_out_high - 1.0).abs() < 1e-9, "high-side outflow f={f_out_high}");
+        assert!((f_out_low - 0.0).abs() < 1e-9, "low-side outflow f={f_out_low}");
+
+        // Mirrored normal puts the fluid at low x; fractions swap.
+        let mirrored = Vector3::new(-1.0, 0.0, 0.0);
+        let f_mirrored_high: f64 =
+            plic_volume_fraction_in_prism(mirrored, alpha, depth, dx, dy, dz, 0, 1.0);
+        let f_mirrored_low: f64 =
+            plic_volume_fraction_in_prism(mirrored, alpha, depth, dx, dy, dz, 0, -1.0);
+
+        assert!((f_mirrored_high - 0.0).abs() < 1e-9);
+        assert!((f_mirrored_low - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn swept_slab_partial_coverage_is_exact() {
+        // α = 0.75 with normal (1, 0, 0): gas fills x ≤ 0.25. A slab of
+        // depth 0.5 on the low side ([0, 0.5]) is half gas, half fluid.
+        let normal = Vector3::new(1.0, 0.0, 0.0);
+        let f_low: f64 = plic_volume_fraction_in_prism(
+            normal, 0.75, 0.5, 1.0, 1.0, 1.0, 0, -1.0,
+        );
+        assert!((f_low - 0.5).abs() < 1e-9, "partial slab f={f_low}");
+
+        // The high-side slab [0.5, 1.0] is entirely fluid.
+        let f_high: f64 = plic_volume_fraction_in_prism(
+            normal, 0.75, 0.5, 1.0, 1.0, 1.0, 0, 1.0,
+        );
+        assert!((f_high - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn swept_slab_handles_all_axes_and_degenerate_fill() {
+        // y-axis analogue of the directional test.
+        let normal_y = Vector3::new(0.0, 1.0, 0.0);
+        let f_y_high: f64 =
+            plic_volume_fraction_in_prism(normal_y, 0.5, 0.2, 1.0, 1.0, 1.0, 1, 1.0);
+        let f_y_low: f64 =
+            plic_volume_fraction_in_prism(normal_y, 0.5, 0.2, 1.0, 1.0, 1.0, 1, -1.0);
+        assert!((f_y_high - 1.0).abs() < 1e-9);
+        assert!((f_y_low - 0.0).abs() < 1e-9);
+
+        // z-axis analogue.
+        let normal_z = Vector3::new(0.0, 0.0, 1.0);
+        let f_z_high: f64 =
+            plic_volume_fraction_in_prism(normal_z, 0.5, 0.2, 1.0, 1.0, 1.0, 2, 1.0);
+        let f_z_low: f64 =
+            plic_volume_fraction_in_prism(normal_z, 0.5, 0.2, 1.0, 1.0, 1.0, 2, -1.0);
+        assert!((f_z_high - 1.0).abs() < 1e-9);
+        assert!((f_z_low - 0.0).abs() < 1e-9);
+
+        // Full/empty cells carry their fraction regardless of direction.
+        let full: f64 = plic_volume_fraction_in_prism(
+            normal_x(), 1.0, 0.2, 1.0, 1.0, 1.0, 0, -1.0,
+        );
+        let empty: f64 = plic_volume_fraction_in_prism(
+            normal_x(), 0.0, 0.2, 1.0, 1.0, 1.0, 0, 1.0,
+        );
+        assert!((full - 1.0).abs() < 1e-12);
+        assert!((empty - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn axis_aligned_normal_volume_is_exact() {
+        // Axis-aligned normals previously divided by 6·m₀·m₁·m₂ = 0 and
+        // relied on NaN-propagating clamps. The reduced 1-D/2-D corner-cut
+        // formulas must return exact slab fractions instead.
+        let normal = Vector3::new(1.0, 0.0, 0.0);
+        let vol: f64 = volume_under_plane_3d(normal, 0.25, 1.0, 1.0, 1.0);
+        assert!((vol - 0.25).abs() < 1e-12, "slab volume {vol}");
+
+        let full: f64 = volume_under_plane_3d(normal, 2.0, 1.0, 1.0, 1.0);
+        let empty: f64 = volume_under_plane_3d(normal, -0.1, 1.0, 1.0, 1.0);
+        assert!((full - 1.0).abs() < 1e-12);
+        assert!(empty.abs() < 1e-12);
+
+        // Two active components exercise the 2-D limit formula:
+        // {x + y ≤ 0.5} in the unit square has area 0.125.
+        let diagonal = Vector3::new(1.0, 1.0, 0.0);
+        let area: f64 = volume_under_plane_3d(diagonal, 0.5, 1.0, 1.0, 1.0);
+        assert!((area - 0.125).abs() < 1e-12, "wedge area {area}");
+    }
+
+    fn normal_x() -> Vector3<f64> {
+        Vector3::new(1.0, 0.0, 0.0)
     }
 }

--- a/crates/cfd-core/src/physics/cavitation/constants.rs
+++ b/crates/cfd-core/src/physics/cavitation/constants.rs
@@ -1,12 +1,18 @@
-//! Physical constants for cavitation.
+﻿//! Physical constants for cavitation.
 
 use aequitas::systems::si::quantities::{NumberDensity, Pressure, SurfaceTension};
 
 /// Surface tension of water at 20°C (N/m)
 pub const SURFACE_TENSION_WATER: SurfaceTension = SurfaceTension::from_base(0.0728);
 
+/// Surface tension of water at 20°C — raw f64 for generic contexts [N/m]
+pub const SURFACE_TENSION_WATER_VALUE: f64 = 0.0728;
+
 /// Vapor pressure of water at 20°C (Pa)
 pub const VAPOR_PRESSURE_WATER_20C: Pressure = Pressure::from_base(2339.0);
+
+/// Vapor pressure of water at 20C -- raw f64 for generic contexts [Pa]
+pub const VAPOR_PRESSURE_WATER_20C_VALUE: f64 = 2339.0;
 
 /// Saturation pressure ratio threshold for inception
 pub const CAVITATION_INCEPTION_THRESHOLD: f64 = 0.9;

--- a/crates/cfd-core/src/physics/fluid/blood/casson.rs
+++ b/crates/cfd-core/src/physics/fluid/blood/casson.rs
@@ -39,10 +39,10 @@ use aequitas::systems::si::quantities::{
 #[inline]
 #[must_use]
 pub fn temperature_viscosity_factor(temp_c: f64) -> f64 {
-    const B_K: f64 = 1500.0;
-    const T_REF_K: f64 = 310.15; // 37.0 °C in kelvin
-    let t_k = temp_c + 273.15;
-    (B_K * (1.0 / t_k - 1.0 / T_REF_K)).exp()
+    let b_k = super::constants::ANDRADE_B_BLOOD;
+    let t_ref_k = super::constants::BODY_TEMPERATURE_K;
+    let t_k = temp_c + crate::physics::constants::physics::thermo::CELSIUS_TO_KELVIN;
+    (b_k * (1.0 / t_k - 1.0 / t_ref_k)).exp()
 }
 use crate::physics::fluid::traits::{Fluid as FluidTrait, FluidState, NonNewtonianFluid};
 use eunomia::RealField;
@@ -276,8 +276,8 @@ impl<T: RealField + FloatElement + Copy> CassonBlood<T> {
         shear_rate: T,
         temperature: ThermodynamicTemperature<T>,
     ) -> T {
-        let t_ref = <T as FloatElement>::from_f64(310.15);
-        let b = <T as FloatElement>::from_f64(1500.0);
+        let t_ref = <T as FloatElement>::from_f64(super::constants::BODY_TEMPERATURE_K);
+        let b = <T as FloatElement>::from_f64(super::constants::ANDRADE_B_BLOOD);
         let temp_k = temperature.into_base();
         let t_eff = if temp_k <= <T as NumericElement>::ZERO {
             t_ref

--- a/crates/cfd-core/src/physics/fluid/blood/constants.rs
+++ b/crates/cfd-core/src/physics/fluid/blood/constants.rs
@@ -55,3 +55,11 @@ pub const NORMAL_HEMATOCRIT: f64 = 0.45;
 
 /// Critical vessel diameter for Fåhræus-Lindqvist effect \[m]
 pub const FAHRAEUS_LINDQVIST_CRITICAL_DIAMETER: f64 = 300e-6;
+
+/// Normal human body temperature [K] (37 C)
+pub const BODY_TEMPERATURE_K: f64 = 310.15;
+
+/// Andrade blood viscosity temperature coefficient B [K]
+/// Used in the exponential temperature correction: exp(B * (1/T - 1/T_ref))
+/// Reference: Fung (1993)
+pub const ANDRADE_B_BLOOD: f64 = 1500.0;

--- a/crates/cfd-core/src/physics/fluid/database.rs
+++ b/crates/cfd-core/src/physics/fluid/database.rs
@@ -82,7 +82,9 @@ pub fn ideal_air<T: RealField + FloatElement + Copy>() -> Result<IdealGas<T>, Er
         SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(287.0)),
         SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(1005.0)),
         DynamicViscosity::from_base(<T as FloatElement>::from_f64(1.716e-5)),
-        ThermodynamicTemperature::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::thermo::CELSIUS_TO_KELVIN)),
+        ThermodynamicTemperature::from_base(<T as FloatElement>::from_f64(
+            crate::physics::constants::physics::thermo::CELSIUS_TO_KELVIN,
+        )),
         TemperatureDifference::from_base(<T as FloatElement>::from_f64(110.4)),
     ))
 }

--- a/crates/cfd-core/src/physics/fluid/database.rs
+++ b/crates/cfd-core/src/physics/fluid/database.rs
@@ -82,7 +82,7 @@ pub fn ideal_air<T: RealField + FloatElement + Copy>() -> Result<IdealGas<T>, Er
         SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(287.0)),
         SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(1005.0)),
         DynamicViscosity::from_base(<T as FloatElement>::from_f64(1.716e-5)),
-        ThermodynamicTemperature::from_base(<T as FloatElement>::from_f64(273.15)),
+        ThermodynamicTemperature::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::thermo::CELSIUS_TO_KELVIN)),
         TemperatureDifference::from_base(<T as FloatElement>::from_f64(110.4)),
     ))
 }

--- a/crates/cfd-core/src/physics/fluid/newtonian.rs
+++ b/crates/cfd-core/src/physics/fluid/newtonian.rs
@@ -96,11 +96,11 @@ impl<T: RealField + Copy> ConstantPropertyFluid<T> {
     {
         let fluid = Self::new(
             "Water (20°C)".to_string(),
-            MassDensity::from_base(<T as FloatElement>::from_f64(998.2)),
-            DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.001_002)),
-            SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(4186.0)),
-            ThermalConductivity::from_base(<T as FloatElement>::from_f64(0.599)),
-            Velocity::from_base(<T as FloatElement>::from_f64(1482.0)),
+            MassDensity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_DENSITY)),
+            DynamicViscosity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_VISCOSITY)),
+            SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_SPECIFIC_HEAT)),
+            ThermalConductivity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_THERMAL_CONDUCTIVITY)),
+            Velocity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_SPEED_OF_SOUND)),
         );
         fluid.validate()?;
         Ok(fluid)

--- a/crates/cfd-core/src/physics/fluid/newtonian.rs
+++ b/crates/cfd-core/src/physics/fluid/newtonian.rs
@@ -96,11 +96,21 @@ impl<T: RealField + Copy> ConstantPropertyFluid<T> {
     {
         let fluid = Self::new(
             "Water (20°C)".to_string(),
-            MassDensity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_DENSITY)),
-            DynamicViscosity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_VISCOSITY)),
-            SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_SPECIFIC_HEAT)),
-            ThermalConductivity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_THERMAL_CONDUCTIVITY)),
-            Velocity::from_base(<T as FloatElement>::from_f64(crate::physics::constants::physics::fluid::WATER_SPEED_OF_SOUND)),
+            MassDensity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::constants::physics::fluid::WATER_DENSITY,
+            )),
+            DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::constants::physics::fluid::WATER_VISCOSITY,
+            )),
+            SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::constants::physics::fluid::WATER_SPECIFIC_HEAT,
+            )),
+            ThermalConductivity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::constants::physics::fluid::WATER_THERMAL_CONDUCTIVITY,
+            )),
+            Velocity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::constants::physics::fluid::WATER_SPEED_OF_SOUND,
+            )),
         );
         fluid.validate()?;
         Ok(fluid)

--- a/crates/cfd-core/src/physics/fluid/non_newtonian/carreau_yasuda.rs
+++ b/crates/cfd-core/src/physics/fluid/non_newtonian/carreau_yasuda.rs
@@ -87,15 +87,15 @@ impl<T: RealField + FloatElement + Copy> CarreauYasuda<T> {
     pub fn blood() -> Self {
         Self::new(
             "Blood".to_string(),
-            MassDensity::from_base(<T as FloatElement>::from_f64(1060.0)),
-            DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.056)),
-            DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.0035)),
-            Time::from_base(<T as FloatElement>::from_f64(3.313)),
-            Dimensionless::from_base(<T as FloatElement>::from_f64(0.3568)),
-            Dimensionless::from_base(<T as FloatElement>::from_f64(2.0)),
+            MassDensity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::BLOOD_DENSITY)),
+            DynamicViscosity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::ZERO_SHEAR_VISCOSITY)),
+            DynamicViscosity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
+            Time::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::CARREAU_LAMBDA)),
+            Dimensionless::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::CARREAU_N)),
+            Dimensionless::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::CARREAU_A)),
             SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(3600.0)),
             ThermalConductivity::from_base(<T as FloatElement>::from_f64(0.5)),
-            Velocity::from_base(<T as FloatElement>::from_f64(1540.0)),
+            Velocity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX)),
         )
     }
 }

--- a/crates/cfd-core/src/physics/fluid/non_newtonian/carreau_yasuda.rs
+++ b/crates/cfd-core/src/physics/fluid/non_newtonian/carreau_yasuda.rs
@@ -87,15 +87,29 @@ impl<T: RealField + FloatElement + Copy> CarreauYasuda<T> {
     pub fn blood() -> Self {
         Self::new(
             "Blood".to_string(),
-            MassDensity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::BLOOD_DENSITY)),
-            DynamicViscosity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::ZERO_SHEAR_VISCOSITY)),
-            DynamicViscosity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
-            Time::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::CARREAU_LAMBDA)),
-            Dimensionless::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::CARREAU_N)),
-            Dimensionless::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::CARREAU_A)),
+            MassDensity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::BLOOD_DENSITY,
+            )),
+            DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::ZERO_SHEAR_VISCOSITY,
+            )),
+            DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            )),
+            Time::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::CARREAU_LAMBDA,
+            )),
+            Dimensionless::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::CARREAU_N,
+            )),
+            Dimensionless::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::CARREAU_A,
+            )),
             SpecificHeatCapacity::from_base(<T as FloatElement>::from_f64(3600.0)),
             ThermalConductivity::from_base(<T as FloatElement>::from_f64(0.5)),
-            Velocity::from_base(<T as FloatElement>::from_f64(crate::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX)),
+            Velocity::from_base(<T as FloatElement>::from_f64(
+                crate::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND_APPROX,
+            )),
         )
     }
 }

--- a/crates/cfd-core/src/physics/hemolysis/calculator.rs
+++ b/crates/cfd-core/src/physics/hemolysis/calculator.rs
@@ -182,7 +182,9 @@ impl<T: FloatElement + Copy> HemolysisCalculator<T> {
                 }
             }
             HemolysisModel::LinearThreshold { threshold, .. } => Ok(threshold),
-            HemolysisModel::Zhang { .. } => Ok(1000.0 * crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
+            HemolysisModel::Zhang { .. } => {
+                Ok(1000.0 * crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)
+            }
         }
     }
 }

--- a/crates/cfd-core/src/physics/hemolysis/calculator.rs
+++ b/crates/cfd-core/src/physics/hemolysis/calculator.rs
@@ -181,8 +181,8 @@ impl<T: FloatElement + Copy> HemolysisCalculator<T> {
                     Ok(f64::INFINITY)
                 }
             }
-            HemolysisModel::HeuserOpitz { threshold, .. } => Ok(threshold),
-            HemolysisModel::Zhang { .. } => Ok(1000.0 * 0.0035),
+            HemolysisModel::LinearThreshold { threshold, .. } => Ok(threshold),
+            HemolysisModel::Zhang { .. } => Ok(1000.0 * crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
         }
     }
 }

--- a/crates/cfd-core/src/physics/hemolysis/mod.rs
+++ b/crates/cfd-core/src/physics/hemolysis/mod.rs
@@ -68,14 +68,23 @@ mod tests {
     }
 
     #[test]
-    fn test_heuser_opitz_threshold() {
-        let model = HemolysisModel::heuser_opitz();
+    fn test_linear_threshold_model() {
+        let model = HemolysisModel::linear_threshold(150.0, 0.01);
 
         let d_below = model.damage_index(100.0, 1.0).expect("expected value");
         let d_above = model.damage_index(200.0, 1.0).expect("expected value");
 
         assert_eq!(d_below, 0.0);
         assert!(d_above > 0.0);
+    }
+
+    #[test]
+    fn test_heuser_opitz_couette_power_law() {
+        // Heuser & Opitz (1980): HI = 1.8e-6 · τ^2.09 · t^0.765
+        let model = HemolysisModel::heuser_opitz_couette();
+        let expected = 1.8e-6 * 100.0_f64.powf(2.09) * 1.0_f64.powf(0.765);
+        let actual = model.damage_index(100.0, 1.0).expect("expected value");
+        assert!((actual - expected).abs() < 1e-15);
     }
 
     #[test]

--- a/crates/cfd-core/src/physics/hemolysis/models.rs
+++ b/crates/cfd-core/src/physics/hemolysis/models.rs
@@ -10,7 +10,7 @@
 //! HI = ΔHb / Hb = C · τ^α · t^β
 //! ```
 //!
-//! with standard constants $C = 3.62 \times 10^{-5}$, $\alpha = 2.416$,
+//! with standard constants $C = 3.62 \times 10^{-7}$, $\alpha = 2.416$,
 //! $\beta = 0.785$ (laminar Couette-flow calibration).
 //!
 //! **Proof sketch.** Giersiepen et al. performed controlled Couette-viscometer
@@ -31,24 +31,24 @@
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 
-// ── Named constants for millifluidic Giersiepen model ─────────────────────────
+// ── Named constants for the Giersiepen power law ─────────────────────────────
 
-/// Giersiepen (1990) Table 1: Couette viscometer calibration constant C for
-/// blood processing and millifluidic devices.  `HI = C · τ^β · t^α`.
+/// Giersiepen (1990) calibration constant C for the haemolysis index
+/// `HI = C · τ^α · t^β` (τ in Pa, t in s).
 ///
 /// **Reference**: Giersiepen M. et al. (1990). "Estimation of shear stress-related
 /// blood damage in heart valve prostheses." *Int. J. Artif. Organs* 13(5):300–306.
-pub const GIERSIEPEN_MILLIFLUIDIC_C: f64 = 3.62e-5;
+pub const GIERSIEPEN_MILLIFLUIDIC_C: f64 = 3.62e-7;
 
-/// Giersiepen (1990) shear-stress exponent β for millifluidic devices.
+/// Giersiepen (1990) shear-stress exponent α.
 ///
 /// Calibrated from Couette-viscometer experiments at τ ∈ [40, 255] Pa.
-pub const GIERSIEPEN_MILLIFLUIDIC_STRESS: f64 = 1.991;
+pub const GIERSIEPEN_MILLIFLUIDIC_STRESS: f64 = 2.416;
 
-/// Giersiepen (1990) time exponent α for millifluidic devices.
+/// Giersiepen (1990) time exponent β.
 ///
 /// Calibrated from Couette-viscometer experiments at t ∈ [7, 700] ms.
-pub const GIERSIEPEN_MILLIFLUIDIC_TIME: f64 = 0.765;
+pub const GIERSIEPEN_MILLIFLUIDIC_TIME: f64 = 0.785;
 
 /// Conservative cavitation amplification slope for SDT millifluidic devices.
 ///
@@ -80,8 +80,8 @@ pub enum HemolysisModel {
         /// Shear rate exponent
         rate_exponent: f64,
     },
-    /// Heuser-Opitz model (1980)
-    HeuserOpitz {
+    /// Generic linear-threshold damage model.
+    LinearThreshold {
         /// Critical shear stress threshold (Pa)
         threshold: f64,
         /// Damage rate above threshold
@@ -92,7 +92,7 @@ pub enum HemolysisModel {
 impl Default for HemolysisModel {
     fn default() -> Self {
         Self::PowerLaw {
-            coefficient: 3.62e-5,
+            coefficient: 3.62e-7,
             stress_exponent: 2.416,
             time_exponent: 0.785,
         }
@@ -103,31 +103,38 @@ impl HemolysisModel {
     /// Create Giersiepen model with standard constants
     pub fn giersiepen_standard() -> Self {
         Self::PowerLaw {
-            coefficient: 3.62e-5,
+            coefficient: 3.62e-7,
             stress_exponent: 2.416,
             time_exponent: 0.785,
         }
     }
 
-    /// Create Giersiepen model for turbulent flow
-    pub fn giersiepen_turbulent() -> Self {
+    /// Heuser & Opitz (1980) Couette-viscometer power law:
+    /// `HI = 1.8×10⁻⁶ · τ^2.09 · t^0.765`.
+    ///
+    /// **Reference**: Heuser, G. & Opitz, R. (1980). "A Couette viscometer for
+    /// short time shearing of blood." *Biorheology* 17:17–24.
+    pub fn heuser_opitz_couette() -> Self {
         Self::PowerLaw {
             coefficient: 1.8e-6,
-            stress_exponent: 1.991,
+            stress_exponent: 2.09,
             time_exponent: 0.765,
         }
     }
 
-    /// Create Giersiepen model for laminar flow
-    pub fn giersiepen_laminar() -> Self {
-        Self::PowerLaw {
-            coefficient: 1.228e-5,
-            stress_exponent: 1.9918,
-            time_exponent: 0.6606,
+    /// Create a generic linear-threshold damage model.
+    ///
+    /// Note: this is *not* the published Heuser & Opitz (1980) correlation —
+    /// that is the power law returned by [`Self::heuser_opitz_couette`].
+    pub fn linear_threshold(threshold: f64, damage_rate: f64) -> Self {
+        Self::LinearThreshold {
+            threshold,
+            damage_rate,
         }
     }
 
-    /// Create Zhang model for Couette flow
+    /// Zhang model for Couette flow (Zhang et al. 2011):
+    /// `HI = 1.86×10⁻⁴ · γ̇^1.84 · t` with γ̇ the shear rate in s⁻¹.
     pub fn zhang() -> Self {
         Self::Zhang {
             coefficient: 1.86e-4,
@@ -135,16 +142,14 @@ impl HemolysisModel {
         }
     }
 
-    /// Create Heuser-Opitz threshold model
-    pub fn heuser_opitz() -> Self {
-        Self::HeuserOpitz {
-            threshold: 150.0,
-            damage_rate: 0.01,
-        }
-    }
-
-    /// Giersiepen (1990) model validated for millifluidic and blood-processing
-    /// devices (SDT, micro-pump, oxygenator, venturi).
+    /// Giersiepen (1990) model applied to millifluidic and blood-processing
+    /// device screening (SDT, micro-pump, oxygenator, venturi).
+    ///
+    /// Uses the standard Couette calibration — no device-specific
+    /// recalibration exists in the literature. Prior to 2026-08-20 this
+    /// variant carried fabricated constants (C = 3.62×10⁻⁵, β = 1.991,
+    /// α = 0.765) presented as "Giersiepen Table 1"; the actual published
+    /// values are C = 3.62×10⁻⁷, α = 2.416, β = 0.785.
     ///
     /// # Theorem — Giersiepen Power-Law (Giersiepen et al. 1990)
     ///
@@ -152,10 +157,10 @@ impl HemolysisModel {
     /// exposed to scalar shear stress τ for duration t follows the empirical law:
     ///
     /// ```text
-    /// HI = C · τ^β · t^α
+    /// HI = C · τ^α · t^β
     /// ```
     ///
-    /// with C = 3.62 × 10⁻⁵,  β = 1.991 (shear exponent),  α = 0.765 (time exponent).
+    /// with C = 3.62 × 10⁻⁷,  α = 2.416 (shear exponent),  β = 0.785 (time exponent).
     /// These constants were calibrated against Couette-viscometer experiments at
     /// τ ∈ [40, 255] Pa and t ∈ [7, 700] ms (Table 1 of Giersiepen et al. 1990).
     ///
@@ -225,11 +230,11 @@ impl HemolysisModel {
                 coefficient,
                 rate_exponent,
             } => {
-                let shear_rate = shear_stress / 0.0035;
+                let shear_rate = shear_stress / crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY;
                 Ok(coefficient * shear_rate.powf(*rate_exponent) * exposure_time)
             }
 
-            Self::HeuserOpitz {
+            Self::LinearThreshold {
                 threshold,
                 damage_rate,
             } => {

--- a/crates/cfd-core/src/physics/hemolysis/models.rs
+++ b/crates/cfd-core/src/physics/hemolysis/models.rs
@@ -230,7 +230,8 @@ impl HemolysisModel {
                 coefficient,
                 rate_exponent,
             } => {
-                let shear_rate = shear_stress / crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY;
+                let shear_rate = shear_stress
+                    / crate::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY;
                 Ok(coefficient * shear_rate.powf(*rate_exponent) * exposure_time)
             }
 

--- a/crates/cfd-core/src/physics/material/interface.rs
+++ b/crates/cfd-core/src/physics/material/interface.rs
@@ -44,7 +44,7 @@ impl<T: FloatElement + Copy> FluidSolidInterface<T> {
         let pi = <T as FloatElement>::from_f64(std::f64::consts::PI);
         let contact_angle = Angle::from_base(pi / <T as FloatElement>::from_f64(2.0));
         Self {
-            surface_tension: SurfaceTension::from_base(<T as FloatElement>::from_f64(0.0728)),
+            surface_tension: SurfaceTension::from_base(<T as FloatElement>::from_f64(crate::physics::cavitation::constants::SURFACE_TENSION_WATER_VALUE)),
             contact_angle,
             wetting: WettingProperties {
                 contact_angle,

--- a/crates/cfd-core/src/physics/material/interface.rs
+++ b/crates/cfd-core/src/physics/material/interface.rs
@@ -44,7 +44,9 @@ impl<T: FloatElement + Copy> FluidSolidInterface<T> {
         let pi = <T as FloatElement>::from_f64(std::f64::consts::PI);
         let contact_angle = Angle::from_base(pi / <T as FloatElement>::from_f64(2.0));
         Self {
-            surface_tension: SurfaceTension::from_base(<T as FloatElement>::from_f64(crate::physics::cavitation::constants::SURFACE_TENSION_WATER_VALUE)),
+            surface_tension: SurfaceTension::from_base(<T as FloatElement>::from_f64(
+                crate::physics::cavitation::constants::SURFACE_TENSION_WATER_VALUE,
+            )),
             contact_angle,
             wetting: WettingProperties {
                 contact_angle,

--- a/crates/cfd-core/src/physics/values/temperature.rs
+++ b/crates/cfd-core/src/physics/values/temperature.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 // Temperature conversion constants
-const KELVIN_TO_CELSIUS_OFFSET: f64 = 273.15;
+use crate::physics::constants::physics::thermo::CELSIUS_TO_KELVIN as KELVIN_TO_CELSIUS_OFFSET;
 const FAHRENHEIT_SCALE_FACTOR: f64 = 9.0 / 5.0;
 const FAHRENHEIT_OFFSET: f64 = 32.0;
 const RANKINE_TO_KELVIN_FACTOR: f64 = 5.0 / 9.0;

--- a/crates/cfd-python/src/solver_2d/bifurcation.rs
+++ b/crates/cfd-python/src/solver_2d/bifurcation.rs
@@ -154,10 +154,10 @@ impl PyBifurcationSolver2D {
         let blood = match blood_type {
             "casson" => BloodModel::Casson(CassonBlood::normal_blood()),
             "carreau_yasuda" => BloodModel::CarreauYasuda(CarreauYasudaBlood::normal_blood()),
-            _ => BloodModel::Newtonian(0.0035),
+            _ => BloodModel::Newtonian(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
         };
 
-        let density = 1060.0;
+        let density = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;
         let mut config = SIMPLEConfig::default();
         config.max_iterations = 5000;
         config.tolerance = 1e-5;

--- a/crates/cfd-python/src/solver_2d/bifurcation.rs
+++ b/crates/cfd-python/src/solver_2d/bifurcation.rs
@@ -154,7 +154,9 @@ impl PyBifurcationSolver2D {
         let blood = match blood_type {
             "casson" => BloodModel::Casson(CassonBlood::normal_blood()),
             "carreau_yasuda" => BloodModel::CarreauYasuda(CarreauYasudaBlood::normal_blood()),
-            _ => BloodModel::Newtonian(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
+            _ => BloodModel::Newtonian(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            ),
         };
 
         let density = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;

--- a/crates/cfd-python/src/solver_2d/poiseuille.rs
+++ b/crates/cfd-python/src/solver_2d/poiseuille.rs
@@ -105,13 +105,13 @@ impl PyPoiseuille2DSolver {
             .map_err(|e| PyRuntimeError::new_err(format!("Grid error: {e}")))?;
 
         let mut fields = SimulationFields::new(self.nx, self.ny);
-        let rho = 1060.0;
+        let rho = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;
         let pressure_gradient = pressure_drop / self.length;
 
         let viscosity = match blood_type {
             "casson" => CassonBlood::<f64>::normal_blood().apparent_viscosity(100.0),
             "carreau_yasuda" => CarreauYasudaBlood::<f64>::normal_blood().apparent_viscosity(100.0),
-            _ => 0.0035,
+            _ => cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
         };
 
         for i in 0..self.nx {

--- a/crates/cfd-python/src/solver_2d/serpentine.rs
+++ b/crates/cfd-python/src/solver_2d/serpentine.rs
@@ -74,7 +74,7 @@ impl PySerpentineSolver1D {
         );
 
         let dh = cross_section.hydraulic_diameter();
-        let density = 1060.0;
+        let density = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;
 
         let (mu, re) = match blood_type {
             "casson" => {
@@ -90,7 +90,7 @@ impl PySerpentineSolver1D {
                 (mu, re)
             }
             _ => {
-                let mu = 0.0035;
+                let mu = cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY;
                 let re = density * velocity * dh / mu;
                 (mu, re)
             }
@@ -105,7 +105,7 @@ impl PySerpentineSolver1D {
             DynamicViscosity::from_base(mu),
             SpecificHeatCapacity::from_base(3617.0),
             ThermalConductivity::from_base(0.52),
-            Velocity::from_base(1570.0),
+            Velocity::from_base(cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND),
         );
 
         let resistance = model

--- a/crates/cfd-python/src/solver_2d/venturi.rs
+++ b/crates/cfd-python/src/solver_2d/venturi.rs
@@ -116,10 +116,10 @@ impl PyVenturiSolver2D {
         let blood = match blood_type {
             "casson" => BloodModel::Casson(CassonBlood::normal_blood()),
             "carreau_yasuda" => BloodModel::CarreauYasuda(CarreauYasudaBlood::normal_blood()),
-            _ => BloodModel::Newtonian(0.0035),
+            _ => BloodModel::Newtonian(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
         };
 
-        let density = 1060.0;
+        let density = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;
         let mut solver = VSolver::new(geom, blood, density, self.nx, self.ny);
 
         let sol = solver
@@ -223,7 +223,7 @@ impl PyVenturiSolver1D {
             self.total_length,
         );
 
-        let density = 1060.0;
+        let density = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;
         let dh = self.inlet_diameter;
 
         let mu = match blood_type {
@@ -235,7 +235,7 @@ impl PyVenturiSolver1D {
                 let blood = CarreauYasudaBlood::<f64>::normal_blood();
                 blood.apparent_viscosity(velocity / dh * 8.0)
             }
-            _ => 0.0035,
+            _ => cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
         };
 
         let re = density * velocity * dh / mu;
@@ -248,7 +248,7 @@ impl PyVenturiSolver1D {
             DynamicViscosity::from_base(mu),
             SpecificHeatCapacity::from_base(3617.0),
             ThermalConductivity::from_base(0.52),
-            Velocity::from_base(1570.0),
+            Velocity::from_base(cfd_core::physics::fluid::blood::constants::BLOOD_SPEED_OF_SOUND),
         );
 
         let resistance = model

--- a/crates/cfd-python/src/solver_2d/venturi.rs
+++ b/crates/cfd-python/src/solver_2d/venturi.rs
@@ -116,7 +116,9 @@ impl PyVenturiSolver2D {
         let blood = match blood_type {
             "casson" => BloodModel::Casson(CassonBlood::normal_blood()),
             "carreau_yasuda" => BloodModel::CarreauYasuda(CarreauYasudaBlood::normal_blood()),
-            _ => BloodModel::Newtonian(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY),
+            _ => BloodModel::Newtonian(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            ),
         };
 
         let density = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;

--- a/crates/cfd-python/src/solver_3d/poiseuille.rs
+++ b/crates/cfd-python/src/solver_3d/poiseuille.rs
@@ -82,11 +82,11 @@ impl PyPoiseuille3DSolver {
     fn solve(&self, pressure_drop: f64, blood_type: &str) -> PyResult<PyPoiseuille3DResult> {
         use cfd_core::physics::fluid::blood::CarreauYasudaBlood;
 
-        let rho = 1060.0;
+        let rho = cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY;
         let gamma_dot = 100.0;
 
         let mu = match blood_type {
-            "newtonian" => 0.0035,
+            "newtonian" => cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
             "casson" => {
                 let fluid = CassonBlood::<f64>::normal_blood();
                 fluid.apparent_viscosity(gamma_dot)

--- a/crates/cfd-validation/src/analytical/womersley.rs
+++ b/crates/cfd-validation/src/analytical/womersley.rs
@@ -61,8 +61,8 @@ impl<T: CfdScalar> WomersleyFlow<T> {
     pub fn physiological_blood_flow() -> Self {
         Self {
             radius: Length::from_base(<T as FloatElement>::from_f64(4.0e-3)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(1060.0)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(0.0035)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
             omega: ReciprocalTime::from_base(<T as FloatElement>::from_f64(2.0 * PI * 1.2)),
             pressure_gradient_amplitude: PressureGradient::from_base(
                 <T as FloatElement>::from_f64(1000.0),

--- a/crates/cfd-validation/src/analytical/womersley.rs
+++ b/crates/cfd-validation/src/analytical/womersley.rs
@@ -61,8 +61,12 @@ impl<T: CfdScalar> WomersleyFlow<T> {
     pub fn physiological_blood_flow() -> Self {
         Self {
             radius: Length::from_base(<T as FloatElement>::from_f64(4.0e-3)),
-            density: MassDensity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY)),
-            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY)),
+            density: MassDensity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+            )),
+            viscosity: DynamicViscosity::from_base(<T as FloatElement>::from_f64(
+                cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY,
+            )),
             omega: ReciprocalTime::from_base(<T as FloatElement>::from_f64(2.0 * PI * 1.2)),
             pressure_gradient_amplitude: PressureGradient::from_base(
                 <T as FloatElement>::from_f64(1000.0),

--- a/crates/cfd-validation/src/benchmarks/bifurcation.rs
+++ b/crates/cfd-validation/src/benchmarks/bifurcation.rs
@@ -105,8 +105,13 @@ where
 
         // Perform simulation iterations
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY); // Blood density
-        let _nu_base: T = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY / cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY); // Base kinematic viscosity
+        let rho = <T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+        ); // Blood density
+        let _nu_base: T = <T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY
+                / cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+        ); // Base kinematic viscosity
 
         for _ in 0..config.max_iterations {
             // In a real implementation, we'd update viscosity based on local shear rate here

--- a/crates/cfd-validation/src/benchmarks/bifurcation.rs
+++ b/crates/cfd-validation/src/benchmarks/bifurcation.rs
@@ -105,8 +105,8 @@ where
 
         // Perform simulation iterations
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(1060.0); // Blood density
-        let _nu_base: T = <T as FloatElement>::from_f64(3.5e-3 / 1060.0); // Base kinematic viscosity
+        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY); // Blood density
+        let _nu_base: T = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::INFINITE_SHEAR_VISCOSITY / cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY); // Base kinematic viscosity
 
         for _ in 0..config.max_iterations {
             // In a real implementation, we'd update viscosity based on local shear rate here

--- a/crates/cfd-validation/src/benchmarks/serpentine.rs
+++ b/crates/cfd-validation/src/benchmarks/serpentine.rs
@@ -10,10 +10,10 @@ use cfd_2d::fields::SimulationFields;
 use cfd_2d::grid::StructuredGrid2D;
 use cfd_2d::simplec_pimple::solver::SimplecPimpleSolver;
 use cfd_core::error::Result;
-use cfd_core::physics::fluid::blood::CarreauYasudaBlood;
-use cfd_core::physics::fluid::blood::constants::BODY_TEMPERATURE_K;
-use cfd_core::physics::fluid::traits::Fluid as FluidTrait;
 use cfd_core::physics::constants::physics::thermo::P_ATM;
+use cfd_core::physics::fluid::blood::constants::BODY_TEMPERATURE_K;
+use cfd_core::physics::fluid::blood::CarreauYasudaBlood;
+use cfd_core::physics::fluid::traits::Fluid as FluidTrait;
 use cfd_core::CfdScalar;
 use eunomia::NumericElement;
 use eunomia::{FloatElement, RealField};
@@ -92,7 +92,9 @@ where
 
         let start_time = std::time::Instant::now();
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY);
+        let rho = <T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+        );
 
         for _ in 0..config.max_iterations {
             let dt = config

--- a/crates/cfd-validation/src/benchmarks/serpentine.rs
+++ b/crates/cfd-validation/src/benchmarks/serpentine.rs
@@ -11,7 +11,9 @@ use cfd_2d::grid::StructuredGrid2D;
 use cfd_2d::simplec_pimple::solver::SimplecPimpleSolver;
 use cfd_core::error::Result;
 use cfd_core::physics::fluid::blood::CarreauYasudaBlood;
+use cfd_core::physics::fluid::blood::constants::BODY_TEMPERATURE_K;
 use cfd_core::physics::fluid::traits::Fluid as FluidTrait;
+use cfd_core::physics::constants::physics::thermo::P_ATM;
 use cfd_core::CfdScalar;
 use eunomia::NumericElement;
 use eunomia::{FloatElement, RealField};
@@ -90,7 +92,7 @@ where
 
         let start_time = std::time::Instant::now();
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(1060.0);
+        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY);
 
         for _ in 0..config.max_iterations {
             let dt = config
@@ -115,8 +117,8 @@ where
         // Calculate metrics
         let props = FluidTrait::properties_at(
             &blood,
-            <T as FloatElement>::from_f64(310.0),
-            <T as FloatElement>::from_f64(101325.0),
+            <T as FloatElement>::from_f64(BODY_TEMPERATURE_K),
+            <T as FloatElement>::from_f64(P_ATM),
         )?;
         // dynamic_viscosity available via props if needed downstream
         let _ = props.dynamic_viscosity;

--- a/crates/cfd-validation/src/benchmarks/trifurcation.rs
+++ b/crates/cfd-validation/src/benchmarks/trifurcation.rs
@@ -99,7 +99,9 @@ where
 
         let start_time = std::time::Instant::now();
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY);
+        let rho = <T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+        );
 
         for _ in 0..config.max_iterations {
             let dt = config

--- a/crates/cfd-validation/src/benchmarks/trifurcation.rs
+++ b/crates/cfd-validation/src/benchmarks/trifurcation.rs
@@ -99,7 +99,7 @@ where
 
         let start_time = std::time::Instant::now();
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(1060.0);
+        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY);
 
         for _ in 0..config.max_iterations {
             let dt = config

--- a/crates/cfd-validation/src/benchmarks/venturi.rs
+++ b/crates/cfd-validation/src/benchmarks/venturi.rs
@@ -98,7 +98,9 @@ where
 
         let start_time = std::time::Instant::now();
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY);
+        let rho = <T as FloatElement>::from_f64(
+            cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY,
+        );
 
         for _ in 0..config.max_iterations {
             let dt = config

--- a/crates/cfd-validation/src/benchmarks/venturi.rs
+++ b/crates/cfd-validation/src/benchmarks/venturi.rs
@@ -11,6 +11,7 @@ use cfd_2d::grid::StructuredGrid2D;
 use cfd_2d::simplec_pimple::solver::SimplecPimpleSolver;
 use cfd_core::error::Result;
 use cfd_core::physics::cavitation::VenturiCavitation;
+use cfd_core::physics::constants::physics::thermo::P_ATM;
 use cfd_core::physics::fluid::blood::CassonBlood;
 use cfd_core::CfdScalar;
 use eunomia::NumericElement;
@@ -97,7 +98,7 @@ where
 
         let start_time = std::time::Instant::now();
         let mut convergence = Vec::new();
-        let rho = <T as FloatElement>::from_f64(1060.0);
+        let rho = <T as FloatElement>::from_f64(cfd_core::physics::fluid::blood::constants::BLOOD_DENSITY);
 
         for _ in 0..config.max_iterations {
             let dt = config
@@ -127,7 +128,7 @@ where
                 self.geometry.outlet_width - self.geometry.throat_width,
                 self.geometry.l_diverge,
             )),
-            inlet_pressure: Pressure::from_base(<T as FloatElement>::from_f64(101325.0)),
+            inlet_pressure: Pressure::from_base(<T as FloatElement>::from_f64(P_ATM)),
             inlet_velocity: Velocity::from_base(<T as FloatElement>::from_f64(1.0)),
             density: MassDensity::from_base(rho),
             vapor_pressure: Pressure::from_base(<T as FloatElement>::from_f64(2339.0)),

--- a/crates/cfd-validation/src/conservation/mod.rs
+++ b/crates/cfd-validation/src/conservation/mod.rs
@@ -4,6 +4,7 @@
 //! This module provides tools to verify that CFD simulations satisfy fundamental
 //! conservation laws such as mass, momentum, and energy conservation.
 
+use cfd_core::physics::constants::physics::thermo::P_ATM;
 use crate::scalar;
 use eunomia::FloatElement;
 use eunomia::NumericElement;
@@ -78,7 +79,7 @@ pub fn run_comprehensive_conservation_verification<T: RealField + Copy + FloatEl
     );
     let u_prev = Array2::from_elem([32, 32], <T as FloatElement>::from_f64(0.95)); // Slightly different for time derivative
     let v_prev = Array2::zeros([32, 32]);
-    let pressure = Array2::from_elem([32, 32], <T as FloatElement>::from_f64(101325.0)); // Atmospheric pressure
+    let pressure = Array2::from_elem([32, 32], <T as FloatElement>::from_f64(P_ATM)); // Atmospheric pressure
 
     match momentum_checker.check_momentum_2d(
         &velocity_u,

--- a/crates/cfd-validation/src/conservation/mod.rs
+++ b/crates/cfd-validation/src/conservation/mod.rs
@@ -4,8 +4,8 @@
 //! This module provides tools to verify that CFD simulations satisfy fundamental
 //! conservation laws such as mass, momentum, and energy conservation.
 
-use cfd_core::physics::constants::physics::thermo::P_ATM;
 use crate::scalar;
+use cfd_core::physics::constants::physics::thermo::P_ATM;
 use eunomia::FloatElement;
 use eunomia::NumericElement;
 use eunomia::RealField;

--- a/docs/book/appendix_glossary.md
+++ b/docs/book/appendix_glossary.md
@@ -1,4 +1,4 @@
-# Appendix C — Atlas Glossary
+# Appendix B — Atlas Glossary
 
 <!-- generated-figure-start -->
 ![Figure B.2 — B. Glossary](figures/appendix/fig02_b_glossary.svg)

--- a/gap_audit.md
+++ b/gap_audit.md
@@ -1,3 +1,298 @@
+## Finding 2026-08-20: CFDrs scope-vs-delivery audit
+
+Static-evidence audit (no build, no test run) of the declared scope in
+`README.md`, `docs/book/SUMMARY.md`, and `docs/adr.md` against the tree at
+`68e69690` (branch `codex/cfdrs-tvd-test-integration`, 35 pre-existing dirty
+files from a peer session, left untouched). Every number below is a command
+result, not an estimate. No gate was executed, so nothing here asserts that any
+suite passes.
+
+### Measured baseline
+
+| Quantity | Value | How measured |
+|---|---|---|
+| Workspace packages | 12 (11 libs + xtask) | `cargo metadata --offline --no-deps` |
+| Library source | 1154 `.rs`, 268 175 lines under `crates/*/src` | `find`/`cat`/`wc -l` |
+| All Rust incl. tests/benches/examples | 1393 `.rs`, 331 108 lines | same |
+| Test functions | 3129 `#[test]` | `grep -rn '#\[test\]'` |
+| `proptest!` blocks | 60 | `grep -rn 'proptest!'` |
+| Cargo targets | 10 lib, 1 cdylib, 2 bin, 112 test, 49 example, 18 bench | `cargo metadata` |
+| `todo!` / `unimplemented!` / TODO / FIXME | 0 / 0 / 0 | `grep` over `crates xtask tests benches examples` |
+| Files > 500 lines | 135 | `find … -exec wc -l` (Atlas baseline records 134; +1 drift) |
+| Crate-level `#![allow(...)]` in `lib.rs` | 292 across 10 of 11 crates | `grep -h '^#!\[allow' crates/*/src/lib.rs \| wc -l` |
+| `#[allow(` sites | 97 | `grep -rn '#\[allow('` (Atlas baseline 89; **+8 regression**) |
+| Crates with `#![deny(missing_docs)]` | **0 of 11** (all use `warn`) | `grep -l 'deny(missing_docs)' crates/*/src/lib.rs` |
+| Production `.unwrap()` | 0 | `grep -rn '\.unwrap()' crates/*/src \| grep -v test` |
+| `.expect(` sites in `crates/*/src` | 1701, of which **739 read `expect("expected value")`** | `grep -rho 'expect("[^"]*"' \| sort \| uniq -c` |
+| Ignored tests | 32, of which 3 admit unimplemented behaviour | `grep -rn '#\[ignore'` |
+| Book chapters | 19 numbered + 2 appendices, 1610 total lines incl. a 249-line glossary | `wc -l docs/book/*.md` |
+| ADRs | 1 file (`docs/adr.md`, 1601 lines, 53 table rows), 0 numbered ADR files, no index | `ls docs/adr` → absent |
+
+### Substrate consumption — clean at the manifest layer
+
+No workspace or member manifest declares `ndarray`, `nalgebra`, `rayon`,
+`tokio`, `rustfft`, or `approx`. The two occurrences in `Cargo.lock` are
+legitimate boundary transitives: `ndarray` ← `numpy` (the PyO3 NumPy bridge in
+`cfd-python`) and `rayon` ← `criterion` (dev-only). The ndarray→leto migration
+is complete at the dependency-graph level; the only `ndarray::`/`nalgebra::`
+string in the tree is inside `xtask/src/migration_audit.rs`, which is the
+scanner that enforces their absence.
+
+Atlas providers genuinely bound (import-site counts across `crates`, `xtask`,
+`benches`, `examples`, `tests`): eunomia 864, aequitas 518, leto 411,
+gaia-mesh 409 (as `cfd_mesh`), leto-ops 92, athena-leto 31, athena-core 17,
+moirai 17, iris 15, hephaestus-wgpu 14, apollo-fft 8, melinoe 4, hyperion 4,
+themis 3, apollo-nufft 3, hermes-simd 2, coeus-optim 2, consus 3, ritk-vtk 1,
+harmonia 1, proteus 1, tyche-core 1. `moirai` is real consumption — six crates
+declare it and use `Adaptive`, `fold_reduce_with`, `map_collect_mut_with`,
+`ParallelSlice` — not a manifest-only edge. Only 4 `std::thread` sites remain in
+library source. Zero raw `wgpu::` references survive; GPU work routes through
+`hephaestus-wgpu`, though 14 in-repo `.wgsl` kernels remain
+(`crates/cfd-core/src/compute/gpu/kernels/*`, `crates/cfd-math/src/shaders/*`),
+which `Cargo.toml:110` already labels an in-flight replacement.
+
+### F-1 [arch][major] Ungated `#[global_allocator]` inside a library crate
+
+`crates/cfd-validation/src/benchmarking/memory.rs:93` installs
+`TrackingAllocator` as the process global allocator with no `#[cfg]` guard:
+
+    #[global_allocator]
+    static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator {
+        allocator: System,
+        stats: MemoryStats::new(),
+    };
+
+Every binary that links `cfd-validation` — its 40 test targets, both benches,
+its examples, and any downstream consumer — silently routes all allocation
+through atomic counters (`unsafe impl GlobalAlloc`, lines 315-345). Two
+consequences, both observable without running anything: allocation-heavy
+benchmark numbers produced anywhere in that link graph are contaminated by
+instrumentation the measured code did not ask for, and a downstream consumer
+that declares its own `#[global_allocator]` cannot compile against
+`cfd-validation` at all (`E0152`, one allocator per program). This is public
+behaviour of a published crate, so removing or gating it is `[major]`.
+
+### F-2 [verification][patch] 54 files / 10 543 lines sit outside every cargo target
+
+The root manifest is a virtual workspace: `grep '^\[' Cargo.toml` returns
+`[workspace]`, `[workspace.package]`, `[workspace.dependencies]`,
+`[workspace.lints.*]` — and no `[package]`. `Cargo.toml:26` states the cause
+outright: "There is no `cfd-suite` package." Target auto-discovery is
+per-package, so the root `examples/` (37 files), `benches/` (11 files), and
+`tests/` (6 files) are claimed by nothing. Confirmed authoritatively:
+`cargo metadata --offline --no-deps` reports **0 targets** whose `src_path`
+lies under those three directories, while the 49 example / 18 bench / 112 test
+targets it does report all live under `crates/*/`.
+
+`README.md:130-141` presents those same directories as the live set — "37
+example programs", "`benches/` holds 11 criterion suites", and "Examples are not
+run by the test gates, so `cargo build --examples` is the check that keeps them
+from rotting". That check cannot reach them. Neither can `cargo bench
+--workspace`, `cargo check --workspace --all-targets` (the CI step at
+`.github/workflows/ci.yml:85`), or nextest. 10 543 lines of validation drivers —
+including `examples/cavity_validation.rs`, `examples/pipe_flow_validation.rs`,
+and `examples/turbulent_channel_flow.rs`, the three named as figure sources in
+the book manifest — are unverified by construction.
+
+### F-3 [arch][major] 20 563 lines of committed Python domain logic in `validation/`
+
+`git ls-files validation` returns 126 tracked files: 59 `.py` (20 563 lines),
+6 `.pyc` bytecode files under `__pycache__/`, 52 `.xml` and 5 `.png` run
+outputs, 1 `.ps1`, 2 `.md`. The Python is not binding glue — it is a parallel
+implementation of the crate's own declared scope:
+`validation/analytical/poiseuille_2d.py` and
+`validation/analytical/bernoulli_venturi.py` restate analytical solutions that
+`crates/cfd-validation/src/analytical/{poiseuille_2d,…}.rs` already own, and
+`validation/convergence_study.py` restates `crates/cfd-validation/src/convergence/`.
+`xtask/src/main.rs` carries the harness for it (`setup_venv`, `install_deps`,
+`install_fenics`, `validate(…, plot, quick, category)`), so the second stack is
+tooled, not vestigial.
+
+None of it runs in CI — `.github/workflows/ci.yml` has exactly six run steps
+(metadata, fmt, check, clippy, two nextest invocations, doctests) plus the
+figure job. The run outputs are committed under timestamped directories
+(`validation/fluidsim_output/NS2D_64x64_S2pix2pi_2026-02-09_18-10-11/…`),
+which is run-output segregation inverted: the outputs are in git and the
+verification is not in the gate. `CHECKLIST.md:15-17` shows the `.pyc` caches
+were excluded from the *sdist*; they remain tracked in the repository.
+
+### F-4 [arch][minor] Three in-repo SIMD implementations beside a 2-call-site hermes binding
+
+2026 lines of SIMD live in the workspace across three unrelated homes:
+
+- `crates/cfd-core/src/compute/simd/x86.rs` (286 lines) and `aarch64.rs` (197):
+  hand-written `std::arch` intrinsics behind six `pub unsafe fn`
+  (`advection_avx2`, `advection_sse41`, `diffusion_avx2`, `advection_neon`,
+  `diffusion_neon`, `dot_product_neon`), each `#[target_feature(enable = …)]`.
+- `crates/cfd-math/src/simd/` (972 lines: `cfd.rs`, `vector.rs`,
+  `vectorization.rs`, `ops/`, `tests.rs`).
+- `crates/cfd-2d/src/solvers/simd_kernels.rs` (562 lines).
+
+`hermes-simd`, the Atlas SIMD provider, is declared by exactly one crate
+(`crates/cfd-math/Cargo.toml:22`) and referenced at exactly two lines —
+`crates/cfd-math/src/simd/ops/mod.rs:8` and `:196`, the second being an error
+conversion. For an integrator layer this is the substrate-duplication pattern:
+the provider is bound as a thin alias while the workspace keeps three
+first-party implementations of the capability the provider exists to own.
+Related: 17 `unsafe` sites in library source carry only 2 `// SAFETY:` comments;
+the six `pub unsafe fn` do carry `# Safety` rustdoc, and the two genuine
+`unsafe {}` blocks (`crates/cfd-core/src/physics/fluid_dynamics/operations.rs:41,73`)
+are the two that are commented, so the gap is in the intrinsic bodies rather
+than at the call sites.
+
+### F-5 [correctness][patch] 739 content-free `expect` sites, including production solver paths
+
+`grep -rho 'expect("[^"]*"' crates/*/src | sort | uniq -c` puts
+`expect("expected value")` at 739 occurrences — 43% of all 1701 `.expect(` sites
+— against 154 that carry an `invariant:`-prefixed statement. The message states
+nothing a reader or a panic report can use. These are not confined to tests:
+
+    crates/cfd-2d/src/physics/momentum/solve.rs:83   self.matrix_u.as_ref().expect("expected value"),
+    crates/cfd-2d/src/physics/momentum/solve.rs:84   self.rhs_u.as_ref().expect("expected value"),
+    crates/cfd-2d/src/physics/momentum/solve.rs:343  MomentumComponent::U => self.matrix_u.take().expect("expected value"),
+
+That file contains no `mod tests`. Each site is an `Option` field whose
+`Some`-ness depends on an earlier assembly call — an undocumented call-order
+requirement panicking with an unlabelled message. The repo's 0-production-unwrap
+conformance number is therefore satisfied in form: `clippy::unwrap_used` is
+denied at `Cargo.toml:150` and the sites were converted to `expect` without the
+proof the panic policy asks the message to carry.
+
+### F-6 [verification][patch] The flagship grid-convergence study asserts nothing
+
+`crates/cfd-2d/tests/ghia_cavity_simplec_validation.rs:1088-1123` computes an
+observed order per grid pair and prints it. Line 1109 reads
+`let _target_order = 2.0;` — bound, underscored, never compared. The only
+branch is `if *final_error < expected_error { println!("✓ …") } else {
+println!("⚠ …") }`. Replacing the solver body with a constant field would still
+let this test pass; it cannot fail on a convergence regression.
+
+The MMS layer is a source-term library rather than a code-verification gate. The
+Reynolds-stress "grid convergence" test says so in its own comment —
+`crates/cfd-2d/tests/reynolds_stress_comprehensive_tests.rs:583-584`: "This
+tests the MMS implementation itself rather than numerical convergence." The one
+genuine order-of-accuracy assertion found is
+`crates/cfd-2d/tests/poisson_fdm_validation.rs:443-448` (`reduction_factor > 3.0`
+for an expected 4× at second order); `crates/cfd-math/src/time_stepping/imex.rs:484`
+covers temporal order. So the V&V ladder has real published-benchmark anchors
+(Ghia cavity, Armaly backward step in `benchmarks/step.rs`, Taylor-Green,
+Poiseuille, Couette, Blasius, Womersley, Stokes, cylinder) and real analytical
+oracles, but code verification via observed order is asserted at one spatial and
+one temporal site, not across the solver families that declare second order.
+
+Three ignored tests are admissions of unimplemented declared behaviour rather
+than slowness:
+
+    crates/cfd-1d/tests/component_validation.rs:185  "Implementation does not clamp parameters to physical bounds"
+    crates/cfd-1d/tests/component_validation.rs:234  "Valve resistance behavior does not follow expected monotonic relationship"
+    crates/cfd-1d/tests/component_validation.rs:443  "FlowSensor component API differs from expected"
+
+and two more park a migration: `crates/cfd-math/tests/amg_coarsening_tests.rs:5,9`
+"pending migration of domain-specific multigrid code to leto-ops API".
+
+### F-7 [verification][patch] The figure SSOT gate checks names, and its provenance is dangling
+
+`xtask/src/check_figures.rs:94-129` — the function CI runs at
+`.github/workflows/ci.yml:131` — parses `figures/*.svg` references out of
+`SUMMARY.md` and `README.md`, collects the `FIGURE_SPECS` names from
+`prebook.rs`, and reports the two set differences. It never opens an SVG, never
+compares a hash, and never regenerates anything. A figure whose content diverged
+from the data it depicts passes.
+
+`docs/book/figures/MANIFEST.json` records each figure's
+`source_example` as `{"crate_name":"cfd-suite","example_name":"…"}` —
+`cfd-suite` is the package `Cargo.toml:26` states does not exist, and the named
+examples (`pipe_flow_validation`, `cavity_validation`, `turbulent_channel_flow`)
+are root-directory files that F-2 shows cargo cannot build. The figure → data
+chain is therefore unverifiable end to end: the gate does not check content, and
+the recorded producer cannot be run.
+
+### F-8 [pm-hygiene][patch] Two parallel PM systems, a non-conformant ADR store, stale status
+
+Both trees are live and neither defers to the other:
+
+    root:  backlog.md (4487 L)  CHECKLIST.md (4550 L)  gap_audit.md (8705 L)   last touched 2026-08-19
+    docs/: docs/backlog.md (4587 L)  docs/checklist.md (5212 L)  docs/gap_audit.md (4505 L)  last touched 2026-08-20 (68e69690)
+           plus docs/gap_audit_clean.md (a fourth gap file)
+
+`README.md:146` names the root three. The peer session at HEAD writes the
+`docs/` three. `git ls-files` tracks `CHECKLIST.md`; README references
+`checklist.md` — identical on this case-insensitive host, a broken reference on
+a case-sensitive one.
+
+`CFDRS-VAL-RED-1` (`backlog.md:702`) is the item this audit was asked to locate.
+Its status marker reads "(in progress 2026-07-31; owner=Claude atlas session
+0161539d)" while its own body at `backlog.md:729` records "CLOSURE:
+cfd-validation Nextest 434/434 (1 slow)", with root causes named for both
+failures and all four timeouts. The work is reported complete; only the status
+field is stale. It is left as found — the item is another owner's.
+
+ADRs do not follow the governance form: there is no `docs/adr/` directory, no
+numbered records, and no index. `docs/adr.md` is one 1601-line file whose header
+reads `## Status: ACTIVE - Version 1.42.0-SIMD-EXCELLENCE` (the workspace is at
+`0.3.0`) above a 53-row decision table. Decisions cannot be cited by number from
+board items or commits.
+
+`docs/` additionally holds 52 sprint/audit report files
+(`SPRINT_1.45.0_SUMMARY.md` … `SPRINT_1.94.0_…`, `FINAL_VALIDATION_REPORT.md`,
+`AUDIT_SUMMARY_2025_11_18.md`), the report-file genre in bulk. `CHANGELOG.md`
+opens with 30 lines of internal vocabulary policy before its `# Changelog`
+heading; the same block is duplicated verbatim at `gap_audit.md:41`.
+Repository-root non-source files include `errors.json` (174 KB of raw
+`cargo --message-format=json` build output), `ACCOMPLISHMENTS.md`, and
+`ARCHITECTURE.md`.
+
+Book chapter numbering has drifted from `SUMMARY.md`: `core_flows.md` and
+`governing_equations.md` both open "Chapter 2"; `pressure_velocity.md` and
+`turbulence_multiphase.md` both open "Chapter 3"; `crate_schematics.md` opens
+"Chapter 21" where SUMMARY lists it as 13 and its own figure is labelled 13.1;
+`crate_optim.md` opens "Chapter 22" against SUMMARY's 19 / figure 19.1;
+`cavitation.md`, `matrix_free_operators.md`, `schematic_integration_2d.md`, and
+`vascular_bifurcations.md` carry no chapter number at all. Several chapters are
+stubs — `crate_schematics.md` is 8 lines (a figure plus a cross-reference),
+`core_flows.md` 11 lines.
+
+### Conformance floor: the pedantic baseline is suppressed at crate level
+
+`Cargo.toml:133-145` sets `clippy::all` and `clippy::pedantic` to warn and denies
+`unwrap_used`, `print_stdout`, `print_stderr`, `dbg_macro`, with the comment
+"the floor itself never `allow`s them — that would erase the ratchet signal."
+The floor is nonetheless erased downstream: `crates/cfd-validation/src/lib.rs:1`
+is `#![allow(clippy::print_stdout)]` and `crates/cfd-3d/src/lib.rs:6` allows
+`print_stderr`. 409 print/`dbg` sites sit in `crates/*/src` (2673 across all
+targets). Only 5 `#[expect(…)]` ratchet sites exist against 97 `#[allow(`.
+`README.md:113-119` describes this honestly, which is why the crate-level count
+in that paragraph is worth keeping accurate — it read 288 and measures 292.
+
+All 12 packages are `edition = "2021"` with `resolver = "2"`; the toolchain pin
+is `1.97.0`. `crates/cfd-python` ships `pyproject.toml` and a README but no
+`py.typed` and no `.pyi` stubs, so the Python surface is untyped to mypy and
+IDEs; it also carries a committed `casson_rheology_validation.png`.
+
+`crates/cfd-validation/src/convergence/richardson.rs` (224 lines) and
+`crates/cfd-validation/src/manufactured/richardson/core.rs` (551 lines) are two
+implementations of Richardson extrapolation in one crate — `estimate_order`,
+`extrapolate`, and `is_asymptotic` exist in both, the second returning
+`Result<_, String>` (9 stringly-typed error returns in `cfd-validation`, 56
+workspace-wide).
+
+### Completeness
+
+66% of declared scope delivered and verified. Denominator: the capability set
+named in `README.md` (11 crates and their stated solver families), the 19
+chapters plus 2 appendices of `docs/book/SUMMARY.md`, and the 53 accepted
+decisions in `docs/adr.md`. Weighting per the Atlas rubric — capabilities
+implemented without stubs 40% (scored ≈0.92: no `todo!`/`unimplemented!`
+anywhere, every declared solver family present, minus five ignored tests that
+admit unfinished behaviour), verification depth 25% (≈0.55: strong analytical
+and published-benchmark anchors, but observed-order code verification asserted
+at two sites, the flagship convergence study vacuous, 10 543 lines of drivers
+and 20 563 lines of Python validation outside every gate, figure provenance
+dangling), documentation 20% (≈0.55: complete book skeleton with stub chapters
+and drifted numbering, zero crates at `deny(missing_docs)`, non-conformant ADR
+store), conformance floor 15% (≈0.30: 135 oversized files, 292 crate-level
+allows, +8 `#[allow]` regression against the Atlas baseline, edition 2021).
+
 ## ATLAS-CFDRS-BACKWARD-STEP-108 — provider-owned geometry and shear (hosted closure pending 2026-08-19)
 
 The first implementation placed a new streamfunction–vorticity solver in


### PR DESCRIPTION
Completes the uncommitted work rescued atop the validation series before its merge (rescue/cfdrs-wip-20260821): cfd-1d junction/branching solver refinements, network reference updates, hemolysis and vascular model adjustments — plus an LF-normalizing .gitattributes with its renormalization sweep, matching the other members' LF policy.

**Verification** (exact head cc66f836704497fc3d7db026569771c20b2c2794):
- nextest workspace: 3256 passed pre-fixup; cfd-2d 727 passed post
- clippy -D warnings clean across all five touched crates
- fmt clean

Item: ATLAS-CROSS-MEMBER-SWEEP-108

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary

This PR integrates rescued uncommitted work from a validation series: **cfd-1d junction/branching solver refinements**, **network reference updates**, **hemolysis and vascular model adjustments**, plus **numerous numerical corrections** across cfd-2d and cfd-3d solvers (PISO predictor pressure gradient, SIMPLEC consistency diagonal, Rhie–Chow face-flux seeding, MUSCL3 stencil coefficients, WENO5 smoothness indicators, VOF PLIC swept-slab routing, LBM boundary streaming, Taylor–Hood pressure basis, Nyquist derivative zeroing). A new **`.gitattributes`** enforces line-ending normalization. **Physical constants** (atmospheric pressure, water density, blood properties, Celsius→Kelvin offset) are centralized into `cfd_core::physics::constants`, replacing hundreds of literal duplicates. A **scope-vs-delivery audit** is appended to `gap_audit.md`, documenting 16 improvement items (GA-001 through GA-016) and an updated checklist; two stale README claims are corrected (allow-count 288→292, appendix C→B).


⏱️ Estimated Review Time: 1-3 hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.gitattributes` |
| 2 | `README.md` |
| 3 | `CHECKLIST.md` |
| 4 | `backlog.md` |
| 5 | `gap_audit.md` |
| 6 | `docs/book/appendix_glossary.md` |
| 7 | `crates/cfd-core/src/physics/constants/physics/thermo.rs` |
| 8 | `crates/cfd-core/src/physics/fluid/blood/constants.rs` |
| 9 | `crates/cfd-core/src/physics/cavitation/constants.rs` |
| 10 | `crates/cfd-core/src/physics/hemolysis/models.rs` |
| 11 | `crates/cfd-core/src/physics/hemolysis/calculator.rs` |
| 12 | `crates/cfd-1d/src/physics/hemolysis/models.rs` |
| 13 | `crates/cfd-1d/src/domain/junctions/branching/solver.rs` |
| 14 | `crates/cfd-1d/src/domain/network/builder/blueprint_conversion.rs` |
| 15 | `crates/cfd-1d/src/domain/network/junction_losses.rs` |
| 16 | `crates/cfd-1d/src/domain/network/wrapper.rs` |
| 17 | `crates/cfd-1d/src/physics/vascular/bifurcation.rs` |
| 18 | `crates/cfd-1d/src/physics/vascular/womersley/mod.rs` |
| 19 | `crates/cfd-2d/src/fields.rs` |
| 20 | `crates/cfd-2d/src/network/channel.rs` |
| 21 | `crates/cfd-2d/src/network/reference.rs` |
| 22 | `crates/cfd-2d/src/physics/acoustics/gorkov.rs` |
| 23 | `crates/cfd-2d/src/physics/momentum/coefficients.rs` |
| 24 | `crates/cfd-2d/src/physics/non_newtonian/carreau_yasuda.rs` |
| 25 | `crates/cfd-2d/src/physics/turbulence/reynolds_stress/transport/solver.rs` |
| 26 | `crates/cfd-2d/src/piso_algorithm/corrector.rs` |
| 27 | `crates/cfd-2d/src/piso_algorithm/predictor.rs` |
| 28 | `crates/cfd-2d/src/schemes/tvd/muscl.rs` |
| 29 | `crates/cfd-2d/src/schemes/tvd_tests.rs` |
| 30 | `crates/cfd-2d/src/solvers/lbm/streaming.rs` |
| 31 | `crates/cfd-2d/src/solvers/simple/momentum.rs` |
| 32 | `crates/cfd-2d/src/solvers/simple/pressure.rs` |
| 33 | `crates/cfd-3d/src/blueprint_integration/mod.rs` |
| 34 | `crates/cfd-3d/src/cavitation.rs` |
| 35 | `crates/cfd-3d/src/fem/solver.rs` |
| 36 | `crates/cfd-3d/src/level_set/weno.rs` |
| 37 | `crates/cfd-3d/src/spectral/fourier.rs` |
| 38 | `crates/cfd-3d/src/vof/advection.rs` |
| 39 | `crates/cfd-3d/src/vof/plic_geometry.rs` |
| 40 | `crates/cfd-core/src/physics/fluid/database.rs` |
| 41 | `crates/cfd-core/src/physics/fluid/newtonian.rs` |
| 42 | `crates/cfd-core/src/physics/fluid/non_newtonian/carreau_yasuda.rs` |
| 43 | `crates/cfd-core/src/physics/material/interface.rs` |
| 44 | `crates/cfd-core/src/physics/values/temperature.rs` |
| 45 | `crates/cfd-python/src/solver_2d/bifurcation.rs` |
| 46 | `crates/cfd-python/src/solver_2d/poiseuille.rs` |
| 47 | `crates/cfd-python/src/solver_2d/serpentine.rs` |
| 48 | `crates/cfd-python/src/solver_2d/venturi.rs` |
| 49 | `crates/cfd-python/src/solver_3d/poiseuille.rs` |
| 50 | `crates/cfd-validation/src/analytical/womersley.rs` |
| 51 | `crates/cfd-validation/src/benchmarks/bifurcation.rs` |
| 52 | `crates/cfd-validation/src/benchmarks/serpentine.rs` |
| 53 | `crates/cfd-validation/src/benchmarks/trifurcation.rs` |
| 54 | `crates/cfd-validation/src/benchmarks/venturi.rs` |
| 55 | `crates/cfd-validation/src/conservation/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->