### PR TITLE
ci(cfdrs): Replace lockfile-hash caches with shared rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,14 +80,17 @@ jobs:
           echo "apt-get did not complete after 3 attempts" >&2
           exit 1
 
-      - name: Cache cargo dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      # Shared-key rust-cache instead of a lockfile-hash actions/cache: the
+      # hash key wipes the whole target/ directory whenever Cargo.lock moves
+      # (e.g. a first-party dependency repin), forcing a full workspace
+      # rebuild on exactly the routine dependency-bump PRs. rust-cache
+      # invalidates incrementally and shares one entry across jobs, written
+      # from main only so concurrent branches cannot evict each other.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/
-          key: ${{ runner.os }}-cargo-workspace-${{ hashFiles('**/Cargo.lock') }}
+          workspaces: .
+          shared-key: cfdrs
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Format
         run: cargo fmt --all --check
@@ -129,14 +132,17 @@ jobs:
       - name: Normalize materialized dependency lock
         run: cargo metadata --format-version 1 --all-features > /dev/null
 
-      - name: Cache cargo dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      # Shared-key rust-cache instead of a lockfile-hash actions/cache: the
+      # hash key wipes the whole target/ directory whenever Cargo.lock moves
+      # (e.g. a first-party dependency repin), forcing a full workspace
+      # rebuild on exactly the routine dependency-bump PRs. rust-cache
+      # invalidates incrementally and shares one entry across jobs, written
+      # from main only so concurrent branches cannot evict each other.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/
-          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('**/Cargo.lock') }}
+          workspaces: .
+          shared-key: cfdrs
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check book figures
         run: cargo run --locked -p xtask -- check-figures


### PR DESCRIPTION
Both ci.yml jobs cached ~/.cargo and target/ under a `${{ hashFiles('**/Cargo.lock') }}` key. That key changes on every first-party repin — the proteus-mat adoption being the latest example — and wipes the whole build directory, so routine dependency-bump PRs pay a full workspace rebuild (the Rust workspace gate measured 16m even on a warm run).

Switch both jobs to one shared-key Swatinem/rust-cache entry (written from main, restored everywhere, incrementally invalidated), matching the kwavers CI optimization sweep pattern.

Expected effect: lockfile-touching PRs stop paying full-workspace recompiles; job time converges toward the delta-only compile.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes CI caching for Rust builds by replacing two lockfile-hash-based `actions/cache` configurations with a single shared `Swatinem/rust-cache` setup. The change prevents full workspace rebuilds on routine dependency bumps (which previously invalidated the entire cache whenever `Cargo.lock` changed) and instead uses incremental invalidation with a shared cache key written from main and restored across all jobs and branches.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/ci.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build and validation workflow caching for more consistent CI performance.
  - Updated shared caching behavior across Rust workspace and figure-checking jobs.
  - Cache updates are saved from the main development branch to keep subsequent checks efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->