### PR TITLE
fix(CFDrs): Guard the lockfile at commit rather than only at push

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Refuse a commit that would stage a flattened Cargo.lock.
+#
+# The `pre-push` hook beside this one catches the same defect, and catching it
+# there is too late. By push time the lock is already committed, often several
+# commits back and mixed in with real work; the push is refused, and in practice
+# the branch is then abandoned rather than repaired. Four apollo branches
+# existed only on one developer's disk for exactly this reason, each carrying a
+# lockfile that made it unpushable
+# (`ATLAS-LOCKFILE-POISONING-GENERATOR-2026-08-26`).
+#
+# So this hook exists to stop the poisoned lock entering a commit at all. It is
+# the same rule, applied one step earlier, where the fix is still a one-line
+# regenerate rather than a history edit.
+#
+# It checks the *staged blob*, not the working file: a repaired working copy
+# with the poisoned version still in the index is precisely the case that would
+# otherwise slip through, and the index is what becomes the commit.
+#
+# Install (git does not apply tracked hooks on its own):
+#
+#     git config core.hooksPath .githooks
+#
+# Bypass deliberately:
+#
+#     SKIP_LOCKFILE_CHECK=1 git commit
+set -euo pipefail
+
+if [ "${SKIP_LOCKFILE_CHECK:-0}" = "1" ]; then
+  echo "pre-commit: lockfile check skipped by SKIP_LOCKFILE_CHECK" >&2
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+checker="$repo_root/scripts/lockfile.py"
+
+if [ ! -f "$checker" ]; then
+  # Say so rather than passing silently, so a missing guard is visible instead
+  # of assumed.
+  echo "pre-commit: scripts/lockfile.py not present; lockfile not verified" >&2
+  exit 0
+fi
+
+python_bin="${PYTHON:-}"
+if [ -z "$python_bin" ]; then
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      python_bin="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$python_bin" ]; then
+  echo "pre-commit: no python interpreter found; lockfile not verified" >&2
+  exit 0
+fi
+
+# --check-staged is index-only and runs no cargo, so an ordinary commit that
+# does not touch Cargo.lock pays nothing for this.
+exec "$python_bin" "$checker" --check-staged

--- a/scripts/lockfile.py
+++ b/scripts/lockfile.py
@@ -34,8 +34,9 @@ discovery.
 
 # Usage
 
-    scripts/lockfile.py --check        # verify the committed lock, offline
-    scripts/lockfile.py --regenerate   # rewrite it correctly (needs network)
+    scripts/lockfile.py --check         # verify the committed lock, offline
+    scripts/lockfile.py --check-staged  # fast index-only check, for pre-commit
+    scripts/lockfile.py --regenerate    # rewrite it correctly (needs network)
 """
 
 from __future__ import annotations
@@ -123,6 +124,57 @@ def check() -> int:
     return 0
 
 
+def check_staged() -> int:
+    """Structural check of the *staged* `Cargo.lock`, for use from `pre-commit`.
+
+    Deliberately does not run cargo. A pre-commit hook has to be fast enough that
+    nobody reaches for `--no-verify`, and the flattened lock has an unmistakable
+    signature -- zero first-party git sources -- that a text scan settles
+    instantly. Staleness, the other failure `--check` detects, needs real
+    resolution and stays a pre-push concern.
+
+    Checking the *staged blob* rather than the working file is the point: the
+    working copy may already have been repaired while the poisoned version sits
+    in the index, and it is the index that becomes the commit.
+    """
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--", "Cargo.lock"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if staged.returncode != 0 or not staged.stdout.strip():
+        return 0
+
+    blob = subprocess.run(
+        ["git", "show", ":Cargo.lock"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if blob.returncode != 0:
+        return 0
+
+    if len(FIRST_PARTY_SOURCE.findall(blob.stdout)) > 0:
+        return 0
+
+    print(
+        "error: the staged Cargo.lock contains no first-party git sources.\n"
+        "\n"
+        "A cargo command run against a tree under the Atlas stack root rewrote\n"
+        "it with the overlay active, which resolves those dependencies to local\n"
+        "paths and drops their git sources. Committing it now is what turns a\n"
+        "working branch into one that can never be pushed.\n"
+        "\n"
+        "Fix: scripts/lockfile.py --regenerate, then stage the result.\n"
+        "To commit anyway: SKIP_LOCKFILE_CHECK=1 git commit",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def regenerate() -> int:
     completed = run_outside_the_overlay(["generate-lockfile"])
     if completed.returncode != 0:
@@ -137,8 +189,17 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check", action="store_true", help="verify the committed lock")
     mode.add_argument("--regenerate", action="store_true", help="rewrite the lock correctly")
+    mode.add_argument(
+        "--check-staged",
+        action="store_true",
+        help="fast structural check of the staged lock, for pre-commit",
+    )
     arguments = parser.parse_args()
-    return regenerate() if arguments.regenerate else check()
+    if arguments.regenerate:
+        return regenerate()
+    if arguments.check_staged:
+        return check_staged()
+    return check()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The pre-push hook already refuses a flattened `Cargo.lock`, but by push time the lock is committed — often several commits back and mixed with real work — so the branch gets abandoned rather than repaired (`ATLAS-LOCKFILE-POISONING-GENERATOR-2026-08-26`). This adds the pre-commit hook from the apollo pilot (5602a20d) plus the `--check-staged` surface in `scripts/lockfile.py`, so a poisoned lock never enters a commit in the first place. The check is index-only and runs no cargo, so commits that do not touch Cargo.lock pay nothing. Identical to the apollo pilot; no gate, job, timeout, or trigger changes.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a pre-commit hook to prevent flattened `Cargo.lock` files from being committed in the first place, rather than only catching them at push time. The existing pre-push hook already rejects flattened lockfiles, but by that point the problematic lock is already committed (often mixed with real work), leading to abandoned branches rather than fixes. The new hook checks the *staged* lockfile blob for the telltale signature of a flattened lock (zero first-party git sources) and is index-only with no cargo execution, so commits that don't touch `Cargo.lock` have zero overhead. A corresponding `--check-staged` flag is added to `scripts/lockfile.py` to support this fast structural check.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/lockfile.py` |
| 2 | `.githooks/pre-commit` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-commit check that detects invalid flattened lockfiles before changes are committed.
  * The check validates only the staged lockfile and supports configurable Python interpreters.

* **Bug Fixes**
  * Prevents commits when required first-party source entries are missing from the staged lockfile.

* **Chores**
  * Added options to skip the check or proceed gracefully when validation tools are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->