### PR TITLE
fix(cfdrs): Let the lockfile guard report why cargo failed

### DIFF
--- a/scripts/lockfile.py
+++ b/scripts/lockfile.py
@@ -68,7 +68,14 @@ def run_outside_the_overlay(arguments: list[str]) -> subprocess.CompletedProcess
             ["cargo", *arguments, "--manifest-path", str(MANIFEST)],
             cwd=neutral_directory,
             capture_output=True,
-            text=True,
+            # `text=True` alone decodes with the locale codepage. Cargo emits
+            # UTF-8, so on a Windows console (cp1252) subprocess's reader thread
+            # dies on the first byte it cannot map and the captured stream is
+            # lost. The verdict survives -- it comes from `returncode` -- but the
+            # message explaining a failure does not, which is the one moment it
+            # is needed.
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
 


### PR DESCRIPTION
One-line (well, +8/-1) fix to scripts/lockfile.py: replace 'text=True' with explicit encoding='utf-8' and errors='replace' so the captured stderr stream survives on a Windows console (cp1252) where cargo's UTF-8 output would otherwise kill the subprocess reader thread on the first unmappable byte. Identical to the canonical fix already applied across coeus, hephaestus, kwavers, and the other 18 promoted providers.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a Windows-specific bug in the lockfile script where cargo's UTF-8 output would cause the subprocess reader thread to crash on Windows consoles using cp1252 encoding. The fix replaces `text=True` with explicit `encoding='utf-8'` and `errors='replace'` parameters to ensure that error messages from cargo failures are properly captured and displayed even when there are unmappable characters, bringing this script in line with similar fixes already applied to other providers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/lockfile.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of command output on Windows.
  * Preserved explanatory error messages when output contains characters unsupported by the system locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->