### PR TITLE
fix(CFDrs): Let the lockfile guard report why cargo failed

### DIFF
--- a/scripts/lockfile.py
+++ b/scripts/lockfile.py
@@ -68,7 +68,14 @@ def run_outside_the_overlay(arguments: list[str]) -> subprocess.CompletedProcess
             ["cargo", *arguments, "--manifest-path", str(MANIFEST)],
             cwd=neutral_directory,
             capture_output=True,
-            text=True,
+            # `text=True` alone decodes with the locale codepage. Cargo emits
+            # UTF-8, so on a Windows console (cp1252) subprocess's reader thread
+            # dies on the first byte it cannot map and the captured stream is
+            # lost. The verdict survives -- it comes from `returncode` -- but the
+            # message explaining a failure does not, which is the one moment it
+            # is needed.
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
 


### PR DESCRIPTION
One-line propagation of the coeus/hephaestus correction (Atlas `ATLAS-LOCKFILE-GUARD-DUPLICATED`): the lockfile guard ran cargo under `subprocess.run(..., text=True)`, which decodes with the locale codepage. Cargo emits UTF-8, so on a Windows console (cp1252) subprocess's reader thread dies on the first unmappable byte and the captured stream is lost — the verdict survives (it comes from `returncode`) but `completed.stderr`, the message printed to explain *why* cargo refused, does not.

Decoding as UTF-8 with replacement fixes it; identical to coeus `b3b1208e` and hephaestus `10718bc`.

**Verification on this lane**
- script is byte-identical (modulo line endings) to the fixed canonical copy
- `python -m py_compile` clean
- `scripts/lockfile.py --check` exits 0 (`Cargo.lock resolves under --locked`)
- pre-push hook ran the same check before publish
- diff is exactly +8/−1 in `scripts/lockfile.py`; commit is code-only

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the lockfile guard script where cargo error messages were lost on Windows systems due to encoding issues. The fix changes the `subprocess.run()` call to explicitly decode cargo's UTF-8 output instead of using the locale codepage (cp1252 on Windows), which prevented the reader thread from dying when encountering unmappable bytes. This ensures that when cargo fails, the error message explaining *why* it failed is properly captured and displayed.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/lockfile.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of command output containing non-standard characters.
  * Prevented decoding errors by consistently using UTF-8 with replacement for unmappable bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->