### PR TITLE
build(cfdrs): Adopt proteus-mat facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aequitas"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/aequitas#14fdd44c1fd8cecaa9fc5ea79af6649a782e1c46"
+source = "git+https://github.com/ryancinsight/aequitas#dc4bdefbbd679a732017886657bef2d54af9d9bb"
 dependencies = [
  "eunomia",
  "serde",
@@ -116,7 +116,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 [[package]]
 name = "apollo-fft"
 version = "0.27.0"
-source = "git+https://github.com/ryancinsight/apollo#fd9ecd0206c2b4ee3993a42eec65a1703d592ac2"
+source = "git+https://github.com/ryancinsight/apollo#424ce4314cf53a8602a65f1fc82add0e1ca8dc1d"
 dependencies = [
  "apollo-fft-macros",
  "apollo-leto-interop",
@@ -138,7 +138,7 @@ dependencies = [
 [[package]]
 name = "apollo-fft-macros"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/apollo#fd9ecd0206c2b4ee3993a42eec65a1703d592ac2"
+source = "git+https://github.com/ryancinsight/apollo#424ce4314cf53a8602a65f1fc82add0e1ca8dc1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "apollo-leto-interop"
 version = "0.18.0"
-source = "git+https://github.com/ryancinsight/apollo#fd9ecd0206c2b4ee3993a42eec65a1703d592ac2"
+source = "git+https://github.com/ryancinsight/apollo#424ce4314cf53a8602a65f1fc82add0e1ca8dc1d"
 dependencies = [
  "leto",
 ]
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "apollo-nufft"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/apollo#fd9ecd0206c2b4ee3993a42eec65a1703d592ac2"
+source = "git+https://github.com/ryancinsight/apollo#424ce4314cf53a8602a65f1fc82add0e1ca8dc1d"
 dependencies = [
  "apollo-fft",
  "apollo-leto-interop",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "athena-core"
 version = "0.1.1"
-source = "git+https://github.com/ryancinsight/athena#1c7a7f941b4d0856b8b5e16436a34124381edf8f"
+source = "git+https://github.com/ryancinsight/athena#21318aebed746c9eea42ccc9d24f4e56d9fecae3"
 dependencies = [
  "eunomia",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "athena-leto"
 version = "0.1.1"
-source = "git+https://github.com/ryancinsight/athena#1c7a7f941b4d0856b8b5e16436a34124381edf8f"
+source = "git+https://github.com/ryancinsight/athena#21318aebed746c9eea42ccc9d24f4e56d9fecae3"
 dependencies = [
  "athena-core",
  "eunomia",
@@ -489,7 +489,7 @@ dependencies = [
  "moirai-runtime",
  "num_cpus",
  "proptest",
- "proteus",
+ "proteus-mat",
  "serde",
  "serde_json",
  "themis-topology",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "coeus-autograd"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "apollo-fft",
  "coeus-core",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "coeus-core"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "coeus-leto"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "coeus-core",
  "leto",
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "coeus-nn"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "coeus-ops"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "coeus-optim"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "coeus-autograd",
  "coeus-core",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "coeus-sparse"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "coeus-core",
  "coeus-tensor",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "coeus-tensor"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/Coeus.git#c2f938c09b822fb85956ccdbeff9d44d4379a710"
+source = "git+https://github.com/ryancinsight/Coeus.git#43f288a0f3df3bd097ecec9658c05ecae476aeb1"
 dependencies = [
  "bytemuck",
  "coeus-core",
@@ -890,7 +890,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "consus-compression"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5fc1443ecee71d90e5f80dd7df419636f1dda1c8"
+source = "git+https://github.com/ryancinsight/consus.git#3bde52a8fabaf3b18085f6e04b4a2d07a12d1e52"
 dependencies = [
  "byteorder",
  "consus-core",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "consus-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5fc1443ecee71d90e5f80dd7df419636f1dda1c8"
+source = "git+https://github.com/ryancinsight/consus.git#3bde52a8fabaf3b18085f6e04b4a2d07a12d1e52"
 dependencies = [
  "byteorder",
  "smallvec",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "consus-hdf5"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5fc1443ecee71d90e5f80dd7df419636f1dda1c8"
+source = "git+https://github.com/ryancinsight/consus.git#3bde52a8fabaf3b18085f6e04b4a2d07a12d1e52"
 dependencies = [
  "byteorder",
  "consus-compression",
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "consus-io"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/consus.git#5fc1443ecee71d90e5f80dd7df419636f1dda1c8"
+source = "git+https://github.com/ryancinsight/consus.git#3bde52a8fabaf3b18085f6e04b4a2d07a12d1e52"
 dependencies = [
  "consus-core",
 ]
@@ -1421,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "gaia-mesh"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/gaia#9b476fecc6ed9ee8395498acc805ac65b6ce8ce2"
+source = "git+https://github.com/ryancinsight/gaia#2ce0984a33d5fec2e1d010fb5340341fb6e91b1e"
 dependencies = [
  "aequitas",
  "anyhow",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "harmonia"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/harmonia#c762c8adabd212f4f1b82120e8cad85bbb4ecd64"
+source = "git+https://github.com/ryancinsight/harmonia#cc56787bc2e789c6f3a2f147b56efb074a79ba3c"
 dependencies = [
  "aequitas",
  "athena-core",
@@ -1588,7 +1588,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hephaestus-core"
 version = "0.19.0"
-source = "git+https://github.com/ryancinsight/hephaestus#03cadd76c58c3f2298e103b0e5445a4ce87539b8"
+source = "git+https://github.com/ryancinsight/hephaestus#79f1aa728d65b68f32bedd44d2bda8ad9d5511e0"
 dependencies = [
  "aequitas",
  "bytemuck",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "hephaestus-wgpu"
 version = "0.19.0"
-source = "git+https://github.com/ryancinsight/hephaestus#03cadd76c58c3f2298e103b0e5445a4ce87539b8"
+source = "git+https://github.com/ryancinsight/hephaestus#79f1aa728d65b68f32bedd44d2bda8ad9d5511e0"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#78b87453ddbbde1c54051f29b9e0c61b6c4b79d3"
+source = "git+https://github.com/ryancinsight/hermes.git#0faa5acccf90a15e13688aae477f96ed101e1b41"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-core"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#78b87453ddbbde1c54051f29b9e0c61b6c4b79d3"
+source = "git+https://github.com/ryancinsight/hermes.git#0faa5acccf90a15e13688aae477f96ed101e1b41"
 dependencies = [
  "bytemuck",
  "eunomia",
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-intrinsics"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#78b87453ddbbde1c54051f29b9e0c61b6c4b79d3"
+source = "git+https://github.com/ryancinsight/hermes.git#0faa5acccf90a15e13688aae477f96ed101e1b41"
 dependencies = [
  "eunomia",
  "hermes-simd-core",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-macros"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#78b87453ddbbde1c54051f29b9e0c61b6c4b79d3"
+source = "git+https://github.com/ryancinsight/hermes.git#0faa5acccf90a15e13688aae477f96ed101e1b41"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "hermes-simd-types"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/hermes.git#78b87453ddbbde1c54051f29b9e0c61b6c4b79d3"
+source = "git+https://github.com/ryancinsight/hermes.git#0faa5acccf90a15e13688aae477f96ed101e1b41"
 dependencies = [
  "hermes-simd-core",
  "hermes-simd-intrinsics",
@@ -1681,7 +1681,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 [[package]]
 name = "horae"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/horae#abe42e5da1b36a6e8f730ec4a371781d52c818b1"
+source = "git+https://github.com/ryancinsight/horae#9d78347954821afd3369682d2f4e13aa9fbb3ac4"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1690,11 +1690,11 @@ dependencies = [
 [[package]]
 name = "hyperion"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/hyperion#3bc0e43d7c818ffab7092bde2d11d1750e59009c"
+source = "git+https://github.com/ryancinsight/hyperion#017a66937deb67508586ab4d47a065051076085f"
 dependencies = [
  "aequitas",
  "eunomia",
- "proteus",
+ "proteus-mat",
 ]
 
 [[package]]
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "iris-viz"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/iris#636a261377ce6a54549ea4cea0520537f9646c71"
+source = "git+https://github.com/ryancinsight/iris#2f11a513b5158c5b82e11c6be7c803a92889204a"
 
 [[package]]
 name = "is-terminal"
@@ -1818,7 +1818,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leto"
 version = "0.42.0"
-source = "git+https://github.com/ryancinsight/leto.git#fc0648ee90d211ce8bb065ff023404483f49041b"
+source = "git+https://github.com/ryancinsight/leto.git#bd7162dca25e4b910ac278fef1d370870f4dc37c"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "leto-ops"
 version = "0.42.0"
-source = "git+https://github.com/ryancinsight/leto.git#fc0648ee90d211ce8bb065ff023404483f49041b"
+source = "git+https://github.com/ryancinsight/leto.git#bd7162dca25e4b910ac278fef1d370870f4dc37c"
 dependencies = [
  "eunomia",
  "hermes-simd",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-arena"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "eunomia",
  "loom",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "mnemosyne-memory-core",
 ]
@@ -1975,12 +1975,12 @@ dependencies = [
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-heap"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "libc",
  "melinoe",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-local"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory"
 version = "0.7.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "eunomia",
  "mnemosyne-arena",
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-memory-core"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "loom",
 ]
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9da9f92e33842d46c6c85b235b6346fe780a1f6d"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#5e895adeb907c51ff887c0c4c32ca74203478cdd"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -2053,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "moirai-async"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "futures",
  "libc",
@@ -2069,7 +2069,7 @@ dependencies = [
 [[package]]
 name = "moirai-async-macros"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2079,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "moirai-core"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "bytemuck",
  "libc",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "moirai-executor"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "moirai-gpu"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "mnemosyne-memory-core",
  "moirai-core",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "moirai-iter"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "futures",
  "libc",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "moirai-pal"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "js-sys",
  "libc",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "moirai-parallel"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "melinoe",
  "moirai-core",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "moirai-runtime"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "melinoe",
  "mnemosyne-memory",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "moirai-scheduler"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "mnemosyne-memory",
  "moirai-core",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "moirai-sync"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "libc",
  "moirai-core",
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "moirai-transport"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 dependencies = [
  "bytemuck",
  "moirai-core",
@@ -2209,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "moirai-utils"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Moirai#a1dfc305c7ab63fba5de919844d859dfc5d98a2e"
+source = "git+https://github.com/ryancinsight/Moirai#1666d5c633b1c99483967e9bd14668a80835a14a"
 
 [[package]]
 name = "munge"
@@ -2660,9 +2660,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "proteus"
+name = "proteus-mat"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/proteus#73c6c813bbb53190b810b3cda56d1720f8445598"
+source = "git+https://github.com/ryancinsight/proteus#cd93e67a82bb14f407c0bd07418cf7aa171f50ef"
 dependencies = [
  "aequitas",
  "eunomia",
@@ -2977,7 +2977,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "ritk-image"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/ritk#810dd492b3a1295b13d50d74a43a0d1aa00702ed"
+source = "git+https://github.com/ryancinsight/ritk#8bbd50e4c3c9b63ba9416034fecc129f0e30de15"
 dependencies = [
  "anyhow",
  "coeus-autograd",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "ritk-spatial"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#810dd492b3a1295b13d50d74a43a0d1aa00702ed"
+source = "git+https://github.com/ryancinsight/ritk#8bbd50e4c3c9b63ba9416034fecc129f0e30de15"
 dependencies = [
  "leto",
  "serde",
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "ritk-vtk"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#810dd492b3a1295b13d50d74a43a0d1aa00702ed"
+source = "git+https://github.com/ryancinsight/ritk#8bbd50e4c3c9b63ba9416034fecc129f0e30de15"
 dependencies = [
  "anyhow",
  "coeus-core",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "ritk-wgpu-compat"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/ritk#810dd492b3a1295b13d50d74a43a0d1aa00702ed"
+source = "git+https://github.com/ryancinsight/ritk#8bbd50e4c3c9b63ba9416034fecc129f0e30de15"
 
 [[package]]
 name = "rkyv"
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "themis-topology"
 version = "0.10.1"
-source = "git+https://github.com/ryancinsight/themis#2c0749873c4860257ba912ff8494937021a79aa1"
+source = "git+https://github.com/ryancinsight/themis#4908c926d96bc61b14499de86f2b5d884520bc40"
 dependencies = [
  "melinoe",
 ]
@@ -3519,7 +3519,7 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 [[package]]
 name = "tyche-core"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/tyche#e5c6a3922d816ee8d1ea18fa8f538ff979c692ea"
+source = "git+https://github.com/ryancinsight/tyche#288600eed5db51496b4a6dcdb258411c544e9d5b"
 dependencies = [
  "eunomia",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = "0.3"
 
 # Math and numerical
 aequitas = { version = "0.2.0", git = "https://github.com/ryancinsight/aequitas", default-features = false, features = ["std"] }
-proteus = { version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
+proteus = { package = "proteus-mat", version = "0.1.0", git = "https://github.com/ryancinsight/proteus" }
 hyperion = { version = "0.1.0", git = "https://github.com/ryancinsight/hyperion", default-features = false, features = ["std"] }
 tyche-core = { version = "0.2.0", git = "https://github.com/ryancinsight/tyche" }
 eunomia = { version = "0.8.0", git = "https://github.com/ryancinsight/eunomia", default-features = false, features = ["std"] }


### PR DESCRIPTION
## Summary
Repoint the CFDrs manifest to the renamed `proteus-mat` package (`package = "proteus-mat"`, git URL unchanged, import path unchanged — proteus keeps `[lib] name = "proteus"` via merged PR ryancinsight/proteus#19).

Part of the ATLAS-PUB-006 unblocker chain (consumer adoption of the proteus rename).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the `proteus` dependency in the CFDrs manifest to point to the renamed `proteus-mat` package while maintaining the same git repository URL and import path. This change is part of adopting the proteus package rename and supports the ATLAS-PUB-006 unblocker chain.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dependency resolution so the application references the intended package while retaining the existing crate alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->