### PR TITLE
ci(cfdrs): Cancel superseded CI runs on the same ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,14 @@ env:
 permissions:
   contents: read
 
+# Superseded runs cancel rather than queue. Without this, every force-push
+# or rapid commit series on one branch accumulated a full three-job pipeline
+# per push; during the 2026-08-25 runner-saturation window CFDrs carried the
+# fleet's worst queue-to-work ratio (828 queued minutes against 741 consumed).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # First and alone: needs no toolchain, cache or build, and guards the one
   # artifact whose correctness cannot be checked from inside the environment


### PR DESCRIPTION
Load-shedding increment for ATLAS-CI-RUNNER-SATURATION-2026-08-25.

## Problem
The workflow had no ``concurrency`` group: every push to a PR branch queued a fresh three-job pipeline without cancelling its predecessor. During the 2026-08-25 hosted-runner saturation window CFDrs carried the fleet's **worst queue-to-work ratio - 828 queued minutes against 741 consumed** (atlas ``scripts/atlas-ci-queue-report.py``, job-summed, week ending 2026-08-25T22:36Z), and a main-branch merge gate sat behind superseded duplicates.

## Change
``concurrency.group`` scoped to ``github.ref`` with ``cancel-in-progress: true``. Ref-scoped so concurrent PRs never cancel each other; only newer runs of the same ref replace older ones. Every other fleet repo already carries this pattern.

No job definition, flag, or gate changes.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a `concurrency` configuration to the GitHub Actions CI workflow to automatically cancel superseded pipeline runs on the same branch. This prevents queue buildup when multiple commits are pushed rapidly to the same branch, addressing a runner saturation issue where the repository had 828 queued minutes against 741 consumed minutes during a recent incident. The change is scoped to `github.ref` so that concurrent PRs don't interfere with each other, only newer runs on the same ref cancel older ones.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/ci.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->